### PR TITLE
Phase 3: Command Layer Deduplication

### DIFF
--- a/src/keboola_agent_cli/commands/_helpers.py
+++ b/src/keboola_agent_cli/commands/_helpers.py
@@ -1,0 +1,51 @@
+"""Shared command-layer helpers to eliminate duplication across command files.
+
+Provides common patterns used by all CLI commands:
+- Context extraction (formatter, services)
+- Exit code mapping for API errors
+- Warning emission for multi-project operations
+"""
+
+from typing import Any
+
+import typer
+
+from ..errors import KeboolaApiError
+from ..output import OutputFormatter
+
+
+def get_formatter(ctx: typer.Context) -> OutputFormatter:
+    """Retrieve the OutputFormatter from the Typer context."""
+    return ctx.obj["formatter"]
+
+
+def get_service(ctx: typer.Context, key: str) -> Any:
+    """Retrieve a service from the Typer context."""
+    return ctx.obj[key]
+
+
+def map_error_to_exit_code(exc: KeboolaApiError) -> int:
+    """Map a KeboolaApiError to a CLI exit code.
+
+    Unified 3-case logic:
+    - INVALID_TOKEN -> 3 (authentication error)
+    - TIMEOUT / CONNECTION_ERROR / RETRY_EXHAUSTED -> 4 (network error)
+    - Everything else -> 1 (general error)
+    """
+    if exc.error_code == "INVALID_TOKEN":
+        return 3
+    if exc.error_code in ("TIMEOUT", "CONNECTION_ERROR", "RETRY_EXHAUSTED"):
+        return 4
+    return 1
+
+
+def emit_project_warnings(formatter: OutputFormatter, result: dict) -> None:
+    """Emit warnings from multi-project operation results.
+
+    Iterates the 'errors' list in the result dict (if present) and prints
+    each entry as a warning via the formatter.
+    """
+    for err in result.get("errors", []):
+        alias = err.get("project_alias", "unknown")
+        message = err.get("message", "Unknown error")
+        formatter.warning(f"Project '{alias}': {message}")

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -7,22 +7,12 @@ No business logic belongs here.
 import typer
 
 from ..errors import ConfigError, KeboolaApiError
-from ..output import OutputFormatter, format_config_detail, format_configs_table
-from ..services.config_service import ConfigService
+from ..output import format_config_detail, format_configs_table
+from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
 
 config_app = typer.Typer(help="Browse and inspect configurations")
 
 VALID_COMPONENT_TYPES = ["extractor", "writer", "transformation", "application"]
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_service(ctx: typer.Context) -> ConfigService:
-    """Retrieve the ConfigService from the Typer context."""
-    return ctx.obj["config_service"]
 
 
 @config_app.command("list")
@@ -45,8 +35,8 @@ def config_list(
     ),
 ) -> None:
     """List configurations from connected projects."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "config_service")
 
     # Validate component_type if provided
     if component_type and component_type not in VALID_COMPONENT_TYPES:
@@ -73,10 +63,7 @@ def config_list(
     else:
         # In human mode, show per-project errors as warnings and configs as table
         format_configs_table(formatter.console, result)
-
-        # Show error warnings on stderr too
-        for err in result.get("errors", []):
-            formatter.warning(f"Project '{err['project_alias']}': {err['message']}")
+        emit_project_warnings(formatter, result)
 
 
 @config_app.command("detail")
@@ -87,8 +74,8 @@ def config_detail(
     config_id: str = typer.Option(..., "--config-id", help="Configuration ID"),
 ) -> None:
     """Show detailed information about a specific configuration."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "config_service")
 
     try:
         result = service.get_config_detail(
@@ -101,12 +88,7 @@ def config_detail(
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
     except KeboolaApiError as exc:
-        if exc.error_code == "INVALID_TOKEN":
-            exit_code = 3
-        elif exc.error_code in ("TIMEOUT", "CONNECTION_ERROR", "RETRY_EXHAUSTED"):
-            exit_code = 4
-        else:
-            exit_code = 1
+        exit_code = map_error_to_exit_code(exc)
         formatter.error(
             message=exc.message,
             error_code=exc.error_code,

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -7,7 +7,7 @@ can consume to understand how to use kbagent effectively.
 import typer
 
 from .. import __version__
-from ..output import OutputFormatter
+from ._helpers import get_formatter
 
 AGENT_CONTEXT = f"""\
 # kbagent - Keboola Agent CLI v{__version__}
@@ -229,14 +229,9 @@ When you receive a non-zero exit code, use --json to get structured error detail
 """
 
 
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
 def context_command(ctx: typer.Context) -> None:
     """Show usage instructions for AI agents interacting with Keboola."""
-    formatter = _get_formatter(ctx)
+    formatter = get_formatter(ctx)
 
     if formatter.json_mode:
         # In JSON mode, output the context text as structured data

--- a/src/keboola_agent_cli/commands/doctor.py
+++ b/src/keboola_agent_cli/commands/doctor.py
@@ -21,19 +21,9 @@ from .. import __version__
 from ..config_store import ConfigStore
 from ..errors import KeboolaApiError
 from ..models import AppConfig
-from ..output import OutputFormatter
 from ..services.mcp_service import McpService
 from ..services.base import ClientFactory, default_client_factory
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_config_store(ctx: typer.Context) -> ConfigStore:
-    """Retrieve the ConfigStore from the Typer context."""
-    return ctx.obj["config_store"]
+from ._helpers import get_formatter, get_service
 
 
 def _check_config_file(config_store: ConfigStore) -> dict[str, Any]:
@@ -243,8 +233,8 @@ def _format_doctor_human(console: Console, data: dict[str, Any]) -> None:
 
 def doctor_command(ctx: typer.Context) -> None:
     """Run health checks on CLI configuration and project connectivity."""
-    formatter = _get_formatter(ctx)
-    config_store = _get_config_store(ctx)
+    formatter = get_formatter(ctx)
+    config_store = get_service(ctx, "config_store")
 
     # Determine client factory - use the default unless we're in a test context
     client_factory: ClientFactory = ctx.obj.get("client_factory", default_client_factory)

--- a/src/keboola_agent_cli/commands/job.py
+++ b/src/keboola_agent_cli/commands/job.py
@@ -8,22 +8,12 @@ import typer
 
 from ..constants import DEFAULT_JOB_LIMIT, MAX_JOB_LIMIT
 from ..errors import ConfigError, KeboolaApiError
-from ..output import OutputFormatter, format_job_detail, format_jobs_table
-from ..services.job_service import JobService
+from ..output import format_job_detail, format_jobs_table
+from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
 
 job_app = typer.Typer(help="Browse job history")
 
 VALID_STATUSES = ["processing", "terminated", "cancelled", "success", "error"]
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_service(ctx: typer.Context) -> JobService:
-    """Retrieve the JobService from the Typer context."""
-    return ctx.obj["job_service"]
 
 
 @job_app.command("list")
@@ -56,8 +46,8 @@ def job_list(
     ),
 ) -> None:
     """List jobs from connected projects."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "job_service")
 
     # Validate status
     if status and status not in VALID_STATUSES:
@@ -99,9 +89,7 @@ def job_list(
         formatter.output(result)
     else:
         format_jobs_table(formatter.console, result)
-
-        for err in result.get("errors", []):
-            formatter.warning(f"Project '{err['project_alias']}': {err['message']}")
+        emit_project_warnings(formatter, result)
 
 
 @job_app.command("detail")
@@ -111,8 +99,8 @@ def job_detail(
     job_id: str = typer.Option(..., "--job-id", help="Job ID"),
 ) -> None:
     """Show detailed information about a specific job."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "job_service")
 
     try:
         result = service.get_job_detail(alias=project, job_id=job_id)
@@ -121,12 +109,7 @@ def job_detail(
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
     except KeboolaApiError as exc:
-        if exc.error_code == "INVALID_TOKEN":
-            exit_code = 3
-        elif exc.error_code in ("TIMEOUT", "CONNECTION_ERROR", "RETRY_EXHAUSTED"):
-            exit_code = 4
-        else:
-            exit_code = 1
+        exit_code = map_error_to_exit_code(exc)
         formatter.error(
             message=exc.message,
             error_code=exc.error_code,

--- a/src/keboola_agent_cli/commands/lineage.py
+++ b/src/keboola_agent_cli/commands/lineage.py
@@ -7,20 +7,10 @@ No business logic belongs here.
 import typer
 
 from ..errors import ConfigError
-from ..output import OutputFormatter, format_lineage_table
-from ..services.lineage_service import LineageService
+from ..output import format_lineage_table
+from ._helpers import emit_project_warnings, get_formatter, get_service
 
 lineage_app = typer.Typer(help="Analyze cross-project data lineage via bucket sharing")
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_service(ctx: typer.Context) -> LineageService:
-    """Retrieve the LineageService from the Typer context."""
-    return ctx.obj["lineage_service"]
 
 
 @lineage_app.command("show")
@@ -33,8 +23,8 @@ def lineage_show(
     ),
 ) -> None:
     """Show cross-project data lineage via bucket sharing."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "lineage_service")
 
     try:
         result = service.get_lineage(aliases=project)
@@ -46,9 +36,7 @@ def lineage_show(
         formatter.output(result)
     else:
         format_lineage_table(formatter.console, result)
-
-        for err in result.get("errors", []):
-            formatter.warning(f"Project '{err['project_alias']}': {err['message']}")
+        emit_project_warnings(formatter, result)
 
 
 @lineage_app.callback(invoke_without_command=True)

--- a/src/keboola_agent_cli/commands/org.py
+++ b/src/keboola_agent_cli/commands/org.py
@@ -13,20 +13,9 @@ from rich.table import Table
 
 from ..constants import DEFAULT_TOKEN_DESCRIPTION, ENV_KBC_MANAGE_API_TOKEN, ENV_KBC_STORAGE_API_URL
 from ..errors import KeboolaApiError
-from ..output import OutputFormatter
-from ..services.org_service import OrgService
+from ._helpers import get_formatter, get_service, map_error_to_exit_code
 
 org_app = typer.Typer(help="Organization management")
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_service(ctx: typer.Context) -> OrgService:
-    """Retrieve the OrgService from the Typer context."""
-    return ctx.obj["org_service"]
 
 
 def _resolve_manage_token() -> str:
@@ -171,8 +160,8 @@ def org_setup(
     The manage token is read from KBC_MANAGE_API_TOKEN env var or prompted
     interactively (never passed as a CLI argument for security).
     """
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "org_service")
 
     manage_token = _resolve_manage_token()
 
@@ -220,14 +209,9 @@ def org_setup(
     formatter.output(result, _format_setup_result)
 
 
-def _handle_api_error(formatter: OutputFormatter, exc: KeboolaApiError) -> None:
+def _handle_api_error(formatter, exc: KeboolaApiError) -> None:
     """Handle a KeboolaApiError by outputting it and raising Exit."""
-    if exc.error_code == "INVALID_TOKEN":
-        exit_code = 3
-    elif exc.error_code in ("TIMEOUT", "CONNECTION_ERROR", "RETRY_EXHAUSTED"):
-        exit_code = 4
-    else:
-        exit_code = 1
+    exit_code = map_error_to_exit_code(exc)
     formatter.error(
         message=exc.message,
         error_code=exc.error_code,

--- a/src/keboola_agent_cli/commands/project.py
+++ b/src/keboola_agent_cli/commands/project.py
@@ -14,20 +14,9 @@ from rich.table import Table
 
 from ..constants import DEFAULT_STACK_URL, ENV_KBC_STORAGE_API_URL, ENV_KBC_TOKEN
 from ..errors import ConfigError, KeboolaApiError
-from ..output import OutputFormatter
-from ..services.project_service import ProjectService
+from ._helpers import get_formatter, get_service, map_error_to_exit_code
 
 project_app = typer.Typer(help="Manage connected Keboola projects")
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_service(ctx: typer.Context) -> ProjectService:
-    """Retrieve the ProjectService from the Typer context."""
-    return ctx.obj["project_service"]
 
 
 def _format_project_table(console: Console, projects: list[dict[str, Any]]) -> None:
@@ -133,8 +122,8 @@ def project_add(
     The Storage API token is read from KBC_TOKEN env var or prompted
     interactively (never passed as a CLI argument for security).
     """
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "project_service")
     token = _resolve_token()
 
     try:
@@ -147,7 +136,7 @@ def project_add(
             ),
         )
     except KeboolaApiError as exc:
-        exit_code = 3 if exc.error_code == "INVALID_TOKEN" else 4
+        exit_code = map_error_to_exit_code(exc)
         formatter.error(
             message=exc.message,
             error_code=exc.error_code,
@@ -162,8 +151,8 @@ def project_add(
 @project_app.command("list")
 def project_list(ctx: typer.Context) -> None:
     """List all connected Keboola projects."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "project_service")
 
     try:
         projects = service.list_projects()
@@ -179,8 +168,8 @@ def project_remove(
     alias: str = typer.Option(..., help="Alias of the project to remove"),
 ) -> None:
     """Remove a Keboola project connection."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "project_service")
 
     try:
         result = service.remove_project(alias=alias)
@@ -209,8 +198,8 @@ def project_edit(
     KBC_TOKEN env var or prompted interactively (never passed as a CLI
     argument for security).
     """
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "project_service")
     token: str | None = None
     if new_token:
         token = _resolve_token()
@@ -224,7 +213,7 @@ def project_edit(
             ),
         )
     except KeboolaApiError as exc:
-        exit_code = 3 if exc.error_code == "INVALID_TOKEN" else 4
+        exit_code = map_error_to_exit_code(exc)
         formatter.error(
             message=exc.message,
             error_code=exc.error_code,
@@ -244,8 +233,8 @@ def project_status(
     ),
 ) -> None:
     """Test connectivity to connected Keboola projects."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "project_service")
 
     aliases = [project] if project else None
 
@@ -256,7 +245,7 @@ def project_status(
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
     except KeboolaApiError as exc:
-        exit_code = 3 if exc.error_code == "INVALID_TOKEN" else 4
+        exit_code = map_error_to_exit_code(exc)
         formatter.error(
             message=exc.message,
             error_code=exc.error_code,

--- a/src/keboola_agent_cli/commands/tool.py
+++ b/src/keboola_agent_cli/commands/tool.py
@@ -9,20 +9,10 @@ import json
 import typer
 
 from ..errors import ConfigError
-from ..output import OutputFormatter, format_tool_result, format_tools_table
-from ..services.mcp_service import McpService
+from ..output import format_tool_result, format_tools_table
+from ._helpers import emit_project_warnings, get_formatter, get_service
 
 tool_app = typer.Typer(help="MCP tools - interact with Keboola via MCP server")
-
-
-def _get_formatter(ctx: typer.Context) -> OutputFormatter:
-    """Retrieve the OutputFormatter from the Typer context."""
-    return ctx.obj["formatter"]
-
-
-def _get_service(ctx: typer.Context) -> McpService:
-    """Retrieve the McpService from the Typer context."""
-    return ctx.obj["mcp_service"]
 
 
 @tool_app.command("list")
@@ -35,8 +25,8 @@ def tool_list(
     ),
 ) -> None:
     """List available MCP tools from the keboola-mcp-server."""
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "mcp_service")
 
     aliases = [project] if project else None
 
@@ -50,9 +40,7 @@ def tool_list(
         formatter.output(result)
     else:
         format_tools_table(formatter.console, result)
-
-        for err in result.get("errors", []):
-            formatter.warning(f"Project '{err['project_alias']}': {err['message']}")
+        emit_project_warnings(formatter, result)
 
 
 @tool_app.command("call")
@@ -78,8 +66,8 @@ def tool_call(
     Write tools (create_*, update_*, delete_*, add_*) run on a single project.
     Use --project to specify the target, or the default project is used.
     """
-    formatter = _get_formatter(ctx)
-    service = _get_service(ctx)
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "mcp_service")
 
     # Parse tool input JSON
     parsed_input: dict = {}
@@ -137,6 +125,4 @@ def tool_call(
         formatter.output(result)
     else:
         format_tool_result(formatter.console, result)
-
-        for err in result.get("errors", []):
-            formatter.warning(f"Project '{err['project_alias']}': {err['message']}")
+        emit_project_warnings(formatter, result)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,63 @@
+"""Tests for commands._helpers shared command-layer utilities."""
+
+from keboola_agent_cli.commands._helpers import map_error_to_exit_code
+from keboola_agent_cli.errors import KeboolaApiError
+
+
+class TestMapErrorToExitCode:
+    """Tests for map_error_to_exit_code."""
+
+    def test_map_error_to_exit_code_invalid_token(self) -> None:
+        """INVALID_TOKEN error maps to exit code 3 (authentication error)."""
+        exc = KeboolaApiError(
+            message="Invalid token",
+            status_code=401,
+            error_code="INVALID_TOKEN",
+            retryable=False,
+        )
+        assert map_error_to_exit_code(exc) == 3
+
+    def test_map_error_to_exit_code_timeout(self) -> None:
+        """TIMEOUT error maps to exit code 4 (network error)."""
+        exc = KeboolaApiError(
+            message="Request timed out",
+            status_code=0,
+            error_code="TIMEOUT",
+            retryable=True,
+        )
+        assert map_error_to_exit_code(exc) == 4
+
+    def test_map_error_to_exit_code_connection(self) -> None:
+        """CONNECTION_ERROR maps to exit code 4 (network error)."""
+        exc = KeboolaApiError(
+            message="Connection refused",
+            status_code=0,
+            error_code="CONNECTION_ERROR",
+            retryable=True,
+        )
+        assert map_error_to_exit_code(exc) == 4
+
+    def test_map_error_to_exit_code_retry_exhausted(self) -> None:
+        """RETRY_EXHAUSTED maps to exit code 4 (network error)."""
+        exc = KeboolaApiError(
+            message="Retries exhausted",
+            status_code=503,
+            error_code="RETRY_EXHAUSTED",
+            retryable=False,
+        )
+        assert map_error_to_exit_code(exc) == 4
+
+    def test_map_error_to_exit_code_other(self) -> None:
+        """Unknown/other error codes map to exit code 1 (general error)."""
+        exc = KeboolaApiError(
+            message="Something went wrong",
+            status_code=500,
+            error_code="INTERNAL_ERROR",
+            retryable=False,
+        )
+        assert map_error_to_exit_code(exc) == 1
+
+    def test_map_error_to_exit_code_unknown(self) -> None:
+        """Default UNKNOWN_ERROR maps to exit code 1."""
+        exc = KeboolaApiError(message="Unknown error")
+        assert map_error_to_exit_code(exc) == 1


### PR DESCRIPTION
## Summary
- Extract duplicated `_get_formatter`/`_get_service` from all 8 command files into shared `commands/_helpers.py`
- Unify exit code mapping to consistent 3-case logic (INVALID_TOKEN->3, TIMEOUT/CONNECTION_ERROR/RETRY_EXHAUSTED->4, else->1)
- Replace duplicated warning loops with shared `emit_project_warnings` helper

## Acceptance Criteria
- [x] No `_get_formatter` / `_get_service` functions remain in individual command files
- [x] All command files import from `commands._helpers`
- [x] Exit code mapping consistent (3-case: INVALID_TOKEN->3, TIMEOUT/CONNECTION_ERROR/RETRY_EXHAUSTED->4, else->1)
- [x] Warning loop not duplicated -- all commands use `emit_project_warnings`
- [x] All existing CLI tests pass (472 passed)

## Tests
- All 472 existing tests pass
- New: 6 tests in `test_helpers.py` for `map_error_to_exit_code` (invalid_token, timeout, connection, retry_exhausted, other, unknown)

## Files Changed
- **NEW**: `src/keboola_agent_cli/commands/_helpers.py` -- shared command helpers
- **NEW**: `tests/test_helpers.py` -- unit tests for helpers
- **Modified**: `src/keboola_agent_cli/commands/project.py`
- **Modified**: `src/keboola_agent_cli/commands/config.py`
- **Modified**: `src/keboola_agent_cli/commands/job.py`
- **Modified**: `src/keboola_agent_cli/commands/lineage.py`
- **Modified**: `src/keboola_agent_cli/commands/org.py`
- **Modified**: `src/keboola_agent_cli/commands/tool.py`
- **Modified**: `src/keboola_agent_cli/commands/context.py`
- **Modified**: `src/keboola_agent_cli/commands/doctor.py`