### PR TITLE
Phase 7: Test Coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = ["src/keboola_agent_cli"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 markers = [
     "integration: marks tests as integration tests requiring real API credentials (deselect with '-m \"not integration\"')",
 ]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,94 @@
+"""Shared test helper functions for Keboola Agent CLI tests.
+
+Contains factory functions for creating mock clients and pre-configured
+ConfigStore instances. Used across multiple test files to avoid duplication.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import KeboolaApiError
+from keboola_agent_cli.models import ProjectConfig, TokenVerifyResponse
+
+
+def make_mock_client(
+    project_name: str = "Test Project",
+    project_id: int = 1234,
+    token_description: str = "My Token",
+) -> MagicMock:
+    """Create a mock KeboolaClient that returns a successful verify_token response.
+
+    Used by test_cli.py, test_services.py, and other test files that need
+    a mock client with a working verify_token.
+    """
+    mock_client = MagicMock()
+    mock_client.verify_token.return_value = TokenVerifyResponse(
+        token_id="12345",
+        token_description=token_description,
+        project_id=project_id,
+        project_name=project_name,
+        owner_name=project_name,
+    )
+    return mock_client
+
+
+def make_failing_client(error: KeboolaApiError) -> MagicMock:
+    """Create a mock KeboolaClient whose verify_token raises the given error."""
+    mock_client = MagicMock()
+    mock_client.verify_token.side_effect = error
+    return mock_client
+
+
+def setup_single_project(
+    tmp_config_dir: Path,
+    alias: str = "prod",
+    stack_url: str = "https://connection.keboola.com",
+    token: str = "901-xxx",
+    project_name: str = "Production",
+    project_id: int = 258,
+) -> ConfigStore:
+    """Create a ConfigStore with a single project configured.
+
+    Used by test_base_service.py, test_lineage_service.py, and other test files
+    that need a pre-configured ConfigStore with one project.
+    """
+    store = ConfigStore(config_dir=tmp_config_dir)
+    store.add_project(
+        alias,
+        ProjectConfig(
+            stack_url=stack_url,
+            token=token,
+            project_name=project_name,
+            project_id=project_id,
+        ),
+    )
+    return store
+
+
+def setup_two_projects(tmp_config_dir: Path) -> ConfigStore:
+    """Create a ConfigStore with two projects (prod and dev) configured.
+
+    Used by test_base_service.py, test_lineage_service.py, and other test files
+    that need a pre-configured ConfigStore with two projects.
+    """
+    store = ConfigStore(config_dir=tmp_config_dir)
+    store.add_project(
+        "prod",
+        ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token="901-xxx",
+            project_name="Production",
+            project_id=258,
+        ),
+    )
+    store.add_project(
+        "dev",
+        ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token="7012-yyy",
+            project_name="Development",
+            project_id=7012,
+        ),
+    )
+    return store

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -16,6 +16,8 @@ from keboola_agent_cli.errors import ConfigError
 from keboola_agent_cli.models import ProjectConfig
 from keboola_agent_cli.services.base import BaseService, ENV_MAX_PARALLEL_WORKERS
 
+from helpers import setup_single_project, setup_two_projects
+
 
 class _TestService(BaseService):
     """Concrete subclass of BaseService used exclusively for testing."""
@@ -23,55 +25,9 @@ class _TestService(BaseService):
     pass
 
 
-def _setup_single_project(
-    tmp_config_dir: Path,
-    alias: str = "prod",
-    stack_url: str = "https://connection.keboola.com",
-    token: str = "901-xxx",
-    project_name: str = "Production",
-    project_id: int = 258,
-) -> ConfigStore:
-    """Create a ConfigStore with a single project configured."""
-    store = ConfigStore(config_dir=tmp_config_dir)
-    store.add_project(
-        alias,
-        ProjectConfig(
-            stack_url=stack_url,
-            token=token,
-            project_name=project_name,
-            project_id=project_id,
-        ),
-    )
-    return store
-
-
-def _setup_two_projects(tmp_config_dir: Path) -> ConfigStore:
-    """Create a ConfigStore with two projects (prod and dev) configured."""
-    store = ConfigStore(config_dir=tmp_config_dir)
-    store.add_project(
-        "prod",
-        ProjectConfig(
-            stack_url="https://connection.keboola.com",
-            token="901-xxx",
-            project_name="Production",
-            project_id=258,
-        ),
-    )
-    store.add_project(
-        "dev",
-        ProjectConfig(
-            stack_url="https://connection.keboola.com",
-            token="7012-yyy",
-            project_name="Development",
-            project_id=7012,
-        ),
-    )
-    return store
-
-
 def _setup_three_projects(tmp_config_dir: Path) -> ConfigStore:
     """Create a ConfigStore with three projects (prod, dev, staging) configured."""
-    store = _setup_two_projects(tmp_config_dir)
+    store = setup_two_projects(tmp_config_dir)
     store.add_project(
         "staging",
         ProjectConfig(
@@ -89,7 +45,7 @@ class TestResolveProjects:
 
     def test_resolve_all_projects_with_none_aliases(self, tmp_config_dir: Path) -> None:
         """Passing aliases=None returns all configured projects."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
 
         resolved = service.resolve_projects(aliases=None)
@@ -112,7 +68,7 @@ class TestResolveProjects:
 
     def test_unknown_alias_raises_config_error(self, tmp_config_dir: Path) -> None:
         """Passing an alias not in the config raises ConfigError."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
 
         with pytest.raises(ConfigError, match="Project 'nonexistent' not found"):
@@ -120,7 +76,7 @@ class TestResolveProjects:
 
     def test_mixed_valid_and_unknown_alias_raises(self, tmp_config_dir: Path) -> None:
         """If any alias in the list is unknown, ConfigError is raised."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
 
         with pytest.raises(ConfigError, match="Project 'missing' not found"):
@@ -128,7 +84,7 @@ class TestResolveProjects:
 
     def test_empty_aliases_list_returns_all(self, tmp_config_dir: Path) -> None:
         """Passing an empty list returns all configured projects (same as None)."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
 
         resolved = service.resolve_projects(aliases=[])
@@ -137,7 +93,7 @@ class TestResolveProjects:
 
     def test_resolve_single_alias(self, tmp_config_dir: Path) -> None:
         """Resolving a single valid alias returns just that project."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
 
         resolved = service.resolve_projects(aliases=["dev"])
@@ -147,7 +103,7 @@ class TestResolveProjects:
 
     def test_resolve_projects_preserves_config(self, tmp_config_dir: Path) -> None:
         """Resolved ProjectConfig instances have the correct stack_url and token."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
 
         resolved = service.resolve_projects(aliases=["prod"])
@@ -161,14 +117,14 @@ class TestResolveMaxWorkers:
 
     def test_default_value_from_app_config(self, tmp_config_dir: Path) -> None:
         """Default max_parallel_workers is 10 from AppConfig."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
 
         assert service._resolve_max_workers() == 10
 
     def test_custom_value_from_config_json(self, tmp_config_dir: Path) -> None:
         """max_parallel_workers can be set in config.json."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 20
         store.save(config)
@@ -181,7 +137,7 @@ class TestResolveMaxWorkers:
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """KBAGENT_MAX_PARALLEL_WORKERS env var overrides config.json value."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 5
         store.save(config)
@@ -195,7 +151,7 @@ class TestResolveMaxWorkers:
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Invalid (non-numeric) env var value falls back to config.json."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 15
         store.save(config)
@@ -209,7 +165,7 @@ class TestResolveMaxWorkers:
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Zero is not a valid positive integer, so it falls back to config.json."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 8
         store.save(config)
@@ -223,7 +179,7 @@ class TestResolveMaxWorkers:
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Negative env var value is not positive, so it falls back to config.json."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 12
         store.save(config)
@@ -237,7 +193,7 @@ class TestResolveMaxWorkers:
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Env var set to 1 is valid and should be used (sequential execution)."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         monkeypatch.setenv(ENV_MAX_PARALLEL_WORKERS, "1")
         service = _TestService(config_store=store)
@@ -250,7 +206,7 @@ class TestRunParallel:
 
     def test_empty_projects_returns_empty_tuple(self, tmp_config_dir: Path) -> None:
         """Empty projects dict returns ([], []) without spawning threads."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
 
         def worker(alias: str, project: ProjectConfig) -> tuple[Any, ...]:
@@ -263,7 +219,7 @@ class TestRunParallel:
 
     def test_single_project_success_three_tuple(self, tmp_config_dir: Path) -> None:
         """Worker returning a 3-tuple is classified as success."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -278,7 +234,7 @@ class TestRunParallel:
 
     def test_multiple_projects_success(self, tmp_config_dir: Path) -> None:
         """All workers succeeding with 3-tuples are collected in successes."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -299,7 +255,7 @@ class TestRunParallel:
 
     def test_worker_returning_two_tuple_classified_as_error(self, tmp_config_dir: Path) -> None:
         """Worker returning a 2-tuple (alias, error_dict) is classified as error."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -320,7 +276,7 @@ class TestRunParallel:
 
     def test_mixed_success_and_error(self, tmp_config_dir: Path) -> None:
         """One worker returns success (3-tuple), another returns error (2-tuple)."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -346,7 +302,7 @@ class TestRunParallel:
 
     def test_unexpected_exception_caught_as_unexpected_error(self, tmp_config_dir: Path) -> None:
         """Exception raised by worker is caught and recorded as UNEXPECTED_ERROR."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -363,7 +319,7 @@ class TestRunParallel:
 
     def test_exception_mixed_with_success(self, tmp_config_dir: Path) -> None:
         """One worker raises, the other succeeds. Both results are collected."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -386,7 +342,7 @@ class TestRunParallel:
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """max_workers is min(len(projects), _resolve_max_workers())."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # Set a very high max_workers via env var
         monkeypatch.setenv(ENV_MAX_PARALLEL_WORKERS, "100")
@@ -409,7 +365,7 @@ class TestRunParallel:
 
     def test_four_plus_tuple_classified_as_success(self, tmp_config_dir: Path) -> None:
         """Worker returning a 4-tuple is also classified as success (len > 2)."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -424,7 +380,7 @@ class TestRunParallel:
 
     def test_all_projects_fail_with_exceptions(self, tmp_config_dir: Path) -> None:
         """When all workers raise exceptions, successes is empty and all are errors."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
         service = _TestService(config_store=store)
         projects = service.resolve_projects()
 
@@ -447,7 +403,7 @@ class TestDefaultClientFactory:
 
     def test_default_client_factory_is_used_when_none(self, tmp_config_dir: Path) -> None:
         """When client_factory is None, default_client_factory is assigned."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = _TestService(config_store=store, client_factory=None)
 
         # The internal _client_factory should be callable
@@ -455,7 +411,7 @@ class TestDefaultClientFactory:
 
     def test_custom_client_factory_is_used(self, tmp_config_dir: Path) -> None:
         """When a custom client_factory is provided, it is stored and used."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         mock_factory = MagicMock()
         service = _TestService(config_store=store, client_factory=mock_factory)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from typer.testing import CliRunner
 
 from keboola_agent_cli.cli import app
@@ -14,27 +16,14 @@ from keboola_agent_cli.models import ProjectConfig, TokenVerifyResponse
 from keboola_agent_cli.services.config_service import ConfigService
 from keboola_agent_cli.services.job_service import JobService
 from keboola_agent_cli.services.lineage_service import LineageService
+from keboola_agent_cli.services.org_service import OrgService
 from keboola_agent_cli.services.project_service import ProjectService
+
+from helpers import make_mock_client
 
 TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
 
 runner = CliRunner()
-
-
-def _make_mock_client(
-    project_name: str = "Test Project",
-    project_id: int = 1234,
-) -> MagicMock:
-    """Create a mock client for the factory."""
-    mock_client = MagicMock()
-    mock_client.verify_token.return_value = TokenVerifyResponse(
-        token_id="12345",
-        token_description="My Token",
-        project_id=project_id,
-        project_name=project_name,
-        owner_name=project_name,
-    )
-    return mock_client
 
 
 class TestProjectAdd:
@@ -42,7 +31,7 @@ class TestProjectAdd:
 
     def test_project_add_success_json(self, tmp_path: Path) -> None:
         """project add with --json outputs structured success response."""
-        mock_client = _make_mock_client(project_name="Prod Project", project_id=5678)
+        mock_client = make_mock_client(project_name="Prod Project", project_id=5678)
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -84,7 +73,7 @@ class TestProjectAdd:
 
     def test_project_add_success_human(self, tmp_path: Path) -> None:
         """project add in human mode outputs success message."""
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -229,7 +218,7 @@ class TestProjectList:
         """project list --json returns project data with masked tokens."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -272,7 +261,7 @@ class TestProjectList:
         """project list in human mode outputs a Rich table."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client(project_name="My Production")
+        mock_client = make_mock_client(project_name="My Production")
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -332,7 +321,7 @@ class TestProjectRemove:
         """project remove --json returns structured success."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -411,7 +400,7 @@ class TestProjectStatus:
         """project status --json returns connectivity info."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client(project_name="Prod", project_id=123)
+        mock_client = make_mock_client(project_name="Prod", project_id=123)
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -451,7 +440,7 @@ class TestProjectStatus:
         """project status in human mode shows status table."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -490,7 +479,7 @@ class TestProjectEdit:
         """project edit --url with --json updates URL and returns result."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -540,7 +529,7 @@ class TestProjectEdit:
         """project edit with no changes returns exit code 5."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -2123,7 +2112,7 @@ class TestDoctor:
             ),
         )
 
-        mock_client = _make_mock_client(project_name="Prod", project_id=1234)
+        mock_client = make_mock_client(project_name="Prod", project_id=1234)
 
         with (
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
@@ -2734,8 +2723,8 @@ class TestProjectEditTokenReverify:
         """project edit --new-token triggers re-verification and returns updated info."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()
-        mock_client = _make_mock_client(project_name="Original", project_id=100)
-        new_mock_client = _make_mock_client(project_name="Updated", project_id=200)
+        mock_client = make_mock_client(project_name="Original", project_id=100)
+        new_mock_client = make_mock_client(project_name="Updated", project_id=200)
 
         call_count = 0
 
@@ -2794,7 +2783,7 @@ class TestProjectAddTokenSecurity:
 
     def test_project_add_token_from_env(self, tmp_path: Path) -> None:
         """Token from KBC_TOKEN env var works for project add."""
-        mock_client = _make_mock_client(project_name="EnvProject", project_id=999)
+        mock_client = make_mock_client(project_name="EnvProject", project_id=999)
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -2837,7 +2826,7 @@ class TestProjectAddTokenSecurity:
         We mock _resolve_token to simulate the interactive prompt returning a token,
         since CliRunner does not have a real TTY and sys.stdin.isatty() is False.
         """
-        mock_client = _make_mock_client(project_name="PromptProject", project_id=888)
+        mock_client = make_mock_client(project_name="PromptProject", project_id=888)
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -2878,7 +2867,7 @@ class TestProjectAddTokenSecurity:
 
     def test_project_add_rejects_http_url(self, tmp_path: Path) -> None:
         """http:// URL rejected with error at project add time."""
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -2913,7 +2902,7 @@ class TestProjectAddTokenSecurity:
 
     def test_project_add_rejects_file_url(self, tmp_path: Path) -> None:
         """file:// URL rejected with error at project add time."""
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -2948,7 +2937,7 @@ class TestProjectAddTokenSecurity:
 
     def test_project_add_accepts_https_url(self, tmp_path: Path) -> None:
         """https:// URL is accepted at project add time."""
-        mock_client = _make_mock_client(project_name="SecureProject", project_id=777)
+        mock_client = make_mock_client(project_name="SecureProject", project_id=777)
         config_dir = tmp_path / "config"
         config_dir.mkdir()
 
@@ -3977,3 +3966,557 @@ class TestVerboseFlag:
         mock_basic_config.assert_called_once()
         call_kwargs = mock_basic_config.call_args
         assert call_kwargs[1]["level"] == logging.WARNING
+
+
+# ---------------------------------------------------------------------------
+# Lineage command tests
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_LINEAGE_RESULT = {
+    "edges": [
+        {
+            "source_project_alias": "prod",
+            "source_project_id": 258,
+            "source_project_name": "Production",
+            "source_bucket_id": "in.c-shared-data",
+            "source_bucket_name": "shared-data",
+            "sharing_type": "organization-project",
+            "target_project_alias": "dev",
+            "target_project_id": 7012,
+            "target_project_name": "Development",
+            "target_bucket_id": "in.c-linked",
+        },
+    ],
+    "shared_buckets": [
+        {
+            "project_alias": "prod",
+            "project_id": 258,
+            "project_name": "Production",
+            "bucket_id": "in.c-shared-data",
+            "bucket_name": "shared-data",
+            "sharing_type": "organization-project",
+            "shared_by": {},
+        },
+    ],
+    "linked_buckets": [],
+    "summary": {
+        "total_shared_buckets": 1,
+        "total_linked_buckets": 0,
+        "total_edges": 1,
+        "projects_queried": 2,
+        "projects_with_errors": 0,
+    },
+    "errors": [],
+}
+
+
+class TestLineageShow:
+    """Tests for `kbagent lineage` and `kbagent lineage show` commands."""
+
+    def test_lineage_show_json(self, tmp_path: Path) -> None:
+        """lineage show --json returns structured JSON with lineage data."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.LineageService") as MockLineageService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.get_lineage.return_value = SAMPLE_LINEAGE_RESULT
+            MockLineageService.return_value = mock_service
+
+            result = runner.invoke(app, ["--json", "lineage", "show"])
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert len(output["data"]["edges"]) == 1
+        assert output["data"]["edges"][0]["source_project_alias"] == "prod"
+        assert output["data"]["edges"][0]["target_project_alias"] == "dev"
+        assert output["data"]["summary"]["total_edges"] == 1
+        assert output["data"]["summary"]["projects_queried"] == 2
+
+    def test_lineage_show_human(self, tmp_path: Path) -> None:
+        """lineage show in human mode shows Rich table with data flow edges."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.LineageService") as MockLineageService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.get_lineage.return_value = SAMPLE_LINEAGE_RESULT
+            MockLineageService.return_value = mock_service
+
+            result = runner.invoke(app, ["lineage", "show"])
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        # Verify human output contains key information
+        assert "Data Flow" in result.output or "shared" in result.output
+        # Rich may truncate long strings in table columns, so check prefixes
+        assert "in.c-shared" in result.output
+        assert "organization" in result.output
+
+    def test_lineage_default_subcommand(self, tmp_path: Path) -> None:
+        """kbagent lineage (without 'show') invokes the show subcommand."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.LineageService") as MockLineageService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.get_lineage.return_value = SAMPLE_LINEAGE_RESULT
+            MockLineageService.return_value = mock_service
+
+            result = runner.invoke(app, ["--json", "lineage"])
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert "edges" in output["data"]
+        assert len(output["data"]["edges"]) == 1
+
+    def test_lineage_config_error_exit_code_5(self, tmp_path: Path) -> None:
+        """lineage with nonexistent project alias returns exit code 5."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.LineageService") as MockLineageService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.get_lineage.side_effect = ConfigError("Project 'nonexistent' not found")
+            MockLineageService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                ["--json", "lineage", "show", "--project", "nonexistent"],
+            )
+
+        assert result.exit_code == 5
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "CONFIG_ERROR"
+
+    def test_lineage_show_with_warnings(self, tmp_path: Path) -> None:
+        """lineage show in human mode displays per-project warnings."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        result_with_errors = {
+            "edges": [],
+            "shared_buckets": [],
+            "linked_buckets": [],
+            "summary": {
+                "total_shared_buckets": 0,
+                "total_linked_buckets": 0,
+                "total_edges": 0,
+                "projects_queried": 2,
+                "projects_with_errors": 1,
+            },
+            "errors": [
+                {
+                    "project_alias": "bad",
+                    "error_code": "INVALID_TOKEN",
+                    "message": "Token expired",
+                },
+            ],
+        }
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.LineageService") as MockLineageService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.get_lineage.return_value = result_with_errors
+            MockLineageService.return_value = mock_service
+
+            result = runner.invoke(app, ["lineage", "show"])
+
+        assert result.exit_code == 0
+        assert "bad" in result.output
+        assert "Token expired" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Org setup command tests
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_ORG_SETUP_RESULT = {
+    "organization_id": 42,
+    "stack_url": "https://connection.keboola.com",
+    "projects_found": 2,
+    "projects_added": [
+        {
+            "project_id": 100,
+            "project_name": "New Project",
+            "alias": "new-project",
+            "token": "100-***",
+            "action": "added",
+        },
+    ],
+    "projects_skipped": [
+        {
+            "project_id": 200,
+            "project_name": "Existing Project",
+            "reason": "Already registered in config",
+        },
+    ],
+    "projects_failed": [],
+    "dry_run": False,
+}
+
+SAMPLE_ORG_DRY_RUN_RESULT = {
+    "organization_id": 42,
+    "stack_url": "https://connection.keboola.com",
+    "projects_found": 2,
+    "projects_added": [
+        {
+            "project_id": 100,
+            "project_name": "New Project",
+            "alias": "new-project",
+            "action": "would_add",
+        },
+    ],
+    "projects_skipped": [
+        {
+            "project_id": 200,
+            "project_name": "Existing Project",
+            "reason": "Already registered in config",
+        },
+    ],
+    "projects_failed": [],
+    "dry_run": True,
+}
+
+
+class TestOrgSetup:
+    """Tests for `kbagent org setup` command."""
+
+    def test_org_setup_dry_run(self, tmp_path: Path) -> None:
+        """org setup --dry-run returns structured preview without changes."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.org._resolve_manage_token",
+                return_value="manage-token-abcdef",
+            ),
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.setup_organization.return_value = SAMPLE_ORG_DRY_RUN_RESULT
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "org",
+                    "setup",
+                    "--org-id",
+                    "42",
+                    "--url",
+                    "https://connection.keboola.com",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["dry_run"] is True
+        assert len(output["data"]["projects_added"]) == 1
+        assert output["data"]["projects_added"][0]["action"] == "would_add"
+
+    def test_org_setup_with_env_token(self, tmp_path: Path) -> None:
+        """org setup uses KBC_MANAGE_API_TOKEN env var for authentication."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch.dict(os.environ, {"KBC_MANAGE_API_TOKEN": "manage-test-token"}),
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.setup_organization.return_value = SAMPLE_ORG_DRY_RUN_RESULT
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "org",
+                    "setup",
+                    "--org-id",
+                    "42",
+                    "--url",
+                    "https://connection.keboola.com",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+
+    def test_org_setup_confirmation_declined(self, tmp_path: Path) -> None:
+        """org setup exits cleanly when user declines confirmation."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.org._resolve_manage_token",
+                return_value="manage-token-abcdef",
+            ),
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            # The preview dry-run call returns projects to add
+            mock_service.setup_organization.return_value = SAMPLE_ORG_DRY_RUN_RESULT
+            MockOrgService.return_value = mock_service
+
+            # Simulate user typing "n" to decline confirmation
+            result = runner.invoke(
+                app,
+                [
+                    "org",
+                    "setup",
+                    "--org-id",
+                    "42",
+                    "--url",
+                    "https://connection.keboola.com",
+                ],
+                input="n\n",
+            )
+
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    def test_org_setup_api_error(self, tmp_path: Path) -> None:
+        """org setup with API error returns appropriate exit code."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.org._resolve_manage_token",
+                return_value="manage-token-abcdef",
+            ),
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.setup_organization.side_effect = KeboolaApiError(
+                message="Invalid manage token",
+                status_code=401,
+                error_code="INVALID_TOKEN",
+                retryable=False,
+            )
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "org",
+                    "setup",
+                    "--org-id",
+                    "42",
+                    "--url",
+                    "https://connection.keboola.com",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 3
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "INVALID_TOKEN"
+
+    def test_org_setup_json_with_yes_flag(self, tmp_path: Path) -> None:
+        """org setup --json --yes skips confirmation and executes directly."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.org._resolve_manage_token",
+                return_value="manage-token-abcdef",
+            ),
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            mock_service = MagicMock()
+            mock_service.setup_organization.return_value = SAMPLE_ORG_SETUP_RESULT
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "org",
+                    "setup",
+                    "--org-id",
+                    "42",
+                    "--url",
+                    "https://connection.keboola.com",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["organization_id"] == 42
+        assert len(output["data"]["projects_added"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _resolve_manage_token tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveManageToken:
+    """Tests for _resolve_manage_token() in org.py."""
+
+    def test_token_from_env(self) -> None:
+        """_resolve_manage_token returns token from KBC_MANAGE_API_TOKEN env var."""
+        from keboola_agent_cli.commands.org import _resolve_manage_token
+
+        with patch.dict(os.environ, {"KBC_MANAGE_API_TOKEN": "env-manage-token"}):
+            token = _resolve_manage_token()
+
+        assert token == "env-manage-token"
+
+    def test_token_from_prompt(self) -> None:
+        """_resolve_manage_token prompts interactively when env var is not set."""
+        import sys
+
+        from keboola_agent_cli.commands.org import _resolve_manage_token
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("keboola_agent_cli.commands.org.typer.prompt", return_value="prompted-token"),
+            patch.object(sys, "stdin") as mock_stdin,
+        ):
+            # Ensure KBC_MANAGE_API_TOKEN is not set
+            os.environ.pop("KBC_MANAGE_API_TOKEN", None)
+            mock_stdin.isatty.return_value = True
+
+            token = _resolve_manage_token()
+
+        assert token == "prompted-token"
+
+    def test_non_tty_error(self) -> None:
+        """_resolve_manage_token raises Exit when not TTY and no env var."""
+        import sys
+
+        import typer
+
+        from keboola_agent_cli.commands.org import _resolve_manage_token
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch.object(sys, "stdin") as mock_stdin,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            # Ensure KBC_MANAGE_API_TOKEN is not set
+            os.environ.pop("KBC_MANAGE_API_TOKEN", None)
+            mock_stdin.isatty.return_value = False
+
+            _resolve_manage_token()
+
+        assert exc_info.value.exit_code == 2

--- a/tests/test_lineage_service.py
+++ b/tests/test_lineage_service.py
@@ -11,6 +11,8 @@ from keboola_agent_cli.models import ProjectConfig
 from keboola_agent_cli.services.base import ENV_MAX_PARALLEL_WORKERS
 from keboola_agent_cli.services.lineage_service import LineageService
 
+from helpers import setup_single_project, setup_two_projects
+
 
 def _make_lineage_client(buckets: list[dict]) -> MagicMock:
     """Create a mock KeboolaClient that returns the given list of buckets."""
@@ -26,58 +28,12 @@ def _make_failing_lineage_client(error: KeboolaApiError) -> MagicMock:
     return mock_client
 
 
-def _setup_single_project(
-    tmp_config_dir: Path,
-    alias: str = "prod",
-    stack_url: str = "https://connection.keboola.com",
-    token: str = "901-xxx",
-    project_name: str = "Production",
-    project_id: int = 258,
-) -> ConfigStore:
-    """Create a ConfigStore with a single project configured."""
-    store = ConfigStore(config_dir=tmp_config_dir)
-    store.add_project(
-        alias,
-        ProjectConfig(
-            stack_url=stack_url,
-            token=token,
-            project_name=project_name,
-            project_id=project_id,
-        ),
-    )
-    return store
-
-
-def _setup_two_projects(tmp_config_dir: Path) -> ConfigStore:
-    """Create a ConfigStore with two projects (prod and dev) configured."""
-    store = ConfigStore(config_dir=tmp_config_dir)
-    store.add_project(
-        "prod",
-        ProjectConfig(
-            stack_url="https://connection.keboola.com",
-            token="901-xxx",
-            project_name="Production",
-            project_id=258,
-        ),
-    )
-    store.add_project(
-        "dev",
-        ProjectConfig(
-            stack_url="https://connection.keboola.com",
-            token="7012-yyy",
-            project_name="Development",
-            project_id=7012,
-        ),
-    )
-    return store
-
-
 class TestLineageSharedBucket:
     """Tests for a project with a shared bucket that has linkedBy entries."""
 
     def test_shared_bucket_with_linked_by(self, tmp_config_dir: Path) -> None:
         """A shared bucket with linkedBy entries produces edges and shared_buckets."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         buckets = [
             {
@@ -133,7 +89,7 @@ class TestLineageSharedBucket:
 
     def test_shared_bucket_multiple_linked_by(self, tmp_config_dir: Path) -> None:
         """A shared bucket linked by multiple projects produces multiple edges."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         buckets = [
             {
@@ -165,7 +121,7 @@ class TestLineageLinkedBucket:
 
     def test_linked_bucket_with_source(self, tmp_config_dir: Path) -> None:
         """A linked bucket with sourceBucket produces edges and linked_buckets."""
-        store = _setup_single_project(
+        store = setup_single_project(
             tmp_config_dir,
             alias="dev",
             token="7012-yyy",
@@ -228,7 +184,7 @@ class TestLineageMultiProjectDedup:
 
     def test_edges_deduplicated_across_two_projects(self, tmp_config_dir: Path) -> None:
         """When project A shares and project B links the same bucket, edges are deduplicated."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # Project A (prod, id=258) shares bucket with linkedBy pointing to project B
         prod_buckets = [
@@ -294,7 +250,7 @@ class TestLineageMultiProjectDedup:
 
     def test_dedup_with_same_edge_key(self, tmp_config_dir: Path) -> None:
         """Both projects report the same edge key, result is 1 edge not 2."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # Both projects produce the same edge key: (258, "in.c-shared", 7012, "in.c-linked")
         prod_buckets = [
@@ -338,7 +294,7 @@ class TestLineageErrorAccumulation:
 
     def test_one_project_fails_other_succeeds(self, tmp_config_dir: Path) -> None:
         """When one project fails with KeboolaApiError, the other still produces results."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # prod client will fail
         error = KeboolaApiError(
@@ -389,7 +345,7 @@ class TestLineageErrorAccumulation:
 
     def test_client_close_called_even_on_error(self, tmp_config_dir: Path) -> None:
         """Client.close() is called even when list_buckets raises an error."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         error = KeboolaApiError(
             message="Server Error",
@@ -415,7 +371,7 @@ class TestLineageNoSharing:
 
     def test_no_sharing_no_linking(self, tmp_config_dir: Path) -> None:
         """Buckets without sharing, linkedBy, or sourceBucket produce empty results."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         buckets = [
             {"id": "in.c-data", "name": "data"},
@@ -441,7 +397,7 @@ class TestLineageNoSharing:
 
     def test_empty_bucket_list(self, tmp_config_dir: Path) -> None:
         """A project with no buckets at all produces empty results."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         mock_client = _make_lineage_client([])
 
         service = LineageService(
@@ -457,7 +413,7 @@ class TestLineageNoSharing:
 
     def test_empty_linked_by_list(self, tmp_config_dir: Path) -> None:
         """A shared bucket with empty linkedBy list produces no edges."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         buckets = [
             {
@@ -486,7 +442,7 @@ class TestLineageNonexistentAlias:
 
     def test_nonexistent_alias_raises_config_error(self, tmp_config_dir: Path) -> None:
         """Passing an alias not in the config raises ConfigError."""
-        store = _setup_single_project(tmp_config_dir, alias="prod")
+        store = setup_single_project(tmp_config_dir, alias="prod")
 
         service = LineageService(
             config_store=store,
@@ -498,7 +454,7 @@ class TestLineageNonexistentAlias:
 
     def test_nonexistent_alias_in_resolve_projects(self, tmp_config_dir: Path) -> None:
         """resolve_projects also raises ConfigError for unknown aliases."""
-        store = _setup_single_project(tmp_config_dir, alias="prod")
+        store = setup_single_project(tmp_config_dir, alias="prod")
 
         service = LineageService(
             config_store=store,
@@ -514,7 +470,7 @@ class TestLineageProjectFilter:
 
     def test_filter_to_single_alias(self, tmp_config_dir: Path) -> None:
         """With 2 projects configured, passing aliases=['prod'] queries only prod."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         prod_buckets = [
             {
@@ -547,7 +503,7 @@ class TestLineageProjectFilter:
 
     def test_no_aliases_queries_all(self, tmp_config_dir: Path) -> None:
         """Passing aliases=None queries all configured projects."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         mock_client = _make_lineage_client([])
 
@@ -564,7 +520,7 @@ class TestLineageProjectFilter:
 
     def test_resolve_projects_returns_filtered(self, tmp_config_dir: Path) -> None:
         """resolve_projects with aliases returns only the requested project."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         service = LineageService(
             config_store=store,
@@ -577,7 +533,7 @@ class TestLineageProjectFilter:
 
     def test_resolve_projects_no_aliases_returns_all(self, tmp_config_dir: Path) -> None:
         """resolve_projects with aliases=None returns all configured projects."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         service = LineageService(
             config_store=store,
@@ -613,7 +569,7 @@ class TestLineageParallelExecution:
 
     def test_all_projects_queried_in_parallel(self, tmp_config_dir: Path) -> None:
         """All configured projects are queried (each client gets called)."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         prod_client = _make_lineage_client([])
         dev_client = _make_lineage_client([])
@@ -638,7 +594,7 @@ class TestLineageParallelExecution:
 
     def test_mixed_success_and_failure(self, tmp_config_dir: Path) -> None:
         """One project succeeds and one fails; results and errors both preserved."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # prod fails with API error
         error = KeboolaApiError(
@@ -682,7 +638,7 @@ class TestLineageParallelExecution:
 
     def test_unexpected_exception_accumulated_as_error(self, tmp_config_dir: Path) -> None:
         """Non-KeboolaApiError exceptions are caught and accumulated as errors."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
 
         mock_client = MagicMock()
         mock_client.list_buckets.side_effect = RuntimeError("connection pool exhausted")
@@ -704,7 +660,7 @@ class TestLineageParallelExecution:
 
     def test_deterministic_output_ordering(self, tmp_config_dir: Path) -> None:
         """Edges and buckets are sorted deterministically regardless of execution order."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # prod (id=258) shares a bucket linked by dev (id=7012)
         prod_buckets = [
@@ -746,7 +702,7 @@ class TestLineageParallelExecution:
 
     def test_mixed_int_str_project_ids_in_sort(self, tmp_config_dir: Path) -> None:
         """Sorting works when API returns project IDs as mix of int and str."""
-        store = _setup_two_projects(tmp_config_dir)
+        store = setup_two_projects(tmp_config_dir)
 
         # prod shares bucket, linkedBy has project id as int
         prod_buckets = [
@@ -789,13 +745,13 @@ class TestLineageParallelExecution:
 
     def test_default_max_workers_from_config(self, tmp_config_dir: Path) -> None:
         """Default max_parallel_workers is 10 from AppConfig."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         service = LineageService(config_store=store)
         assert service._resolve_max_workers() == 10
 
     def test_max_workers_from_config_file(self, tmp_config_dir: Path) -> None:
         """max_parallel_workers can be set in config.json."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 20
         store.save(config)
@@ -805,7 +761,7 @@ class TestLineageParallelExecution:
 
     def test_env_var_overrides_config(self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """KBAGENT_MAX_PARALLEL_WORKERS env var overrides config.json value."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 5
         store.save(config)
@@ -816,7 +772,7 @@ class TestLineageParallelExecution:
 
     def test_invalid_env_var_falls_back_to_config(self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Invalid env var value falls back to config.json."""
-        store = _setup_single_project(tmp_config_dir)
+        store = setup_single_project(tmp_config_dir)
         config = store.load()
         config.max_parallel_workers = 15
         store.save(config)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -6,7 +6,19 @@ from io import StringIO
 
 from rich.console import Console
 
-from keboola_agent_cli.output import OutputFormatter, format_job_detail, format_jobs_table
+from keboola_agent_cli.output import (
+    OutputFormatter,
+    _format_duration,
+    _seconds_to_human,
+    format_config_detail,
+    format_configs_table,
+    format_doctor_panel,
+    format_job_detail,
+    format_jobs_table,
+    format_lineage_table,
+    format_tool_result,
+    format_tools_table,
+)
 
 
 class TestOutputFormatterJsonMode:
@@ -383,3 +395,515 @@ class TestFormatJobDetail:
 
         assert "3001" in output
         assert "processing" in output
+
+
+# ---------------------------------------------------------------------------
+# _format_duration and _seconds_to_human tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDuration:
+    """Tests for _format_duration helper."""
+
+    def test_duration_from_duration_seconds(self) -> None:
+        """_format_duration uses durationSeconds when available."""
+        job = {"durationSeconds": 90}
+        assert _format_duration(job) == "1m 30s"
+
+    def test_duration_from_start_end_times(self) -> None:
+        """_format_duration calculates from startTime/endTime when no durationSeconds."""
+        job = {
+            "startTime": "2026-02-26T10:00:00+00:00",
+            "endTime": "2026-02-26T10:02:30+00:00",
+        }
+        assert _format_duration(job) == "2m 30s"
+
+    def test_duration_missing_both(self) -> None:
+        """_format_duration returns '-' when neither durationSeconds nor times are present."""
+        job = {}
+        assert _format_duration(job) == "-"
+
+    def test_duration_zero_seconds(self) -> None:
+        """_format_duration handles zero-second duration."""
+        job = {"durationSeconds": 0}
+        assert _format_duration(job) == "0s"
+
+    def test_duration_invalid_time_format(self) -> None:
+        """_format_duration returns '-' for invalid time formats."""
+        job = {"startTime": "not-a-date", "endTime": "also-not-a-date"}
+        assert _format_duration(job) == "-"
+
+
+class TestSecondsToHuman:
+    """Tests for _seconds_to_human helper."""
+
+    def test_seconds_only(self) -> None:
+        """Durations under 60s show as Ns."""
+        assert _seconds_to_human(0) == "0s"
+        assert _seconds_to_human(1) == "1s"
+        assert _seconds_to_human(59) == "59s"
+
+    def test_minutes_and_seconds(self) -> None:
+        """Durations 1m-59m show as Nm Ns."""
+        assert _seconds_to_human(60) == "1m 0s"
+        assert _seconds_to_human(90) == "1m 30s"
+        assert _seconds_to_human(3599) == "59m 59s"
+
+    def test_hours_and_minutes(self) -> None:
+        """Durations >= 1h show as Nh Nm."""
+        assert _seconds_to_human(3600) == "1h 0m"
+        assert _seconds_to_human(3661) == "1h 1m"
+        assert _seconds_to_human(7200) == "2h 0m"
+        assert _seconds_to_human(7260) == "2h 1m"
+
+
+# ---------------------------------------------------------------------------
+# format_lineage_table tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLineageTable:
+    """Tests for format_lineage_table Rich output."""
+
+    def test_lineage_table_with_edges(self) -> None:
+        """format_lineage_table renders data flow table with edge details."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "edges": [
+                {
+                    "source_project_alias": "prod",
+                    "source_project_id": 258,
+                    "source_project_name": "Production",
+                    "source_bucket_id": "in.c-shared",
+                    "source_bucket_name": "shared",
+                    "sharing_type": "organization-project",
+                    "target_project_alias": "dev",
+                    "target_project_id": 7012,
+                    "target_project_name": "Development",
+                    "target_bucket_id": "in.c-linked",
+                },
+            ],
+            "shared_buckets": [
+                {
+                    "project_alias": "prod",
+                    "project_id": 258,
+                    "bucket_id": "in.c-shared",
+                    "bucket_name": "shared",
+                    "sharing_type": "organization-project",
+                },
+            ],
+            "linked_buckets": [],
+            "summary": {
+                "total_shared_buckets": 1,
+                "total_linked_buckets": 0,
+                "total_edges": 1,
+                "projects_queried": 2,
+            },
+            "errors": [],
+        }
+
+        format_lineage_table(console, data)
+        output = console.file.getvalue()
+
+        assert "Data Flow" in output
+        assert "in.c-shared" in output
+        assert "in.c-linked" in output
+        # Rich may truncate long strings in table columns
+        assert "organization" in output
+        assert "1" in output  # edge count in summary
+
+    def test_lineage_table_no_edges_no_buckets(self) -> None:
+        """format_lineage_table shows 'no bucket sharing' when nothing found."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "edges": [],
+            "shared_buckets": [],
+            "linked_buckets": [],
+            "summary": {
+                "total_shared_buckets": 0,
+                "total_linked_buckets": 0,
+                "total_edges": 0,
+                "projects_queried": 2,
+            },
+            "errors": [],
+        }
+
+        format_lineage_table(console, data)
+        output = console.file.getvalue()
+
+        assert "No bucket sharing" in output
+
+    def test_lineage_table_with_errors(self) -> None:
+        """format_lineage_table renders warnings for per-project errors."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "edges": [],
+            "shared_buckets": [],
+            "linked_buckets": [],
+            "summary": {
+                "total_shared_buckets": 0,
+                "total_linked_buckets": 0,
+                "total_edges": 0,
+                "projects_queried": 1,
+            },
+            "errors": [
+                {
+                    "project_alias": "bad",
+                    "message": "Token expired",
+                },
+            ],
+        }
+
+        format_lineage_table(console, data)
+        output = console.file.getvalue()
+
+        assert "Warning" in output
+        assert "bad" in output
+        assert "Token expired" in output
+
+    def test_lineage_table_shared_buckets_no_edges(self) -> None:
+        """format_lineage_table shows shared buckets table when edges are empty."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "edges": [],
+            "shared_buckets": [
+                {
+                    "project_alias": "prod",
+                    "project_id": 258,
+                    "bucket_id": "in.c-shared",
+                    "bucket_name": "shared",
+                    "sharing_type": "organization-project",
+                },
+            ],
+            "linked_buckets": [],
+            "summary": {
+                "total_shared_buckets": 1,
+                "total_linked_buckets": 0,
+                "total_edges": 0,
+                "projects_queried": 1,
+            },
+            "errors": [],
+        }
+
+        format_lineage_table(console, data)
+        output = console.file.getvalue()
+
+        assert "Shared Buckets" in output
+        assert "in.c-shared" in output
+
+
+# ---------------------------------------------------------------------------
+# format_tool_result tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatToolResult:
+    """Tests for format_tool_result Rich output."""
+
+    def test_tool_result_single_success(self) -> None:
+        """format_tool_result renders a single successful result."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "results": [
+                {
+                    "project_alias": "prod",
+                    "isError": False,
+                    "content": ["Table loaded: 1000 rows"],
+                },
+            ],
+            "errors": [],
+        }
+
+        format_tool_result(console, data)
+        output = console.file.getvalue()
+
+        assert "prod" in output
+        assert "OK" in output
+        assert "1000 rows" in output
+
+    def test_tool_result_all_same_error_consolidated(self) -> None:
+        """format_tool_result consolidates identical errors across projects."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "results": [
+                {
+                    "project_alias": "prod",
+                    "isError": True,
+                    "content": ["Missing parameter: bucket_id"],
+                },
+                {
+                    "project_alias": "dev",
+                    "isError": True,
+                    "content": ["Missing parameter: bucket_id"],
+                },
+            ],
+            "errors": [],
+        }
+
+        format_tool_result(console, data)
+        output = console.file.getvalue()
+
+        assert "Tool Error" in output
+        assert "same error across 2 projects" in output
+        assert "prod" in output
+        assert "dev" in output
+
+    def test_tool_result_empty(self) -> None:
+        """format_tool_result handles empty results."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {"results": [], "errors": []}
+
+        format_tool_result(console, data)
+        output = console.file.getvalue()
+
+        assert "No results" in output
+
+    def test_tool_result_with_dict_content(self) -> None:
+        """format_tool_result renders dict content items as JSON."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "results": [
+                {
+                    "project_alias": "prod",
+                    "isError": False,
+                    "content": [{"table_id": "in.c-test.data", "rows": 100}],
+                },
+            ],
+            "errors": [],
+        }
+
+        format_tool_result(console, data)
+        output = console.file.getvalue()
+
+        assert "prod" in output
+        assert "table_id" in output
+        assert "in.c-test.data" in output
+
+
+# ---------------------------------------------------------------------------
+# format_tools_table tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatToolsTable:
+    """Tests for format_tools_table Rich output."""
+
+    def test_tools_table_with_tools(self) -> None:
+        """format_tools_table renders table with tool information."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "tools": [
+                {
+                    "name": "list_tables",
+                    "multi_project": True,
+                    "description": "List all tables in the project",
+                },
+                {
+                    "name": "create_table",
+                    "multi_project": False,
+                    "description": "Create a new table",
+                },
+            ],
+            "errors": [],
+        }
+
+        format_tools_table(console, data)
+        output = console.file.getvalue()
+
+        assert "MCP Tools" in output
+        assert "list_tables" in output
+        assert "create_table" in output
+        assert "yes" in output
+        assert "no" in output
+
+    def test_tools_table_empty(self) -> None:
+        """format_tools_table shows message when no tools found."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {"tools": [], "errors": []}
+
+        format_tools_table(console, data)
+        output = console.file.getvalue()
+
+        assert "No MCP tools found" in output
+
+    def test_tools_table_with_errors(self) -> None:
+        """format_tools_table shows warnings for failed projects."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "tools": [],
+            "errors": [
+                {
+                    "project_alias": "bad",
+                    "message": "Connection refused",
+                },
+            ],
+        }
+
+        format_tools_table(console, data)
+        output = console.file.getvalue()
+
+        assert "Warning" in output
+        assert "bad" in output
+        assert "Connection refused" in output
+
+
+# ---------------------------------------------------------------------------
+# format_config_detail tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatConfigDetail:
+    """Tests for format_config_detail Rich output."""
+
+    def test_config_detail_renders_all_fields(self) -> None:
+        """format_config_detail renders all key fields in a panel."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "project_alias": "prod",
+            "name": "Production Load",
+            "id": "101",
+            "description": "Loads production data",
+            "component_id": "keboola.ex-db-snowflake",
+            "configuration": {"parameters": {"db": "prod"}},
+            "rows": [
+                {"name": "row-1"},
+                {"name": "row-2"},
+            ],
+        }
+
+        format_config_detail(console, data)
+        output = console.file.getvalue()
+
+        assert "Configuration Detail" in output
+        assert "Production Load" in output
+        assert "101" in output
+        assert "keboola.ex-db-snowflake" in output
+        assert "Loads production data" in output
+        assert "2 row(s)" in output
+        assert "row-1" in output
+        assert "row-2" in output
+
+    def test_config_detail_minimal(self) -> None:
+        """format_config_detail handles minimal data without crashing."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "name": "Minimal",
+            "id": "1",
+        }
+
+        format_config_detail(console, data)
+        output = console.file.getvalue()
+
+        assert "Minimal" in output
+        assert "1" in output
+
+
+# ---------------------------------------------------------------------------
+# format_configs_table tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatConfigsTable:
+    """Tests for format_configs_table Rich output."""
+
+    def test_configs_table_grouped_by_project(self) -> None:
+        """format_configs_table groups configs by project alias."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "configs": [
+                {
+                    "project_alias": "prod",
+                    "component_id": "keboola.ex-db-snowflake",
+                    "component_type": "extractor",
+                    "config_id": "101",
+                    "config_name": "Production Load",
+                    "config_description": "Loads production data",
+                },
+                {
+                    "project_alias": "prod",
+                    "component_id": "keboola.wr-db-snowflake",
+                    "component_type": "writer",
+                    "config_id": "201",
+                    "config_name": "Write to DWH",
+                    "config_description": "",
+                },
+            ],
+            "errors": [],
+        }
+
+        format_configs_table(console, data)
+        output = console.file.getvalue()
+
+        assert "Configurations" in output
+        assert "prod" in output
+        assert "Production Load" in output
+        assert "Write to DWH" in output
+
+    def test_configs_table_empty(self) -> None:
+        """format_configs_table shows helpful message when no configs found."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {"configs": [], "errors": []}
+
+        format_configs_table(console, data)
+        output = console.file.getvalue()
+
+        assert "No configurations found" in output
+
+
+# ---------------------------------------------------------------------------
+# format_doctor_panel tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDoctorPanel:
+    """Tests for format_doctor_panel Rich output."""
+
+    def test_doctor_panel_with_checks(self) -> None:
+        """format_doctor_panel renders checks with status indicators."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "checks": [
+                {"check": "config_file", "status": "pass", "name": "Config File", "message": "Found at ~/.config/kbagent/config.json"},
+                {"check": "config_valid", "status": "pass", "name": "Config Valid", "message": "1 project configured"},
+                {"check": "version", "status": "pass", "name": "Version", "message": "kbagent v0.1.0"},
+            ],
+            "summary": {
+                "total": 3,
+                "passed": 3,
+                "failed": 0,
+                "warnings": 0,
+            },
+        }
+
+        format_doctor_panel(console, data)
+        output = console.file.getvalue()
+
+        assert "kbagent doctor" in output
+        assert "PASS" in output
+        assert "Config File" in output
+        assert "3 checks" in output
+        assert "3 passed" in output
+
+    def test_doctor_panel_with_failures(self) -> None:
+        """format_doctor_panel renders failure and warning statuses."""
+        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        data = {
+            "checks": [
+                {"check": "config_file", "status": "fail", "name": "Config File", "message": "Not found"},
+                {"check": "connectivity", "status": "warn", "name": "Connectivity", "message": "Timeout"},
+            ],
+            "summary": {
+                "total": 2,
+                "passed": 0,
+                "failed": 1,
+                "warnings": 1,
+            },
+        }
+
+        format_doctor_panel(console, data)
+        output = console.file.getvalue()
+
+        assert "FAIL" in output
+        assert "WARN" in output
+        assert "1 failed" in output
+        assert "1 warnings" in output

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -12,29 +12,7 @@ from keboola_agent_cli.services.config_service import ConfigService
 from keboola_agent_cli.services.job_service import JobService
 from keboola_agent_cli.services.project_service import ProjectService
 
-
-def _make_mock_client(
-    project_name: str = "Test Project",
-    project_id: int = 1234,
-    token_description: str = "My Token",
-) -> MagicMock:
-    """Create a mock KeboolaClient that returns a successful verify_token response."""
-    mock_client = MagicMock()
-    mock_client.verify_token.return_value = TokenVerifyResponse(
-        token_id="12345",
-        token_description=token_description,
-        project_id=project_id,
-        project_name=project_name,
-        owner_name=project_name,
-    )
-    return mock_client
-
-
-def _make_failing_client(error: KeboolaApiError) -> MagicMock:
-    """Create a mock KeboolaClient whose verify_token raises the given error."""
-    mock_client = MagicMock()
-    mock_client.verify_token.side_effect = error
-    return mock_client
+from helpers import make_failing_client, make_mock_client
 
 
 class TestAddProject:
@@ -43,7 +21,7 @@ class TestAddProject:
     def test_add_project_success(self, tmp_config_dir: Path) -> None:
         """add_project verifies token, saves to config, returns project info."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client(project_name="Production", project_id=9999)
+        mock_client = make_mock_client(project_name="Production", project_id=9999)
 
         service = ProjectService(
             config_store=store,
@@ -73,7 +51,7 @@ class TestAddProject:
     def test_add_project_invalid_token(self, tmp_config_dir: Path) -> None:
         """add_project raises KeboolaApiError when token verification fails."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_failing_client(
+        mock_client = make_failing_client(
             KeboolaApiError(
                 message="Invalid token",
                 status_code=401,
@@ -102,7 +80,7 @@ class TestAddProject:
     def test_add_project_duplicate_alias(self, tmp_config_dir: Path) -> None:
         """add_project raises ConfigError when alias already exists."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         service = ProjectService(
             config_store=store,
@@ -125,7 +103,7 @@ class TestAddProject:
     def test_add_project_network_error(self, tmp_config_dir: Path) -> None:
         """add_project raises KeboolaApiError on network timeout."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_failing_client(
+        mock_client = make_failing_client(
             KeboolaApiError(
                 message="Request timed out",
                 status_code=0,
@@ -156,7 +134,7 @@ class TestRemoveProject:
     def test_remove_project_success(self, tmp_config_dir: Path) -> None:
         """remove_project removes the project and returns confirmation."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -188,7 +166,7 @@ class TestEditProject:
     def test_edit_url_only(self, tmp_config_dir: Path) -> None:
         """edit_project with only URL updates the stack URL without re-verifying."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
 
         service = ProjectService(
             config_store=store,
@@ -213,8 +191,8 @@ class TestEditProject:
     def test_edit_token_reverifies(self, tmp_config_dir: Path) -> None:
         """edit_project with new token re-verifies against the API."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        initial_client = _make_mock_client(project_name="Old Project", project_id=1000)
-        new_client = _make_mock_client(project_name="New Project", project_id=2000)
+        initial_client = make_mock_client(project_name="Old Project", project_id=1000)
+        new_client = make_mock_client(project_name="New Project", project_id=2000)
 
         call_count = [0]
 
@@ -246,7 +224,7 @@ class TestEditProject:
     def test_edit_no_changes_raises_error(self, tmp_config_dir: Path) -> None:
         """edit_project with no changes raises ConfigError."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -284,7 +262,7 @@ class TestListProjects:
     def test_list_multiple_projects(self, tmp_config_dir: Path) -> None:
         """list_projects returns all projects with masked tokens."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -320,7 +298,7 @@ class TestListProjects:
         """list_projects never returns the full token."""
         store = ConfigStore(config_dir=tmp_config_dir)
         full_token = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -343,7 +321,7 @@ class TestGetStatus:
     def test_status_all_ok(self, tmp_config_dir: Path) -> None:
         """get_status returns OK status with response time for healthy projects."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client(project_name="Production", project_id=1234)
+        mock_client = make_mock_client(project_name="Production", project_id=1234)
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -367,8 +345,8 @@ class TestGetStatus:
         """get_status handles mixed success/failure across projects."""
         store = ConfigStore(config_dir=tmp_config_dir)
 
-        ok_client = _make_mock_client(project_name="OK Project")
-        fail_client = _make_failing_client(
+        ok_client = make_mock_client(project_name="OK Project")
+        fail_client = make_failing_client(
             KeboolaApiError(
                 message="Token expired",
                 status_code=401,
@@ -424,7 +402,7 @@ class TestGetStatus:
     def test_status_specific_project(self, tmp_config_dir: Path) -> None:
         """get_status with specific alias only checks that project."""
         store = ConfigStore(config_dir=tmp_config_dir)
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -461,7 +439,7 @@ class TestGetStatus:
         """get_status always masks tokens in output."""
         store = ConfigStore(config_dir=tmp_config_dir)
         full_token = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
-        mock_client = _make_mock_client()
+        mock_client = make_mock_client()
         service = ProjectService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -1955,7 +1933,7 @@ class TestStatusParallel:
             ),
         )
 
-        mock_client = _make_mock_client(project_name="Generic", project_id=1)
+        mock_client = make_mock_client(project_name="Generic", project_id=1)
 
         service = ProjectService(
             config_store=store,
@@ -1985,7 +1963,7 @@ class TestStatusParallel:
             ),
         )
 
-        mock_client = _make_failing_client(
+        mock_client = make_failing_client(
             KeboolaApiError(
                 message="Token expired",
                 status_code=401,
@@ -2070,8 +2048,8 @@ class TestStatusParallel:
             ),
         )
 
-        ok_client = _make_mock_client(project_name="OK Project", project_id=1)
-        expired_client = _make_failing_client(
+        ok_client = make_mock_client(project_name="OK Project", project_id=1)
+        expired_client = make_failing_client(
             KeboolaApiError(
                 message="Token expired",
                 status_code=401,


### PR DESCRIPTION
## Summary
Fill testing gaps identified during code review:
- Add CLI-level tests for `kbagent lineage` command (JSON output, human output, default subcommand, config errors, warnings)
- Add CLI-level tests for `kbagent org setup` command (dry-run, env var token, confirmation declined, API errors, --yes flag)
- Test `_resolve_manage_token()` for all 3 paths (env var, TTY prompt, non-TTY error)
- Add unit tests for all `output.py` format functions (`format_lineage_table`, `format_tool_result`, `format_tools_table`, `format_config_detail`, `format_configs_table`, `format_doctor_panel`, `_format_duration`, `_seconds_to_human`)
- Extract shared test helpers to `tests/helpers.py` to eliminate duplication across test files

## Changes
- **tests/helpers.py** (NEW): Shared test helper functions (`make_mock_client`, `make_failing_client`, `setup_single_project`, `setup_two_projects`)
- **tests/conftest.py**: Kept clean with pytest fixtures only
- **tests/test_cli.py**: Added `TestLineageShow` (5 tests), `TestOrgSetup` (5 tests), `TestResolveManageToken` (3 tests); use shared helpers
- **tests/test_output.py**: Added `TestFormatDuration` (5 tests), `TestSecondsToHuman` (3 tests), `TestFormatLineageTable` (4 tests), `TestFormatToolResult` (4 tests), `TestFormatToolsTable` (3 tests), `TestFormatConfigDetail` (2 tests), `TestFormatConfigsTable` (2 tests), `TestFormatDoctorPanel` (2 tests)
- **tests/test_base_service.py**: Replaced inlined helpers with imports from `helpers.py`
- **tests/test_lineage_service.py**: Replaced inlined helpers with imports from `helpers.py`
- **tests/test_services.py**: Replaced inlined helpers with imports from `helpers.py`
- **pyproject.toml**: Added `tests` to `pythonpath` for helper module imports

## Test Results
- 540 passed, 3 skipped (38 new tests added)
- All existing tests continue to pass

## Acceptance Criteria
- [x] `kbagent lineage` has CLI-level tests (JSON and human output)
- [x] `kbagent org setup` has CLI-level tests (dry-run, confirmation, token sources)
- [x] `_resolve_manage_token()` tested for all 3 paths (env, TTY, non-TTY)
- [x] All `output.py` format functions have direct unit tests
- [x] No duplicate test helpers -- all shared functions in `tests/helpers.py`
- [x] All tests pass