### PR TITLE
Fix: add packaging to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.6.5"
+version = "0.6.6"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -17,6 +17,7 @@ dependencies = [
     "mcp>=1.0.0,<2.0.0",
     "jsonschema>=4.20",
     "pyyaml>=6",
+    "packaging>=23",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Add `packaging>=23` as explicit dependency — `version_service.py` imports it but it wasn't declared
- Bump version to 0.6.6 (aligns pyproject.toml with `__init__.py`)

## Problem

`typer[all]` used to pull in `packaging` transitively, but typer 0.24+ dropped the `all` extra. This causes `ModuleNotFoundError: No module named 'packaging'` on clean installs (e.g. `uv tool install`, `pip install`). Dev installs are unaffected because pytest brings it in.

## Test plan

- [ ] `uv tool install --force .` — verify kbagent starts without crash
- [ ] `kbagent version` — shows v0.6.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)