### PR TITLE
v0.7.0: Local workspace config (.kbagent/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ docs/
 # OS
 .DS_Store
 Thumbs.db
+.kbagent/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ Both inherit from `BaseHttpClient` (`http_base.py`) which provides shared retry/
 ## All CLI Commands
 
 ```
-# Global options: --json, --verbose, --no-color
+# Global options: --json, --verbose, --no-color, --config-dir
 
 kbagent project add --alias NAME --url URL --token TOKEN
 kbagent project list
@@ -192,7 +192,12 @@ kbagent branch delete --project ALIAS --branch ID
 kbagent branch merge --project ALIAS [--branch ID]
 
 kbagent explorer [--project NAME] [--output-dir DIR] [--job-limit N] [--tiers FILE] [--no-open]
+kbagent explorer init-tiers [--output FILE]
+
+kbagent llm export --project ALIAS [--with-samples] [--sample-limit N] [--max-samples N]
 
 kbagent context
-kbagent doctor
+kbagent init [--from-global]
+kbagent doctor [--fix]
+kbagent version
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Keboola's web UI and standard API clients work great for a single project. But w
 | `llm export` | AI-optimized project export via `kbc` Go binary (auto-resolves credentials) |
 | `version` | Show kbagent version and check for kbc / MCP server updates |
 | `context` | Print comprehensive usage instructions for AI agents |
+| `init` | Initialize a local `.kbagent/` workspace for per-directory project isolation |
 | `doctor` | Health check -- verifies config, permissions, connectivity, MCP server availability |
 
 Every command supports `--json` for structured output and Rich formatting for human-readable output.
@@ -60,6 +61,32 @@ All configuration lives in a single file:
 ```
 
 This file contains **Storage API tokens** for each connected project. File permissions are set to `0600` (owner read/write only) to protect these tokens. Tokens are always masked in CLI output (e.g. `901-...pt0k`).
+
+### Workspace isolation (per-client directories)
+
+By default kbagent uses a single global config. For teams working with multiple clients, you can create **per-directory workspaces** so each client folder has its own isolated set of Keboola projects.
+
+```bash
+# Create a workspace for ACME client
+mkdir -p ~/clients/acme && cd ~/clients/acme
+kbagent init                    # creates .kbagent/config.json
+kbagent project add --alias acme-prod --url https://connection.keboola.com --token ...
+
+# Create a workspace for BigCorp client
+mkdir -p ~/clients/bigcorp && cd ~/clients/bigcorp
+kbagent init                    # separate .kbagent/config.json
+kbagent project add --alias bigcorp-main --url https://connection.eu-central-1.keboola.com --token ...
+```
+
+Now when you `cd ~/clients/acme` and run `kbagent project list`, you only see ACME's projects. Each client directory can have its own `CLAUDE.md` with project-specific instructions.
+
+**Config resolution order** (first match wins):
+1. `--config-dir` CLI flag
+2. `KBAGENT_CONFIG_DIR` environment variable
+3. `.kbagent/config.json` in current or parent directory (walks up, like git)
+4. `~/.config/keboola-agent-cli/config.json` (global default)
+
+Run `kbagent doctor` to see which config is active. Use `kbagent init --from-global` to copy existing projects to a local workspace.
 
 The config file structure:
 

--- a/src/keboola_agent_cli/__init__.py
+++ b/src/keboola_agent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Keboola Agent CLI - AI-friendly interface to Keboola projects."""
 
-__version__ = "0.6.7"
+__version__ = "0.7.0"

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -10,6 +10,7 @@ from .commands.config import config_app
 from .commands.context import context_command
 from .commands.doctor import doctor_command
 from .commands.explorer import explorer_app
+from .commands.init import init_command
 from .commands.job import job_app
 from .commands.lineage import lineage_app
 from .commands.llm import llm_app
@@ -17,7 +18,7 @@ from .commands.org import org_app
 from .commands.project import project_app
 from .commands.tool import tool_app
 from .commands.version import version_command
-from .config_store import ConfigStore
+from .config_store import ConfigStore, resolve_config_dir
 from .output import OutputFormatter
 from .services.branch_service import BranchService
 from .services.config_service import ConfigService
@@ -48,6 +49,7 @@ app.add_typer(explorer_app, name="explorer")
 app.add_typer(llm_app, name="llm")
 app.command("context")(context_command)
 app.command("doctor")(doctor_command)
+app.command("init")(init_command)
 app.command("version")(version_command)
 
 
@@ -71,6 +73,11 @@ def main(
         "--no-color",
         help="Disable colored output",
     ),
+    config_dir: str | None = typer.Option(
+        None,
+        "--config-dir",
+        help="Override config directory path.",
+    ),
 ) -> None:
     """Global options applied to all commands."""
     log_level = logging.DEBUG if verbose else logging.WARNING
@@ -89,7 +96,8 @@ def main(
         verbose=verbose,
     )
 
-    config_store = ConfigStore()
+    resolved_dir, source = resolve_config_dir(cli_config_dir=config_dir)
+    config_store = ConfigStore(config_dir=resolved_dir, source=source)
 
     project_service = ProjectService(config_store=config_store)
     config_service = ConfigService(config_store=config_store)

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -269,6 +269,15 @@ Then explore:
 
 ### Utility Commands
 
+  kbagent init [--from-global]
+    Initialize a local .kbagent/ workspace in the current directory.
+    Creates .kbagent/config.json for per-directory project isolation.
+    Use --from-global to copy existing projects from global config.
+    Automatically adds .kbagent/ to .gitignore.
+    Example:
+      kbagent init
+      kbagent init --from-global
+
   kbagent context
     Show this help text with usage instructions for AI agents.
 
@@ -284,6 +293,7 @@ Then explore:
   --json / -j     Output in JSON format (always use this for programmatic parsing)
   --verbose / -v  Enable verbose output
   --no-color      Disable colored output (auto-disabled in non-TTY environments)
+  --config-dir    Override config directory path (bypasses all auto-detection)
 
 ### MCP Tools (Multi-Project)
 
@@ -351,6 +361,7 @@ Then explore:
      KBC_TOKEN             - Storage API token (fallback for --token in project add/edit)
      KBC_STORAGE_API_URL   - Default stack URL (fallback for --url in project add, org setup)
      KBC_MANAGE_API_TOKEN  - Manage API token (for org setup)
+     KBAGENT_CONFIG_DIR    - Override config directory path (same as --config-dir flag)
 
 11. Branch workflow -- develop on a branch without passing --branch every time:
      kbagent --json branch create --project prod --name "fix-transform-x"
@@ -374,7 +385,15 @@ Then explore:
      # and how to interpret each file (schemas, transformations, lineage, etc.)
      # This is much faster than querying each piece via MCP tool calls.
 
-14. Setting up projects -- two approaches:
+14. Workspace isolation -- use per-directory config for client separation:
+     kbagent init                                            # Create local .kbagent/ workspace
+     kbagent --json project add --alias prod --url ...       # Adds to LOCAL config
+     kbagent --json doctor                                   # Shows "Using local config at ..."
+
+    Config resolution order: --config-dir flag > KBAGENT_CONFIG_DIR env var
+    > .kbagent/ in CWD or parent dirs > ~/.config/keboola-agent-cli/ (global)
+
+15. Setting up projects -- two approaches:
 
     a) Single project (you have a Storage API token):
        kbagent --json project add --alias my-proj --url https://connection.keboola.com --token 901-xxxxx

--- a/src/keboola_agent_cli/commands/init.py
+++ b/src/keboola_agent_cli/commands/init.py
@@ -1,0 +1,83 @@
+"""Init command - initialize a local .kbagent/ workspace in the current directory."""
+
+from pathlib import Path
+
+import typer
+
+from ..config_store import ConfigStore
+from ..constants import LOCAL_CONFIG_DIR_NAME
+from ..models import AppConfig
+from ._helpers import get_formatter, get_service
+
+
+def init_command(
+    ctx: typer.Context,
+    from_global: bool = typer.Option(
+        False,
+        "--from-global",
+        help="Copy projects from the global config into the new local workspace.",
+    ),
+) -> None:
+    """Initialize a local .kbagent/ workspace in the current directory."""
+    formatter = get_formatter(ctx)
+    cwd = Path.cwd()
+    local_dir = cwd / LOCAL_CONFIG_DIR_NAME
+    config_path = local_dir / "config.json"
+
+    if config_path.is_file():
+        formatter.output(
+            {
+                "message": f"Already initialized at {local_dir}",
+                "path": str(local_dir),
+                "created": False,
+            }
+        )
+        return
+
+    config = AppConfig()
+    if from_global:
+        global_store: ConfigStore = get_service(ctx, "config_store")
+        if global_store.source != "global":
+            formatter.error(
+                "CONFIG_ERROR",
+                "Cannot use --from-global: active config is not the global config. "
+                "Run from a directory without an existing .kbagent/ workspace.",
+            )
+            raise typer.Exit(code=5)
+        config = global_store.load()
+
+    local_store = ConfigStore(config_dir=local_dir, source="local")
+    local_store.save(config)
+
+    _update_gitignore(cwd)
+
+    project_count = len(config.projects)
+    message = f"Initialized local workspace at {local_dir}"
+    if from_global and project_count > 0:
+        message += f" (copied {project_count} project(s) from global config)"
+
+    formatter.output(
+        {
+            "message": message,
+            "path": str(local_dir),
+            "created": True,
+            "projects_copied": project_count if from_global else 0,
+        }
+    )
+
+
+def _update_gitignore(directory: Path) -> None:
+    """Append .kbagent/ to .gitignore if not already listed."""
+    gitignore_path = directory / ".gitignore"
+    entry = f"{LOCAL_CONFIG_DIR_NAME}/"
+
+    if gitignore_path.is_file():
+        content = gitignore_path.read_text(encoding="utf-8")
+        if entry in content.splitlines():
+            return
+        if not content.endswith("\n"):
+            content += "\n"
+        content += entry + "\n"
+        gitignore_path.write_text(content, encoding="utf-8")
+    else:
+        gitignore_path.write_text(entry + "\n", encoding="utf-8")

--- a/src/keboola_agent_cli/config_store.py
+++ b/src/keboola_agent_cli/config_store.py
@@ -12,12 +12,50 @@ from pathlib import Path
 
 import platformdirs
 
+from .constants import ENV_CONFIG_DIR, LOCAL_CONFIG_DIR_NAME
 from .errors import ConfigError
 from .models import AppConfig, ProjectConfig
 
 logger = logging.getLogger(__name__)
 
 CURRENT_CONFIG_VERSION = 1
+
+
+def resolve_config_dir(cli_config_dir: str | None = None) -> tuple[Path, str]:
+    """Resolve the config directory using the priority chain.
+
+    Priority:
+    1. --config-dir CLI flag (explicit override)
+    2. KBAGENT_CONFIG_DIR environment variable
+    3. Walk up from CWD looking for .kbagent/config.json (like git)
+    4. Global default (~/.config/keboola-agent-cli/)
+
+    Returns:
+        Tuple of (resolved_path, source_label).
+        source_label is one of: "cli-flag", "env-var", "local", "global".
+    """
+    if cli_config_dir:
+        return Path(cli_config_dir), "cli-flag"
+
+    env_val = os.environ.get(ENV_CONFIG_DIR)
+    if env_val:
+        return Path(env_val), "env-var"
+
+    try:
+        current = Path.cwd().resolve()
+    except OSError:
+        return Path(platformdirs.user_config_dir("keboola-agent-cli")), "global"
+
+    home = Path.home().resolve()
+    while True:
+        candidate = current / LOCAL_CONFIG_DIR_NAME / "config.json"
+        if candidate.is_file():
+            return current / LOCAL_CONFIG_DIR_NAME, "local"
+        if current == home or current == current.parent:
+            break
+        current = current.parent
+
+    return Path(platformdirs.user_config_dir("keboola-agent-cli")), "global"
 
 
 class ConfigStore:
@@ -29,17 +67,23 @@ class ConfigStore:
 
     CONFIG_FILENAME = "config.json"
 
-    def __init__(self, config_dir: Path | None = None) -> None:
+    def __init__(self, config_dir: Path | None = None, source: str = "global") -> None:
         if config_dir is None:
             self._config_dir = Path(platformdirs.user_config_dir("keboola-agent-cli"))
         else:
             self._config_dir = config_dir
         self._config_path = self._config_dir / self.CONFIG_FILENAME
+        self._source = source
 
     @property
     def config_path(self) -> Path:
         """Return the path to the config file."""
         return self._config_path
+
+    @property
+    def source(self) -> str:
+        """Return the config source label (cli-flag, env-var, local, global)."""
+        return self._source
 
     def load(self) -> AppConfig:
         """Load configuration from disk.

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -57,6 +57,10 @@ STORAGE_JOB_MAX_WAIT: float = 60.0  # max seconds to wait for a storage job
 # --- Parallel Workers ---
 MAX_PARALLEL_WORKERS_LIMIT: int = 100
 
+# --- Config Resolution ---
+ENV_CONFIG_DIR: str = "KBAGENT_CONFIG_DIR"
+LOCAL_CONFIG_DIR_NAME: str = ".kbagent"
+
 # --- Environment Variable Names ---
 ENV_MAX_PARALLEL_WORKERS: str = "KBAGENT_MAX_PARALLEL_WORKERS"
 ENV_KBC_TOKEN: str = "KBC_TOKEN"

--- a/src/keboola_agent_cli/services/doctor_service.py
+++ b/src/keboola_agent_cli/services/doctor_service.py
@@ -49,6 +49,10 @@ class DoctorService:
         """
         all_checks: list[dict[str, Any]] = []
 
+        # Check 0: Config source (local vs global)
+        source_check = self._check_config_source()
+        all_checks.append(source_check)
+
         # Check 1: Config file exists with correct permissions
         file_check = self._check_config_file()
         all_checks.append(file_check)
@@ -86,6 +90,15 @@ class DoctorService:
                 "skipped": skipped,
                 "healthy": failed == 0,
             },
+        }
+
+    def _check_config_source(self) -> dict[str, Any]:
+        """Check 0: Report which config source is active."""
+        return {
+            "check": "config_source",
+            "name": "Config source",
+            "status": "pass",
+            "message": f"Using {self._config_store.source} config at {self._config_store.config_path}",
         }
 
     def _check_config_file(self) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5273,3 +5273,89 @@ class TestToolAutoResolveBranch:
             alias="prod",
             branch_id="456",
         )
+
+
+class TestInit:
+    """Tests for `kbagent init` command."""
+
+    def test_init_creates_local_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """init creates .kbagent/config.json in CWD."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        result = runner.invoke(app, ["--json", "init"])
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["created"] is True
+
+        config_path = tmp_path / ".kbagent" / "config.json"
+        assert config_path.is_file()
+
+    def test_init_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """init does not overwrite existing .kbagent/config.json."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        # First init
+        runner.invoke(app, ["--json", "init"])
+        # Second init
+        result = runner.invoke(app, ["--json", "init"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["created"] is False
+
+    def test_init_creates_gitignore(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """init creates/updates .gitignore with .kbagent/ entry."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        runner.invoke(app, ["--json", "init"])
+
+        gitignore = tmp_path / ".gitignore"
+        assert gitignore.is_file()
+        assert ".kbagent/" in gitignore.read_text(encoding="utf-8")
+
+    def test_init_from_global_copies_projects(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """init --from-global copies projects from global config."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        # Create a global config with a project
+        global_dir = tmp_path / "global-config"
+        global_dir.mkdir()
+
+        with (
+            patch("keboola_agent_cli.cli.resolve_config_dir") as mock_resolve,
+        ):
+            mock_resolve.return_value = (global_dir, "global")
+
+            # Add a project to global config
+            from keboola_agent_cli.config_store import ConfigStore
+            from keboola_agent_cli.models import ProjectConfig
+
+            global_store = ConfigStore(config_dir=global_dir, source="global")
+            global_store.add_project(
+                "prod",
+                ProjectConfig(
+                    stack_url="https://connection.keboola.com",
+                    token="901-xxx-testtoken1234",
+                    project_name="Production",
+                    project_id=1234,
+                ),
+            )
+
+            result = runner.invoke(app, ["--json", "init", "--from-global"])
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["projects_copied"] == 1
+
+        # Verify local config has the project
+        local_store = ConfigStore(config_dir=tmp_path / ".kbagent")
+        local_config = local_store.load()
+        assert "prod" in local_config.projects

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -1,0 +1,133 @@
+"""Tests for config directory resolution and ConfigStore source property."""
+
+from pathlib import Path
+
+import pytest
+
+from keboola_agent_cli.config_store import ConfigStore, resolve_config_dir
+from keboola_agent_cli.constants import LOCAL_CONFIG_DIR_NAME
+
+
+class TestResolveConfigDir:
+    """Tests for resolve_config_dir() priority chain."""
+
+    def test_cli_flag_takes_precedence(self, tmp_path: Path) -> None:
+        """CLI flag overrides everything."""
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+        path, source = resolve_config_dir(cli_config_dir=str(custom_dir))
+        assert path == custom_dir
+        assert source == "cli-flag"
+
+    def test_env_var_takes_precedence_over_local(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Env var overrides local .kbagent/ discovery."""
+        # Create a local .kbagent/config.json in CWD
+        local_dir = tmp_path / LOCAL_CONFIG_DIR_NAME
+        local_dir.mkdir()
+        (local_dir / "config.json").write_text("{}", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        env_dir = tmp_path / "env-config"
+        env_dir.mkdir()
+        monkeypatch.setenv("KBAGENT_CONFIG_DIR", str(env_dir))
+
+        path, source = resolve_config_dir()
+        assert path == env_dir
+        assert source == "env-var"
+
+    def test_walkup_finds_kbagent_in_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Walk-up finds .kbagent/config.json in CWD."""
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+        local_dir = tmp_path / LOCAL_CONFIG_DIR_NAME
+        local_dir.mkdir()
+        (local_dir / "config.json").write_text("{}", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        path, source = resolve_config_dir()
+        assert path == local_dir
+        assert source == "local"
+
+    def test_walkup_finds_kbagent_in_parent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Walk-up finds .kbagent/config.json in parent directory."""
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+        local_dir = tmp_path / LOCAL_CONFIG_DIR_NAME
+        local_dir.mkdir()
+        (local_dir / "config.json").write_text("{}", encoding="utf-8")
+
+        child_dir = tmp_path / "subdir" / "deep"
+        child_dir.mkdir(parents=True)
+        monkeypatch.chdir(child_dir)
+
+        # Patch Path.home to be above tmp_path so walk-up doesn't stop early
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path.parent))
+
+        path, source = resolve_config_dir()
+        assert path == local_dir
+        assert source == "local"
+
+    def test_walkup_stops_at_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Walk-up stops at $HOME and does not escape beyond it."""
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+        # Place .kbagent/ ABOVE home
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        work_dir = home_dir / "projects" / "myproject"
+        work_dir.mkdir(parents=True)
+
+        above_home = tmp_path / LOCAL_CONFIG_DIR_NAME
+        above_home.mkdir()
+        (above_home / "config.json").write_text("{}", encoding="utf-8")
+
+        monkeypatch.chdir(work_dir)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home_dir))
+
+        _path, source = resolve_config_dir()
+        assert source == "global"  # Should NOT find the one above home
+
+    def test_walkup_requires_config_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Walk-up requires config.json file, not just the directory."""
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+        # Create .kbagent/ dir without config.json
+        local_dir = tmp_path / LOCAL_CONFIG_DIR_NAME
+        local_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        _path, source = resolve_config_dir()
+        assert source == "global"  # Empty dir should not match
+
+    def test_falls_back_to_global(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to global when nothing found."""
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        path, source = resolve_config_dir()
+        assert source == "global"
+        assert "keboola-agent-cli" in str(path)
+
+    def test_oserror_from_cwd_falls_back_to_global(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError from Path.cwd() falls back to global."""
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: (_ for _ in ()).throw(OSError("no cwd"))))
+
+        _path, source = resolve_config_dir()
+        assert source == "global"
+
+
+class TestConfigStoreSource:
+    """Tests for ConfigStore.source property."""
+
+    def test_default_source_is_global(self, tmp_path: Path) -> None:
+        """Default source is 'global'."""
+        store = ConfigStore(config_dir=tmp_path)
+        assert store.source == "global"
+
+    def test_custom_source(self, tmp_path: Path) -> None:
+        """Source can be set via constructor."""
+        store = ConfigStore(config_dir=tmp_path, source="local")
+        assert store.source == "local"
+
+    def test_cli_flag_source(self, tmp_path: Path) -> None:
+        """Source can be 'cli-flag'."""
+        store = ConfigStore(config_dir=tmp_path, source="cli-flag")
+        assert store.source == "cli-flag"

--- a/tests/test_doctor_service.py
+++ b/tests/test_doctor_service.py
@@ -104,6 +104,41 @@ class TestDoctorServiceCheckConfigFile:
         assert "0o644" in result["message"]
 
 
+class TestDoctorServiceCheckConfigSource:
+    """Tests for DoctorService._check_config_source() - config source reporting."""
+
+    def test_reports_global_source(self, tmp_config_dir: Path) -> None:
+        """Reports global config source."""
+        store = ConfigStore(config_dir=tmp_config_dir, source="global")
+        service = DoctorService(config_store=store, mcp_service=_make_mcp_service_mock())
+
+        result = service._check_config_source()
+
+        assert result["check"] == "config_source"
+        assert result["status"] == "pass"
+        assert "global" in result["message"]
+
+    def test_reports_local_source(self, tmp_config_dir: Path) -> None:
+        """Reports local config source."""
+        store = ConfigStore(config_dir=tmp_config_dir, source="local")
+        service = DoctorService(config_store=store, mcp_service=_make_mcp_service_mock())
+
+        result = service._check_config_source()
+
+        assert result["check"] == "config_source"
+        assert result["status"] == "pass"
+        assert "local" in result["message"]
+
+    def test_config_source_in_run_checks(self, tmp_config_dir: Path) -> None:
+        """run_checks includes config_source as first check."""
+        store = ConfigStore(config_dir=tmp_config_dir, source="local")
+        service = DoctorService(config_store=store, mcp_service=_make_mcp_service_mock())
+
+        result = service.run_checks()
+
+        assert result["checks"][0]["check"] == "config_source"
+
+
 class TestDoctorServiceCheckConfigValid:
     """Tests for DoctorService._check_config_valid() - config file validation."""
 
@@ -331,7 +366,7 @@ class TestDoctorServiceRunChecks:
 
         assert "checks" in result
         assert "summary" in result
-        assert len(result["checks"]) >= 4  # file, valid, connectivity, version, mcp
+        assert len(result["checks"]) >= 5  # source, file, valid, connectivity, version, mcp
         assert "total" in result["summary"]
         assert "passed" in result["summary"]
         assert "failed" in result["summary"]


### PR DESCRIPTION
## Summary

- Add per-directory project isolation via `.kbagent/config.json` -- each client folder gets its own set of Keboola projects, no cross-contamination
- New `kbagent init [--from-global]` command creates a local workspace and auto-updates `.gitignore`
- Config resolution walks up from CWD (like git): `--config-dir` flag > `KBAGENT_CONFIG_DIR` env > `.kbagent/` > global
- `kbagent doctor` now reports which config source is active (local/global/cli-flag/env-var)
- New `--config-dir` global CLI flag for explicit override

## Changed files

| File | Change |
|---|---|
| `constants.py` | `ENV_CONFIG_DIR`, `LOCAL_CONFIG_DIR_NAME` constants |
| `config_store.py` | `resolve_config_dir()` function, `source` property on ConfigStore |
| `cli.py` | `--config-dir` global flag, wired to `resolve_config_dir()` |
| `commands/init.py` | **NEW** -- `kbagent init [--from-global]` |
| `services/doctor_service.py` | `config_source` health check |
| `commands/context.py` | Docs for init, `--config-dir`, env var, tip #14 |
| `CLAUDE.md` | Added missing commands (explorer init-tiers, llm export, version, doctor --fix) |
| `README.md` | "Workspace isolation" section |
| `__init__.py` | Version bump 0.6.7 -> 0.7.0 |

## Test plan

- [x] 741 tests pass, 0 failures
- [x] Lint clean (ruff)
- [x] 14 new tests: config resolution (11), init command (4), doctor source (3) -- some overlap with existing
- [ ] Manual: `mkdir /tmp/test && cd /tmp/test && kbagent init && kbagent doctor`
- [ ] Manual: verify walk-up from subdirectory finds parent `.kbagent/`