### PR TITLE
Fix workspace create/delete failing in dev branches

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -448,6 +448,7 @@ class KeboolaClient(BaseHttpClient):
         name: str,
         description: str = "",
         backend_size: str = "small",
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create a keboola.sandboxes configuration.
 
@@ -458,6 +459,7 @@ class KeboolaClient(BaseHttpClient):
             name: Human-readable name for the workspace.
             description: Optional description.
             backend_size: Backend size (small, medium, large).
+            branch_id: Branch ID. If provided, creates config in that branch.
 
         Returns:
             Configuration dict with id, name, etc.
@@ -471,9 +473,10 @@ class KeboolaClient(BaseHttpClient):
             },
             "runtime": {"shared": False},
         }
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         response = self._request(
             "POST",
-            "/v2/storage/components/keboola.sandboxes/configs",
+            f"{prefix}/components/keboola.sandboxes/configs",
             data={
                 "name": name,
                 "description": description,
@@ -482,18 +485,22 @@ class KeboolaClient(BaseHttpClient):
         )
         return response.json()
 
-    def delete_config(self, component_id: str, config_id: str) -> None:
+    def delete_config(
+        self, component_id: str, config_id: str, branch_id: int | None = None
+    ) -> None:
         """Delete a component configuration.
 
         Args:
             component_id: Component ID.
             config_id: Configuration ID.
+            branch_id: Branch ID. If provided, deletes config in that branch.
         """
         safe_component = quote(component_id, safe="")
         safe_config = quote(config_id, safe="")
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         self._request(
             "DELETE",
-            f"/v2/storage/components/{safe_component}/configs/{safe_config}",
+            f"{prefix}/components/{safe_component}/configs/{safe_config}",
         )
 
     def create_config_workspace(

--- a/src/keboola_agent_cli/services/workspace_service.py
+++ b/src/keboola_agent_cli/services/workspace_service.py
@@ -85,10 +85,11 @@ class WorkspaceService(BaseService):
 
         client = self._client_factory(project.stack_url, project.token)
         try:
-            # Step 1: Create keboola.sandboxes config
+            # Step 1: Create keboola.sandboxes config (in the correct branch)
             sandbox_config = client.create_sandbox_config(
                 name=effective_name,
                 description="Created by kbagent CLI",
+                branch_id=branch_id,
             )
             config_id = sandbox_config.get("id", "")
 
@@ -341,6 +342,7 @@ class WorkspaceService(BaseService):
         """
         projects = self.resolve_projects([alias])
         project = projects[alias]
+        branch_id = self._resolve_branch_id(alias, project)
 
         client = self._client_factory(project.stack_url, project.token)
         try:
@@ -356,10 +358,12 @@ class WorkspaceService(BaseService):
             # Delete the workspace
             client.delete_workspace(workspace_id)
 
-            # Clean up associated sandboxes config
+            # Clean up associated sandboxes config (in the correct branch)
             if config_id and component == "keboola.sandboxes":
                 try:
-                    client.delete_config("keboola.sandboxes", config_id)
+                    client.delete_config(
+                        "keboola.sandboxes", config_id, branch_id=branch_id
+                    )
                 except KeboolaApiError:
                     logger.debug("Could not delete sandbox config %s", config_id)
         finally:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1510,3 +1510,71 @@ class TestDeleteDevBranch:
         ) as client:
             # Should not raise any exception
             client.delete_dev_branch(789)
+
+
+class TestCreateSandboxConfigBranch:
+    """Tests for create_sandbox_config() branch_id routing."""
+
+    def test_create_sandbox_config_no_branch(self, httpx_mock) -> None:
+        """Without branch_id, uses /v2/storage/components/... endpoint."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/components/keboola.sandboxes/configs",
+            method="POST",
+            json={"id": "cfg-1", "name": "test"},
+            status_code=201,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.create_sandbox_config(name="test")
+            assert result["id"] == "cfg-1"
+
+    def test_create_sandbox_config_with_branch(self, httpx_mock) -> None:
+        """With branch_id, uses /v2/storage/branch/{id}/components/... endpoint."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/200/components/keboola.sandboxes/configs",
+            method="POST",
+            json={"id": "cfg-2", "name": "branch-ws"},
+            status_code=201,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.create_sandbox_config(name="branch-ws", branch_id=200)
+            assert result["id"] == "cfg-2"
+
+
+class TestDeleteConfigBranch:
+    """Tests for delete_config() branch_id routing."""
+
+    def test_delete_config_no_branch(self, httpx_mock) -> None:
+        """Without branch_id, uses /v2/storage/components/... endpoint."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/components/keboola.sandboxes/configs/cfg-1",
+            method="DELETE",
+            status_code=204,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            client.delete_config("keboola.sandboxes", "cfg-1")
+
+    def test_delete_config_with_branch(self, httpx_mock) -> None:
+        """With branch_id, uses /v2/storage/branch/{id}/components/... endpoint."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/200/components/keboola.sandboxes/configs/cfg-1",
+            method="DELETE",
+            status_code=204,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            client.delete_config("keboola.sandboxes", "cfg-1", branch_id=200)

--- a/tests/test_workspace_service.py
+++ b/tests/test_workspace_service.py
@@ -11,7 +11,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from helpers import setup_single_project, setup_two_projects
+from keboola_agent_cli.config_store import ConfigStore
 from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.models import ProjectConfig
 from keboola_agent_cli.services.workspace_service import WorkspaceService
 
 SAMPLE_WORKSPACE = {
@@ -116,6 +118,7 @@ class TestCreateWorkspace:
         mock_client.create_sandbox_config.assert_called_once_with(
             name="test-ws",
             description="Created by kbagent CLI",
+            branch_id=123,
         )
         mock_client.create_config_workspace.assert_called_once_with(
             branch_id=123,
@@ -153,6 +156,50 @@ class TestCreateWorkspace:
 
         with pytest.raises(KeboolaApiError, match="Quota exceeded"):
             svc.create_workspace(alias="prod")
+
+    def test_create_workspace_in_dev_branch(self, tmp_config_dir: Path) -> None:
+        """create_workspace uses active_branch_id for sandbox config endpoint."""
+        mock_client = MagicMock()
+        mock_client.create_sandbox_config.return_value = {
+            "id": "cfg-456",
+            "name": "branch-ws",
+        }
+        mock_client.create_config_workspace.return_value = SAMPLE_WORKSPACE
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-xxx",
+                project_name="Production",
+                project_id=258,
+                active_branch_id=200,
+            ),
+        )
+        svc = WorkspaceService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.create_workspace(
+            alias="prod", name="branch-ws", backend="snowflake"
+        )
+
+        assert result["config_id"] == "cfg-456"
+        # Sandbox config must be created in the dev branch
+        mock_client.create_sandbox_config.assert_called_once_with(
+            name="branch-ws",
+            description="Created by kbagent CLI",
+            branch_id=200,
+        )
+        # Config workspace must also use the dev branch
+        mock_client.create_config_workspace.assert_called_once_with(
+            branch_id=200,
+            component_id="keboola.sandboxes",
+            config_id="cfg-456",
+            backend="snowflake",
+        )
 
 
 class TestListWorkspacesSingleProject:
@@ -354,6 +401,7 @@ class TestDeleteWorkspace:
     def test_delete_workspace_success(self, tmp_config_dir: Path) -> None:
         """delete_workspace calls the API and returns confirmation."""
         mock_client = MagicMock()
+        mock_client.list_dev_branches.return_value = [{"id": 123, "isDefault": True}]
         mock_client.get_workspace.return_value = {
             "component": "keboola.sandboxes",
             "configurationId": "cfg-123",
@@ -372,12 +420,16 @@ class TestDeleteWorkspace:
         assert "deleted" in result["message"]
         mock_client.get_workspace.assert_called_once_with(42)
         mock_client.delete_workspace.assert_called_once_with(42)
-        mock_client.delete_config.assert_called_once_with("keboola.sandboxes", "cfg-123")
-        mock_client.close.assert_called_once()
+        mock_client.delete_config.assert_called_once_with(
+            "keboola.sandboxes", "cfg-123", branch_id=123
+        )
+        # close() called twice: once in _resolve_branch_id, once in delete_workspace
+        assert mock_client.close.call_count == 2
 
     def test_delete_workspace_api_error(self, tmp_config_dir: Path) -> None:
         """delete_workspace propagates KeboolaApiError from delete call."""
         mock_client = MagicMock()
+        mock_client.list_dev_branches.return_value = [{"id": 123, "isDefault": True}]
         # get_workspace fails (workspace lookup), but delete_workspace also fails
         mock_client.get_workspace.side_effect = KeboolaApiError(
             message="Workspace not found",
@@ -400,6 +452,37 @@ class TestDeleteWorkspace:
 
         with pytest.raises(KeboolaApiError, match="Workspace not found"):
             svc.delete_workspace(alias="prod", workspace_id=999)
+
+    def test_delete_workspace_in_dev_branch(self, tmp_config_dir: Path) -> None:
+        """delete_workspace uses active_branch_id for config deletion."""
+        mock_client = MagicMock()
+        mock_client.get_workspace.return_value = {
+            "component": "keboola.sandboxes",
+            "configurationId": "cfg-789",
+        }
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-xxx",
+                project_name="Production",
+                project_id=258,
+                active_branch_id=200,
+            ),
+        )
+        svc = WorkspaceService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.delete_workspace(alias="prod", workspace_id=42)
+
+        assert result["workspace_id"] == 42
+        mock_client.delete_config.assert_called_once_with(
+            "keboola.sandboxes", "cfg-789", branch_id=200
+        )
 
 
 class TestResetPassword:


### PR DESCRIPTION
## Summary

- `create_sandbox_config()` and `delete_config()` in `client.py` always used the main branch endpoint, ignoring active dev branch context
- This caused workspace creation to fail in dev branches because `create_config_workspace()` looked for the config in the dev branch where it didn't exist
- Added optional `branch_id` parameter to both client methods, propagated from `WorkspaceService`

## Changes

- **client.py**: `create_sandbox_config()` and `delete_config()` now accept `branch_id` and route to `/v2/storage/branch/{id}/...` when provided
- **workspace_service.py**: `create_workspace()` passes `branch_id` to `create_sandbox_config()`; `delete_workspace()` resolves branch and passes it to `delete_config()`
- Tests for both branch and non-branch paths

## Test plan

- [x] All 794 existing tests pass
- [x] New client tests verify correct URL routing with/without branch_id
- [x] New service tests verify dev branch propagation for create and delete
- [ ] Manual test: create workspace in a dev branch project

Fixes #27