### PR TITLE
Add Claude Code plugin for marketplace distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "keboola-agent-cli",
+  "version": "1.0.0",
+  "description": "Claude Code plugin for managing Keboola projects via kbagent CLI",
+  "owner": {
+    "name": "Keboola",
+    "email": "support@keboola.com"
+  },
+  "plugins": [
+    {
+      "name": "kbagent",
+      "source": "./plugins/kbagent",
+      "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
+      "category": "development"
+    }
+  ]
+}

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "kbagent",
+  "version": "0.7.3",
+  "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
+  "author": {
+    "name": "Keboola",
+    "email": "support@keboola.com"
+  },
+  "homepage": "https://github.com/padak/keboola_agent_cli",
+  "repository": "https://github.com/padak/keboola_agent_cli",
+  "license": "MIT"
+}

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: kbagent
+description: >
+  Use when working with Keboola Connection projects via kbagent CLI.
+  Covers: exploring configurations (extractors, writers, transformations),
+  browsing job history, analyzing cross-project data lineage, calling MCP tools
+  across multiple projects, managing development branches, debugging SQL in
+  temporary workspaces, bulk-onboarding organizations, and generating explorer
+  dashboards. Triggers: kbagent, Keboola project, keboola configs, keboola jobs,
+  keboola lineage, keboola transformations, keboola MCP tools, keboola workspace,
+  SQL debugging, keboola branches, keboola organization, keboola explorer.
+---
+
+# kbagent -- Keboola Agent CLI
+
+## First step -- always
+
+Load full CLI documentation before doing anything else:
+
+```bash
+kbagent context
+```
+
+This prints all commands, flags, workflows, and tips. Read it fully before proceeding.
+
+## Rules
+
+1. **Always use `--json`**: `kbagent --json <command>` for parseable output
+2. **Multi-project by default**: read commands query ALL connected projects in parallel -- no need to loop
+3. **Write commands need `--project`**: specify the target project alias
+4. **Tokens are always masked** in output -- this is expected, not an error
+
+## Choosing the right approach
+
+| Goal | Command |
+|------|---------|
+| See what projects are connected | `kbagent --json project list` |
+| Browse configs across projects | `kbagent --json config list` |
+| Check for failed jobs | `kbagent --json job list --status error` |
+| Understand data flow between projects | `kbagent --json lineage` |
+| Generate visual dashboard | `kbagent explorer` |
+| Call MCP tools (read, across all projects) | `kbagent --json tool call <tool>` |
+| Call MCP tools (write, single project) | `kbagent --json tool call <tool> --project <alias> --input '{...}'` |
+| Debug SQL from a transformation | See [workspace workflow](references/workspace-workflow.md) |
+| Work on a dev branch safely | See [branch workflow](references/branch-workflow.md) |
+| Onboard entire organization | `KBC_MANAGE_API_TOKEN=xxx kbagent --json org setup --org-id ID --url URL --yes` |
+
+## Response format
+
+All JSON responses follow one of two shapes:
+
+**Success:**
+```json
+{"status": "ok", "data": ...}
+```
+
+**Error:**
+```json
+{"status": "error", "error": {"code": "ERROR_CODE", "message": "...", "retryable": true}}
+```
+
+Check the `retryable` field -- if `true`, retry the operation.
+
+For detailed response parsing rules and common pitfalls, see [gotchas](references/gotchas.md).
+
+## First-time setup
+
+If kbagent is not yet installed:
+
+```bash
+uv tool install git+https://github.com/padak/keboola_agent_cli
+uv tool install --prerelease=allow keboola-mcp-server
+kbagent doctor --fix
+```
+
+Then add projects:
+
+```bash
+# Single project
+kbagent --json project add --alias prod --url https://connection.keboola.com --token YOUR_TOKEN
+
+# Or bulk-onboard from organization
+KBC_MANAGE_API_TOKEN=xxx kbagent --json org setup --org-id 123 --url https://connection.keboola.com --yes
+```

--- a/plugins/kbagent/skills/kbagent/references/branch-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/branch-workflow.md
@@ -1,0 +1,41 @@
+# Branch Workflow -- Development Branches
+
+Development branches let you make changes to Keboola configs without affecting production.
+kbagent tracks the "active branch" per project so you don't have to pass `--branch` every time.
+
+## Typical workflow
+
+```bash
+# 1. Create a branch (auto-activates it)
+kbagent --json branch create --project ALIAS --name "fix-transform-x"
+# Returns: branch_id, name, and confirms activation
+
+# 2. All subsequent commands on this project auto-use the active branch
+kbagent --json tool call list_configs --project ALIAS
+kbagent --json tool call update_configuration --project ALIAS --input '{...}'
+kbagent --json workspace create --project ALIAS --name "branch-debug"
+
+# 3. When done, get the merge URL (does NOT auto-merge!)
+kbagent --json branch merge --project ALIAS
+# Returns: Keboola UI URL for review and merge
+# Auto-resets active branch back to main
+```
+
+## Branch commands reference
+
+| Command | What it does |
+|---------|-------------|
+| `branch list` | List all branches (marks active one) |
+| `branch create --name "..."` | Create + auto-activate |
+| `branch use --branch ID` | Switch to existing branch |
+| `branch reset` | Switch back to main/production |
+| `branch delete --branch ID` | Delete branch (resets if it was active) |
+| `branch merge` | Get merge URL, reset to main |
+
+## Key details
+
+- **Async operations**: `branch create` and `branch delete` are async on the API. kbagent waits for completion (typically 1-3s). No need to poll.
+- **Merge is manual**: `branch merge` returns a URL for the Keboola UI. It does NOT merge via API. This is intentional for safe review.
+- **Active branch persistence**: stored in kbagent config. Survives between sessions.
+- **MCP tools respect active branch**: tool calls automatically use the active branch without extra flags.
+- **Workspaces respect active branch**: `workspace create` and `workspace delete` operate in the active branch context.

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -1,0 +1,78 @@
+# Gotchas -- Response Parsing and Common Pitfalls
+
+## Response structure varies by command
+
+Not all commands return data the same way. Key differences:
+
+| Command | `data` contains |
+|---------|----------------|
+| `project list` | A **list** directly (not `data.projects`) |
+| `config list` | `{"configs": [...]}` |
+| `job list` | `{"jobs": [...]}` |
+| `lineage show` | `{"lineage_links": [...], "errors": [...]}` |
+| `tool list` | `{"tools": [...]}` |
+| `tool call` | `{"results": [...]}` (one per project) |
+| `workspace list` | `{"workspaces": [...], "errors": [...]}` |
+| `branch list` | `{"branches": [...]}` |
+
+Always check the actual response structure rather than assuming a pattern.
+
+## Multi-project error accumulation
+
+Commands that query multiple projects collect errors per-project without stopping.
+One project failing does not block others. Check the `errors` array:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "configs": [...],
+    "errors": [
+      {"project_alias": "broken-proj", "error_code": "AUTH_ERROR", "message": "..."}
+    ]
+  }
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Usage error (invalid arguments) |
+| 3 | Authentication error (invalid or expired token) |
+| 4 | Network error (timeout, unreachable) |
+| 5 | Configuration error (corrupt config, missing alias) |
+
+## Token handling
+
+- Tokens are always masked in output (e.g. `901-...pt0k`) -- this is normal
+- Token can be passed via `--token`, `KBC_TOKEN` env var, or interactive prompt
+- Manage API token: only via `KBC_MANAGE_API_TOKEN` env var or interactive prompt (never as CLI argument)
+
+## MCP tool call gotchas
+
+- **Read tools** (multi_project=true): automatically query all projects. No `--project` needed.
+- **Write tools** (multi_project=false): require `--project` to specify the target.
+- **Auto-expand**: tools like `list_tables` that need `bucket_id` auto-resolve it by calling `list_buckets` first.
+- **Input validation**: tool input is validated against the tool's `inputSchema` before dispatch.
+- **Branch scope**: when active branch is set, MCP tools automatically scope to that branch.
+
+## Config resolution order
+
+kbagent looks for configuration in this order:
+1. `--config-dir` flag
+2. `KBAGENT_CONFIG_DIR` env var
+3. `.kbagent/` in current or parent directories (local workspace)
+4. `~/.config/keboola-agent-cli/` (global)
+
+Use `kbagent init` to create a local `.kbagent/` workspace for per-directory isolation.
+
+## Common mistakes
+
+- **Forgetting `--json`**: without it, output is human-formatted Rich text, not parseable
+- **Assuming `data.projects`**: `project list` returns data as a flat list
+- **Passing manage token as argument**: use env var `KBC_MANAGE_API_TOKEN` instead
+- **Polling after branch create**: kbagent already waits for async completion
+- **Not saving workspace password**: only returned once on creation

--- a/plugins/kbagent/skills/kbagent/references/workspace-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/workspace-workflow.md
@@ -1,0 +1,96 @@
+# Workspace Workflow -- SQL Debugging
+
+Workspaces let you run SQL against real project data without triggering full Keboola jobs.
+Use this to debug failing transformations iteratively.
+
+## Option A: Debug an existing transformation
+
+Best when you have a failing transformation and want to reproduce the error:
+
+```bash
+# Step 1: Create workspace from transformation (auto-loads input tables)
+kbagent --json workspace from-transformation \
+  --project ALIAS \
+  --component-id keboola.snowflake-transformation \
+  --config-id CONFIG_ID
+
+# Response includes: workspace_id, host, database, schema, user, password
+# SAVE THE PASSWORD -- it cannot be retrieved later!
+```
+
+```bash
+# Step 2: Run the original SQL to reproduce the error
+kbagent --json workspace query \
+  --project ALIAS \
+  --workspace-id WS_ID \
+  --sql "SELECT ..."
+```
+
+```bash
+# Step 3: Iterate on fixes (no need to run full jobs)
+kbagent --json workspace query \
+  --project ALIAS \
+  --workspace-id WS_ID \
+  --sql "SELECT fixed_query ..."
+```
+
+```bash
+# Step 4: Once the fix works, update the transformation config via MCP
+kbagent --json tool call update_configuration \
+  --project ALIAS \
+  --input '{"component_id": "keboola.snowflake-transformation", "configuration_id": "CONFIG_ID", ...}'
+```
+
+```bash
+# Step 5: Clean up (optional -- workspaces expire automatically)
+kbagent --json workspace delete --project ALIAS --workspace-id WS_ID
+```
+
+## Option B: Ad-hoc workspace
+
+Best when you want to explore data or run arbitrary queries:
+
+```bash
+# Create empty workspace
+kbagent --json workspace create --project ALIAS --name "debug-ws"
+
+# Load specific tables
+kbagent --json workspace load \
+  --project ALIAS \
+  --workspace-id WS_ID \
+  --tables in.c-bucket.table1 \
+  --tables in.c-bucket.table2
+
+# Query
+kbagent --json workspace query \
+  --project ALIAS \
+  --workspace-id WS_ID \
+  --sql "SELECT * FROM \"table1\" LIMIT 10"
+```
+
+## Option C: UI-visible workspace
+
+Use `--ui` when the workspace should appear in the Keboola UI Workspaces tab (slower, ~15s):
+
+```bash
+kbagent --json workspace create --project ALIAS --name "shared-debug" --ui
+```
+
+## SQL from file
+
+For multi-line SQL, use `--file` instead of `--sql`:
+
+```bash
+kbagent --json workspace query \
+  --project ALIAS \
+  --workspace-id WS_ID \
+  --file query.sql
+```
+
+## Key details
+
+- **Password**: only returned on creation (headless) or after `workspace password` (reset)
+- **Expiration**: workspaces expire server-side automatically
+- **Quoting**: Snowflake identifiers with hyphens need double quotes: `"my-table"`
+- **Query Service**: uses Storage API token for auth -- no Snowflake credentials needed in the query command
+- **Transactional mode**: add `--transactional` to wrap SQL in a transaction


### PR DESCRIPTION
## Summary

- Marketplace-installable Claude Code plugin that teaches Claude how to use kbagent CLI
- Progressive disclosure design: SKILL.md is lean (~70 lines), loads `kbagent context` dynamically, complex workflows in `references/`
- Skill validates via skill-creator's `quick_validate.py`

### Plugin structure

```
.claude-plugin/marketplace.json              # Repo serves as marketplace
plugins/kbagent/
  .claude-plugin/plugin.json                 # Plugin manifest (v0.7.3)
  skills/kbagent/
    SKILL.md                                 # Trigger + rules + decision table
    references/
      workspace-workflow.md                  # SQL debugging step-by-step
      branch-workflow.md                     # Dev branch lifecycle
      gotchas.md                             # Response parsing, common pitfalls
```

### Installation

```
/plugin marketplace add padak/keboola_agent_cli
/plugin install kbagent@keboola-agent-cli
```

### Design decisions

- **`kbagent context` as first step** (from #25): dynamically loads full CLI docs, always up-to-date with current version
- **References for complex workflows**: workspace and branch workflows are multi-step and need detailed guidance that would bloat SKILL.md
- **Gotchas file**: documents response structure differences per command -- the thing `kbagent context` doesn't cover well enough

Supersedes #25

## Test plan

- [x] Skill validates via `quick_validate.py`
- [ ] Install via `/plugin marketplace add` and test triggering
- [ ] Verify `kbagent context` loads correctly as first step
- [ ] Test workspace and branch workflow references load on demand