### PR TITLE
Add config search for full-text search across configurations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ kbagent project status [--project NAME]
 
 kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID]
 kbagent config detail --project NAME --component-id ID --config-id ID
+kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [--ignore-case] [--regex]
 
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -2,13 +2,14 @@
 name: kbagent
 description: >
   Use when working with Keboola Connection projects via kbagent CLI.
-  Covers: exploring configurations (extractors, writers, transformations),
+  Covers: exploring and searching configurations (extractors, writers, transformations),
   browsing job history, analyzing cross-project data lineage, calling MCP tools
   across multiple projects, managing development branches, debugging SQL in
   temporary workspaces, bulk-onboarding organizations, and generating explorer
   dashboards. Triggers: kbagent, Keboola project, keboola configs, keboola jobs,
   keboola lineage, keboola transformations, keboola MCP tools, keboola workspace,
-  SQL debugging, keboola branches, keboola organization, keboola explorer.
+  SQL debugging, keboola branches, keboola organization, keboola explorer,
+  search configs, find in configurations, audit configurations.
 ---
 
 # kbagent -- Keboola Agent CLI
@@ -36,6 +37,7 @@ This prints all commands, flags, workflows, and tips. Read it fully before proce
 |------|---------|
 | See what projects are connected | `kbagent --json project list` |
 | Browse configs across projects | `kbagent --json config list` |
+| Find a string in configs (audit, grep) | `kbagent --json config search -q "pattern" [-i] [-r]` |
 | Check for failed jobs | `kbagent --json job list --status error` |
 | Understand data flow between projects | `kbagent --json lineage` |
 | Generate visual dashboard | `kbagent explorer` |

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -14,6 +14,7 @@ Not all commands return data the same way. Key differences:
 | `tool call` | `{"results": [...]}` (one per project) |
 | `workspace list` | `{"workspaces": [...], "errors": [...]}` |
 | `branch list` | `{"branches": [...]}` |
+| `config search` | `{"matches": [...], "errors": [...], "stats": {...}}` |
 
 Always check the actual response structure rather than assuming a pattern.
 

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -1,14 +1,16 @@
-"""Configuration browsing commands - list and detail.
+"""Configuration browsing commands - list, detail, and search.
 
 Thin CLI layer: parses arguments, calls ConfigService, formats output.
 No business logic belongs here.
 """
 
+import re
+
 import typer
 
 from ..constants import VALID_COMPONENT_TYPES
 from ..errors import ConfigError, KeboolaApiError
-from ..output import format_config_detail, format_configs_table
+from ..output import format_config_detail, format_configs_table, format_search_results
 from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
 
 config_app = typer.Typer(help="Browse and inspect configurations")
@@ -95,3 +97,83 @@ def config_detail(
             retryable=exc.retryable,
         )
         raise typer.Exit(code=exit_code) from None
+
+
+@config_app.command("search")
+def config_search(
+    ctx: typer.Context,
+    query: str = typer.Option(..., "--query", "-q", help="Search string or regex pattern"),
+    project: list[str] | None = typer.Option(
+        None,
+        "--project",
+        help="Project alias to search (can be repeated for multiple projects)",
+    ),
+    component_type: str | None = typer.Option(
+        None,
+        "--component-type",
+        help="Filter by component type: extractor, writer, transformation, application",
+    ),
+    component_id: str | None = typer.Option(
+        None,
+        "--component-id",
+        help="Filter by specific component ID (e.g. keboola.ex-db-snowflake)",
+    ),
+    ignore_case: bool = typer.Option(
+        False,
+        "--ignore-case",
+        "-i",
+        help="Case-insensitive matching",
+    ),
+    use_regex: bool = typer.Option(
+        False,
+        "--regex",
+        "-r",
+        help="Interpret query as a regular expression",
+    ),
+) -> None:
+    """Search through configuration bodies for a string or pattern.
+
+    Searches config names, descriptions, parameters, and row definitions.
+    Reports which configurations match and where in the JSON tree.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "config_service")
+
+    # Validate component_type
+    if component_type and component_type not in VALID_COMPONENT_TYPES:
+        formatter.error(
+            message=f"Invalid component type '{component_type}'. "
+            f"Valid types: {', '.join(VALID_COMPONENT_TYPES)}",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    # Validate regex if provided
+    if use_regex:
+        try:
+            re.compile(query)
+        except re.error as exc:
+            formatter.error(
+                message=f"Invalid regex pattern: {exc}",
+                error_code="INVALID_ARGUMENT",
+            )
+            raise typer.Exit(code=2) from None
+
+    try:
+        result = service.search_configs(
+            query=query,
+            aliases=project,
+            component_type=component_type,
+            component_id=component_id,
+            ignore_case=ignore_case,
+            use_regex=use_regex,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        format_search_results(formatter.console, result)
+        emit_project_warnings(formatter, result)

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -90,6 +90,21 @@ Then explore:
     Example:
       kbagent --json config detail --project prod --component-id keboola.ex-db-snowflake --config-id 12345
 
+  kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [--component-id ID] [--ignore-case] [--regex]
+    Search through configuration bodies (names, descriptions, parameters, rows)
+    for a string or regex pattern. Reports matching configs and WHERE in the JSON
+    tree the match was found. Runs across all connected projects in parallel.
+    Default: case-sensitive substring match.
+    -i / --ignore-case: case-insensitive matching.
+    -r / --regex: interpret query as a regular expression.
+    --project can be repeated to limit to specific projects.
+    Examples:
+      kbagent --json config search --query "password"
+      kbagent --json config search --query "marketing" --ignore-case
+      kbagent --json config search --query "marketing" -i --project prod
+      kbagent --json config search --query "\\d{{3}}-\\d+" --regex
+      kbagent --json config search --query "(password|secret|heslo)" --regex --ignore-case
+
 ### Job History
 
   kbagent job list [--project NAME] [--component-id ID] [--config-id ID] [--status STATUS] [--limit N]

--- a/src/keboola_agent_cli/output.py
+++ b/src/keboola_agent_cli/output.py
@@ -877,3 +877,59 @@ def format_query_results(console: Console, data: dict[str, Any]) -> None:
 
     panel = Panel("\n".join(lines), title=f"Query Results - Workspace {workspace_id}", expand=False)
     console.print(panel)
+
+
+def format_search_results(console: Console, data: dict[str, Any]) -> None:
+    """Render search results as a Rich table with match locations.
+
+    Args:
+        console: Rich Console instance.
+        data: Dict with "matches", "errors", and "stats".
+    """
+    matches = data.get("matches", [])
+    errors = data.get("errors", [])
+    stats = data.get("stats", {})
+
+    for err in errors:
+        console.print(
+            f"[bold yellow]Warning:[/bold yellow] Project [bold]{err['project_alias']}[/bold]: "
+            f"{err['message']}"
+        )
+
+    if not matches:
+        console.print(
+            f"No matches found. Searched {stats.get('configs_searched', 0)} "
+            f"configurations across {stats.get('projects_searched', 0)} project(s)."
+        )
+        return
+
+    table = Table(title="Search Results")
+    table.add_column("Project", style="bold cyan")
+    table.add_column("Component", style="dim")
+    table.add_column("Config ID", justify="right")
+    table.add_column("Config Name")
+    table.add_column("Hits", justify="right", style="bold yellow")
+    table.add_column("Match Locations", style="dim", max_width=60)
+
+    for match in matches:
+        locations = match.get("match_locations", [])
+        # Show first 3 locations, truncate the rest
+        display_locations = ", ".join(locations[:3])
+        if len(locations) > 3:
+            display_locations += f", ... (+{len(locations) - 3})"
+
+        table.add_row(
+            match["project_alias"],
+            match["component_id"],
+            match["config_id"],
+            match["config_name"],
+            str(match.get("match_count", len(locations))),
+            display_locations,
+        )
+
+    console.print(table)
+    console.print(
+        f"\n[bold]{stats.get('matches_found', 0)}[/bold] matching config(s) "
+        f"in {stats.get('configs_searched', 0)} searched "
+        f"across {stats.get('projects_searched', 0)} project(s)."
+    )

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -1,14 +1,41 @@
 """Configuration listing service - business logic for listing and detailing configs.
 
 Orchestrates multi-project configuration retrieval in parallel, filtering,
-and aggregation without knowing about CLI or HTTP details.
+aggregation, and full-text search without knowing about CLI or HTTP details.
 """
 
+import json
+import re
 from typing import Any
 
 from ..errors import KeboolaApiError
 from ..models import ProjectConfig
 from .base import BaseService
+
+
+def _find_matches_in_json(
+    obj: Any,
+    match_fn: Any,
+    path: str = "",
+) -> list[str]:
+    """Recursively walk a JSON-like object and return paths where match_fn(str_value) is True."""
+    paths: list[str] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            child_path = f"{path}.{key}" if path else key
+            paths.extend(_find_matches_in_json(value, match_fn, child_path))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            child_path = f"{path}[{i}]"
+            paths.extend(_find_matches_in_json(item, match_fn, child_path))
+    elif isinstance(obj, str):
+        if match_fn(obj):
+            paths.append(path)
+    else:
+        # Numbers, booleans -- convert to string for matching
+        if obj is not None and match_fn(str(obj)):
+            paths.append(path)
+    return paths
 
 
 class ConfigService(BaseService):
@@ -163,3 +190,136 @@ class ConfigService(BaseService):
 
         detail["project_alias"] = alias
         return detail
+
+    def search_configs(
+        self,
+        query: str,
+        aliases: list[str] | None = None,
+        component_type: str | None = None,
+        component_id: str | None = None,
+        ignore_case: bool = False,
+        use_regex: bool = False,
+    ) -> dict[str, Any]:
+        """Search through configuration bodies across projects.
+
+        Fetches all configurations (including the full JSON body) and searches
+        for a query string. Reports which configs match and WHERE in the JSON
+        tree the match was found.
+
+        Args:
+            query: Search string (plain substring or regex).
+            aliases: Project aliases to query. None means all projects.
+            component_type: Optional filter by component type.
+            component_id: Optional filter by specific component ID.
+            ignore_case: If True, match case-insensitively.
+            use_regex: If True, interpret query as a regular expression.
+
+        Returns:
+            Dict with "matches", "errors", and "stats" keys.
+        """
+        # Compile the match function once
+        if use_regex:
+            flags = re.IGNORECASE if ignore_case else 0
+            pattern = re.compile(query, flags)
+            match_fn = lambda s: pattern.search(s) is not None  # noqa: E731
+        elif ignore_case:
+            query_lower = query.lower()
+            match_fn = lambda s: query_lower in s.lower()  # noqa: E731
+        else:
+            match_fn = lambda s: query in s  # noqa: E731
+
+        projects = self.resolve_projects(aliases)
+
+        def worker(
+            alias: str, project: ProjectConfig
+        ) -> tuple[str, dict[str, Any], bool] | tuple[str, dict[str, str]]:
+            return self._search_project_configs(
+                alias, project, match_fn, component_type, component_id
+            )
+
+        successes, errors = self._run_parallel(projects, worker)
+
+        all_matches: list[dict[str, Any]] = []
+        total_configs = 0
+        for _alias, result, _ok in successes:
+            all_matches.extend(result["matches"])
+            total_configs += result["configs_searched"]
+
+        all_matches.sort(
+            key=lambda m: (m["project_alias"], m["component_id"], m["config_id"])
+        )
+        errors.sort(key=lambda e: e.get("project_alias", ""))
+
+        return {
+            "matches": all_matches,
+            "errors": errors,
+            "stats": {
+                "projects_searched": len(successes),
+                "configs_searched": total_configs,
+                "matches_found": len(all_matches),
+            },
+        }
+
+    def _search_project_configs(
+        self,
+        alias: str,
+        project: ProjectConfig,
+        match_fn: Any,
+        component_type: str | None = None,
+        component_id: str | None = None,
+    ) -> tuple[str, dict[str, Any], bool] | tuple[str, dict[str, str]]:
+        """Search configs in a single project (worker thread)."""
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            components = client.list_components(component_type=component_type)
+            matches: list[dict[str, Any]] = []
+            configs_searched = 0
+
+            for component in components:
+                comp_id = component.get("id", "")
+                comp_name = component.get("name", "")
+                comp_type = component.get("type", "")
+
+                if component_id and comp_id != component_id:
+                    continue
+
+                for cfg in component.get("configurations", []):
+                    configs_searched += 1
+                    match_locations = _find_matches_in_json(cfg, match_fn)
+
+                    if match_locations:
+                        matches.append(
+                            {
+                                "project_alias": alias,
+                                "component_id": comp_id,
+                                "component_name": comp_name,
+                                "component_type": comp_type,
+                                "config_id": str(cfg.get("id", "")),
+                                "config_name": cfg.get("name", ""),
+                                "config_description": cfg.get("description", ""),
+                                "match_locations": match_locations,
+                                "match_count": len(match_locations),
+                            }
+                        )
+
+            return (alias, {"matches": matches, "configs_searched": configs_searched}, True)
+        except KeboolaApiError as exc:
+            return (
+                alias,
+                {
+                    "project_alias": alias,
+                    "error_code": exc.error_code,
+                    "message": exc.message,
+                },
+            )
+        except Exception as exc:
+            return (
+                alias,
+                {
+                    "project_alias": alias,
+                    "error_code": "UNEXPECTED_ERROR",
+                    "message": str(exc),
+                },
+            )
+        finally:
+            client.close()

--- a/tests/test_config_search.py
+++ b/tests/test_config_search.py
@@ -1,0 +1,352 @@
+"""Tests for ConfigService.search_configs() and _find_matches_in_json helper."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from helpers import setup_single_project, setup_two_projects
+from keboola_agent_cli.models import ProjectConfig
+from keboola_agent_cli.services.config_service import ConfigService, _find_matches_in_json
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_list_components_client(components: list[dict]) -> MagicMock:
+    """Create a mock KeboolaClient with list_components returning given data."""
+    mock_client = MagicMock()
+    mock_client.list_components.return_value = components
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# Sample data that resembles real Keboola API responses
+# ---------------------------------------------------------------------------
+
+SAMPLE_COMPONENTS_RICH = [
+    {
+        "id": "keboola.ex-db-snowflake",
+        "name": "Snowflake Extractor",
+        "type": "extractor",
+        "configurations": [
+            {
+                "id": "123",
+                "name": "My Extractor",
+                "description": "Extracts marketing data",
+                "configuration": {
+                    "parameters": {
+                        "db": {
+                            "host": "account.snowflakecomputing.com",
+                            "#password": "heslo123",
+                            "port": 443,
+                        },
+                        "tables": [
+                            {"tableName": "campaigns", "schema": "PUBLIC"},
+                            {"tableName": "ad_groups", "schema": "PUBLIC"},
+                        ],
+                    }
+                },
+                "rows": [],
+            },
+            {
+                "id": "456",
+                "name": "Staging Extractor",
+                "description": "Staging env loader",
+                "configuration": {
+                    "parameters": {
+                        "db": {
+                            "host": "staging.snowflakecomputing.com",
+                            "#password": "staging-pass",
+                        }
+                    }
+                },
+                "rows": [],
+            },
+        ],
+    },
+    {
+        "id": "keboola.wr-db-snowflake",
+        "name": "Snowflake Writer",
+        "type": "writer",
+        "configurations": [
+            {
+                "id": "789",
+                "name": "Write to DWH",
+                "description": "Writes aggregated data to warehouse",
+                "configuration": {
+                    "parameters": {
+                        "db": {
+                            "host": "dwh.snowflakecomputing.com",
+                            "#password": "dwh-secret",
+                        }
+                    }
+                },
+                "rows": [],
+            },
+        ],
+    },
+]
+
+SAMPLE_COMPONENTS_DEV = [
+    {
+        "id": "keboola.python-transformation-v2",
+        "name": "Python Transformation",
+        "type": "transformation",
+        "configurations": [
+            {
+                "id": "301",
+                "name": "Aggregate 100-200 Data",
+                "description": "Aggregation script with phone 555-1234",
+                "configuration": {
+                    "parameters": {
+                        "script": "import pandas as pd\ndf = df.groupby('campaign').sum()",
+                    }
+                },
+                "rows": [],
+            },
+        ],
+    },
+]
+
+
+# ===========================================================================
+# Tests for _find_matches_in_json
+# ===========================================================================
+
+
+class TestFindMatchesInJson:
+    """Tests for the _find_matches_in_json recursive helper."""
+
+    def test_find_match_in_string_value(self) -> None:
+        """Simple string match returns the correct path."""
+        obj = {"name": "My Extractor", "type": "extractor"}
+        match_fn = lambda s: "Extractor" in s  # noqa: E731
+
+        paths = _find_matches_in_json(obj, match_fn)
+
+        assert "name" in paths
+        assert len(paths) == 1
+
+    def test_find_match_in_nested_dict(self) -> None:
+        """Match in a deeply nested dict returns dotted path."""
+        obj = {
+            "configuration": {
+                "parameters": {
+                    "db": {
+                        "host": "account.snowflakecomputing.com",
+                    }
+                }
+            }
+        }
+        match_fn = lambda s: "snowflakecomputing" in s  # noqa: E731
+
+        paths = _find_matches_in_json(obj, match_fn)
+
+        assert paths == ["configuration.parameters.db.host"]
+
+    def test_find_match_in_list(self) -> None:
+        """Match in array items includes [index] in path."""
+        obj = {
+            "tables": [
+                {"tableName": "campaigns"},
+                {"tableName": "ad_groups"},
+            ]
+        }
+        match_fn = lambda s: "ad_groups" in s  # noqa: E731
+
+        paths = _find_matches_in_json(obj, match_fn)
+
+        assert paths == ["tables[1].tableName"]
+
+    def test_find_match_in_number(self) -> None:
+        """Numeric values are converted to string for matching."""
+        obj = {"port": 443, "name": "test"}
+        match_fn = lambda s: "443" in s  # noqa: E731
+
+        paths = _find_matches_in_json(obj, match_fn)
+
+        assert "port" in paths
+
+    def test_no_match_returns_empty(self) -> None:
+        """When nothing matches, an empty list is returned."""
+        obj = {
+            "name": "Production",
+            "configuration": {"parameters": {"key": "value"}},
+        }
+        match_fn = lambda s: "nonexistent_string_xyz" in s  # noqa: E731
+
+        paths = _find_matches_in_json(obj, match_fn)
+
+        assert paths == []
+
+    def test_find_multiple_matches(self) -> None:
+        """Same substring in multiple locations returns all paths."""
+        obj = {
+            "name": "snowflake loader",
+            "description": "Loads from snowflake",
+            "configuration": {
+                "parameters": {
+                    "db": {
+                        "host": "account.snowflakecomputing.com",
+                    }
+                }
+            },
+        }
+        match_fn = lambda s: "snowflake" in s.lower()  # noqa: E731
+
+        paths = _find_matches_in_json(obj, match_fn)
+
+        assert len(paths) == 3
+        assert "name" in paths
+        assert "description" in paths
+        assert "configuration.parameters.db.host" in paths
+
+
+# ===========================================================================
+# Tests for ConfigService.search_configs
+# ===========================================================================
+
+
+class TestSearchConfigs:
+    """Tests for ConfigService.search_configs()."""
+
+    def test_search_substring_case_sensitive(self, tmp_config_dir: Path) -> None:
+        """Default search is case-sensitive substring match."""
+        store = setup_single_project(tmp_config_dir)
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_RICH)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.search_configs(query="account.snowflakecomputing.com")
+
+        assert len(result["errors"]) == 0
+        matches = result["matches"]
+        # Only config 123 has "account.snowflakecomputing.com"
+        assert len(matches) == 1
+        assert matches[0]["config_id"] == "123"
+        assert matches[0]["component_id"] == "keboola.ex-db-snowflake"
+        assert "configuration.parameters.db.host" in matches[0]["match_locations"]
+        assert matches[0]["match_count"] >= 1
+
+        # Case-sensitive: uppercase should NOT match
+        result_upper = service.search_configs(query="Account.Snowflakecomputing.com")
+        assert len(result_upper["matches"]) == 0
+
+    def test_search_no_match(self, tmp_config_dir: Path) -> None:
+        """When nothing matches, returns empty matches with correct stats."""
+        store = setup_single_project(tmp_config_dir)
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_RICH)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.search_configs(query="this_will_never_match_anything_xyz")
+
+        assert result["matches"] == []
+        assert result["errors"] == []
+        assert result["stats"]["projects_searched"] == 1
+        # 2 extractor configs + 1 writer config = 3 total
+        assert result["stats"]["configs_searched"] == 3
+        assert result["stats"]["matches_found"] == 0
+
+    def test_search_ignore_case(self, tmp_config_dir: Path) -> None:
+        """Case-insensitive search finds matches regardless of casing."""
+        store = setup_single_project(tmp_config_dir)
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_RICH)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.search_configs(
+            query="SNOWFLAKECOMPUTING", ignore_case=True
+        )
+
+        matches = result["matches"]
+        # All 3 configs have "snowflakecomputing" in their host
+        assert len(matches) == 3
+        config_ids = {m["config_id"] for m in matches}
+        assert config_ids == {"123", "456", "789"}
+
+    def test_search_regex(self, tmp_config_dir: Path) -> None:
+        r"""Regex pattern like \d{3}-\d+ matches in config bodies."""
+        store = setup_single_project(tmp_config_dir, alias="dev")
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_DEV)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.search_configs(query=r"\d{3}-\d+", use_regex=True)
+
+        matches = result["matches"]
+        assert len(matches) == 1
+        assert matches[0]["config_id"] == "301"
+        # The match is in the description field ("555-1234")
+        assert any("description" in loc for loc in matches[0]["match_locations"])
+
+    def test_search_multi_project(self, tmp_config_dir: Path) -> None:
+        """Search across two projects aggregates results from both."""
+        store = setup_two_projects(tmp_config_dir)
+
+        prod_client = _make_list_components_client(SAMPLE_COMPONENTS_RICH)
+        dev_client = _make_list_components_client(SAMPLE_COMPONENTS_DEV)
+
+        def factory(url: str, token: str) -> MagicMock:
+            if token == "901-xxx":
+                return prod_client
+            return dev_client
+
+        service = ConfigService(
+            config_store=store,
+            client_factory=factory,
+        )
+
+        # "data" appears in descriptions of both projects
+        result = service.search_configs(query="data", ignore_case=True)
+
+        assert len(result["errors"]) == 0
+        assert result["stats"]["projects_searched"] == 2
+
+        # Verify matches come from both projects
+        project_aliases = {m["project_alias"] for m in result["matches"]}
+        assert "prod" in project_aliases
+        assert "dev" in project_aliases
+
+        # Stats should reflect total configs from both projects
+        # prod: 3 configs (2 extractor + 1 writer), dev: 1 config
+        assert result["stats"]["configs_searched"] == 4
+
+    def test_search_with_component_type_filter(self, tmp_config_dir: Path) -> None:
+        """Filtering by component_type narrows down the search scope."""
+        store = setup_single_project(tmp_config_dir)
+
+        # Return only extractors when component_type filter is applied
+        extractor_only = [c for c in SAMPLE_COMPONENTS_RICH if c["type"] == "extractor"]
+        mock_client = _make_list_components_client(extractor_only)
+
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.search_configs(
+            query="snowflakecomputing",
+            ignore_case=True,
+            component_type="extractor",
+        )
+
+        matches = result["matches"]
+        # Only extractor configs (123 and 456), not the writer (789)
+        assert len(matches) == 2
+        for m in matches:
+            assert m["component_type"] == "extractor"
+
+        # The client was called with the component_type filter
+        mock_client.list_components.assert_called_once_with(component_type="extractor")

--- a/tests/test_config_search_cli.py
+++ b/tests/test_config_search_cli.py
@@ -1,0 +1,318 @@
+"""Tests for `kbagent config search` command via CliRunner."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import ConfigError
+from keboola_agent_cli.models import ProjectConfig
+from keboola_agent_cli.services.config_service import ConfigService
+from keboola_agent_cli.services.project_service import ProjectService
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Sample data - configs with body content for search to match against
+# ---------------------------------------------------------------------------
+
+SAMPLE_COMPONENTS_WITH_BODY = [
+    {
+        "id": "keboola.ex-db-snowflake",
+        "name": "Snowflake Extractor",
+        "type": "extractor",
+        "configurations": [
+            {
+                "id": "101",
+                "name": "Production Load",
+                "description": "Loads production data from Snowflake",
+                "configuration": {
+                    "parameters": {
+                        "db": {"host": "prod.snowflakecomputing.com", "database": "PROD_DB"},
+                    }
+                },
+                "rows": [],
+            },
+            {
+                "id": "102",
+                "name": "Dev Load",
+                "description": "Loads dev data",
+                "configuration": {
+                    "parameters": {
+                        "db": {"host": "dev.snowflakecomputing.com", "database": "DEV_DB"},
+                    }
+                },
+                "rows": [],
+            },
+        ],
+    },
+    {
+        "id": "keboola.wr-db-snowflake",
+        "name": "Snowflake Writer",
+        "type": "writer",
+        "configurations": [
+            {
+                "id": "201",
+                "name": "Write to DWH",
+                "description": "Writes to data warehouse",
+                "configuration": {
+                    "parameters": {"db": {"host": "dwh.snowflakecomputing.com"}},
+                },
+                "rows": [],
+            },
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_config_store(config_dir: Path, projects: dict[str, dict] | None = None) -> ConfigStore:
+    """Set up a ConfigStore with given projects for testing."""
+    store = ConfigStore(config_dir=config_dir)
+    if projects:
+        for alias, info in projects.items():
+            store.add_project(
+                alias,
+                ProjectConfig(
+                    stack_url=info.get("stack_url", "https://connection.keboola.com"),
+                    token=info["token"],
+                    project_name=info.get("project_name", alias),
+                    project_id=info.get("project_id", 1234),
+                ),
+            )
+    return store
+
+
+def _make_list_components_client(components: list[dict]) -> MagicMock:
+    """Create a mock KeboolaClient with list_components returning given data."""
+    mock_client = MagicMock()
+    mock_client.list_components.return_value = components
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSearch:
+    """Tests for `kbagent config search` command."""
+
+    def test_config_search_json_output(self, tmp_path: Path) -> None:
+        """config search --json returns structured JSON with matches, errors, stats."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_WITH_BODY)
+        store = _setup_config_store(
+            config_dir,
+            {"prod": {"token": TEST_TOKEN}},
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            config_service = ConfigService(
+                config_store=store,
+                client_factory=lambda url, token: mock_client,
+            )
+            MockCfgService.return_value = config_service
+
+            result = runner.invoke(
+                app,
+                ["--json", "config", "search", "--query", "snowflakecomputing"],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+
+        data = output["data"]
+        assert "matches" in data
+        assert "errors" in data
+        assert "stats" in data
+
+        # All 3 configs contain "snowflakecomputing" in their parameters
+        assert data["stats"]["matches_found"] == 3
+        assert data["stats"]["projects_searched"] == 1
+        assert data["stats"]["configs_searched"] == 3
+
+        # Verify match structure
+        first_match = data["matches"][0]
+        assert first_match["project_alias"] == "prod"
+        assert "component_id" in first_match
+        assert "config_id" in first_match
+        assert "config_name" in first_match
+        assert "match_locations" in first_match
+        assert "match_count" in first_match
+        assert first_match["match_count"] > 0
+
+        assert data["errors"] == []
+
+    def test_config_search_no_matches_json(self, tmp_path: Path) -> None:
+        """config search --json returns empty result with stats when nothing matches."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_WITH_BODY)
+        store = _setup_config_store(
+            config_dir,
+            {"prod": {"token": TEST_TOKEN}},
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            config_service = ConfigService(
+                config_store=store,
+                client_factory=lambda url, token: mock_client,
+            )
+            MockCfgService.return_value = config_service
+
+            result = runner.invoke(
+                app,
+                ["--json", "config", "search", "--query", "nonexistent_term_xyz_999"],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+
+        data = output["data"]
+        assert data["matches"] == []
+        assert data["stats"]["matches_found"] == 0
+        assert data["stats"]["projects_searched"] == 1
+        assert data["stats"]["configs_searched"] == 3
+        assert data["errors"] == []
+
+    def test_config_search_invalid_regex(self, tmp_path: Path) -> None:
+        """config search --regex with bad pattern exits with code 2."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_store(
+            config_dir,
+            {"prod": {"token": TEST_TOKEN}},
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(
+                config_store=store,
+                client_factory=lambda url, token: MagicMock(),
+            )
+
+            result = runner.invoke(
+                app,
+                ["--json", "config", "search", "--query", "[invalid(", "--regex"],
+            )
+
+        assert result.exit_code == 2, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "INVALID_ARGUMENT"
+        assert "regex" in output["error"]["message"].lower()
+
+    def test_config_search_invalid_component_type(self, tmp_path: Path) -> None:
+        """config search --component-type with invalid value exits with code 2."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_store(
+            config_dir,
+            {"prod": {"token": TEST_TOKEN}},
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(
+                config_store=store,
+                client_factory=lambda url, token: MagicMock(),
+            )
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "config",
+                    "search",
+                    "--query",
+                    "test",
+                    "--component-type",
+                    "bogus_type",
+                ],
+            )
+
+        assert result.exit_code == 2, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "INVALID_ARGUMENT"
+        assert "bogus_type" in output["error"]["message"]
+
+    def test_config_search_unknown_project(self, tmp_path: Path) -> None:
+        """config search --project with unknown alias exits with code 5."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        # Store has NO projects registered
+        store = _setup_config_store(config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(
+                config_store=store,
+                client_factory=lambda url, token: MagicMock(),
+            )
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "config",
+                    "search",
+                    "--query",
+                    "test",
+                    "--project",
+                    "nonexistent",
+                ],
+            )
+
+        assert result.exit_code == 5, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "CONFIG_ERROR"


### PR DESCRIPTION
## Summary

- New command: `kbagent config search --query PATTERN [--ignore-case] [--regex]`
- Searches config names, descriptions, parameters, and row definitions across all projects in parallel
- Reports exact JSON paths where matches were found (e.g. `configuration.parameters.db.#password`)
- Zero extra API calls -- reuses existing `list_components?include=configuration`

### Search modes

| Flag | Mode | Example |
|------|------|---------|
| (default) | Case-sensitive substring | `--query "password"` |
| `-i` | Case-insensitive | `--query "marketing" -i` |
| `-r` | Regular expression | `--query "(password\|secret\|heslo)" -r` |
| `-i -r` | Case-insensitive regex | `--query "token.*key" -i -r` |

### Use case

Security audit: find unencrypted credentials in configs across an organization:
```bash
kbagent --json config search -q "(password|secret|heslo)" -r -i
```

### Changes

- **config_service.py**: `search_configs()` + `_find_matches_in_json()` recursive JSON walker
- **commands/config.py**: `config search` CLI command with validation
- **output.py**: `format_search_results()` Rich table formatter
- **context.py**: Updated agent documentation
- **CLAUDE.md**: Added command to reference
- **Plugin**: Updated SKILL.md decision table and gotchas.md response format

## Test plan

- [x] 811 tests pass (17 new for search)
- [x] Service tests: substring, case-insensitive, regex, multi-project, filters
- [x] CLI tests: JSON output, no matches, invalid regex, invalid component type, unknown project
- [ ] Manual test against real project

Closes #26