### PR TITLE
Add config delete command with branch support

### DIFF
--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -44,6 +44,7 @@ This prints all commands, flags, workflows, and tips. Read it fully before proce
 | List configurations from connected projects | `kbagent config list` |
 | Show detailed information about a specific configuration | `kbagent config detail --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | Search through configuration bodies for a string or pattern | `kbagent config search --query QUERY` |
+| Delete a configuration from a project | `kbagent config delete --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | List jobs from connected projects | `kbagent job list` |
 | Show detailed information about a specific job | `kbagent job detail --project PROJECT --job-id JOB-ID` |
 | Show cross-project data lineage via bucket sharing | `kbagent lineage show` |

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -1,4 +1,4 @@
-"""Configuration browsing commands - list, detail, and search.
+"""Configuration commands - list, detail, search, and delete.
 
 Thin CLI layer: parses arguments, calls ConfigService, formats output.
 No business logic belongs here.
@@ -177,3 +177,65 @@ def config_search(
     else:
         format_search_results(formatter.console, result)
         emit_project_warnings(formatter, result)
+
+
+@config_app.command("delete")
+def config_delete(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    component_id: str = typer.Option(
+        ...,
+        "--component-id",
+        help="Component ID (e.g. keboola.python-transformation-v2)",
+    ),
+    config_id: str = typer.Option(
+        ...,
+        "--config-id",
+        help="Configuration ID to delete",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Delete from a specific dev branch ID (defaults to active branch)",
+    ),
+) -> None:
+    """Delete a configuration from a project.
+
+    If a dev branch is active (via 'branch use'), the deletion targets
+    that branch. Use --branch to override. Deleting in a branch marks
+    the config as removed without affecting Main.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "config_service")
+
+    try:
+        result = service.delete_config(
+            alias=project,
+            component_id=component_id,
+            config_id=config_id,
+            branch_id=branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(
+            message=exc.message,
+            error_code=exc.error_code,
+        )
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        branch_info = ""
+        if result.get("branch_id"):
+            branch_info = f" (branch {result['branch_id']})"
+        formatter.success(
+            f"Deleted config {result['component_id']}/{result['config_id']} "
+            f"from project '{result['project_alias']}'{branch_info}"
+        )

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -90,6 +90,14 @@ Then explore:
     Example:
       kbagent --json config detail --project prod --component-id keboola.ex-db-snowflake --config-id 12345
 
+  kbagent config delete --project NAME --component-id ID --config-id ID [--branch BRANCH_ID]
+    Delete a configuration. If a dev branch is active, deletion targets that branch.
+    Use --branch to override. Deleting in a branch marks the config as removed
+    without affecting Main.
+    Example:
+      kbagent --json config delete --project prod --component-id keboola.python-transformation-v2 --config-id 12345
+      kbagent --json config delete --project prod --component-id keboola.ex-http --config-id 67890 --branch 456
+
   kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [--component-id ID] [--ignore-case] [--regex]
     Search through configuration bodies (names, descriptions, parameters, rows)
     for a string or regex pattern. Reports matching configs and WHERE in the JSON

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -197,6 +197,53 @@ class ConfigService(BaseService):
         detail["project_alias"] = alias
         return detail
 
+    def delete_config(
+        self,
+        alias: str,
+        component_id: str,
+        config_id: str,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Delete a configuration from a project.
+
+        Args:
+            alias: Project alias.
+            component_id: The component ID (e.g. keboola.python-transformation-v2).
+            config_id: The configuration ID to delete.
+            branch_id: If set, delete from a specific dev branch.
+                       If None, uses the project's active branch (if any).
+
+        Returns:
+            Dict with deletion confirmation details.
+
+        Raises:
+            ConfigError: If the alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        # Use active branch if no explicit branch_id given
+        effective_branch_id = branch_id or project.active_branch_id
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            client.delete_config(
+                component_id=component_id,
+                config_id=config_id,
+                branch_id=effective_branch_id,
+            )
+        finally:
+            client.close()
+
+        return {
+            "status": "deleted",
+            "project_alias": alias,
+            "component_id": component_id,
+            "config_id": config_id,
+            "branch_id": effective_branch_id,
+        }
+
     def search_configs(
         self,
         query: str,


### PR DESCRIPTION
## Summary

Resolves #38

New command: `kbagent config delete --project ALIAS --component-id ID --config-id ID [--branch ID]`

- Targets active dev branch by default (set via `branch use`)
- Use `--branch` to override with specific branch ID
- Deleting in a branch marks config as removed without affecting Main
- Uses existing `KeboolaClient.delete_config()` (branch-aware)

## Usage

```bash
# Delete from main (or active branch)
kbagent --json config delete --project prod --component-id keboola.python-transformation-v2 --config-id 1239541872

# Delete from specific branch
kbagent --json config delete --project prod --component-id keboola.ex-http --config-id 67890 --branch 456
```

## Test plan

- [x] `kbagent config delete --help` shows all options
- [x] All 1045 tests pass, lint clean
- [x] Context and SKILL.md updated