### PR TITLE
Add config update command for rename/description

### DIFF
--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -44,6 +44,7 @@ This prints all commands, flags, workflows, and tips. Read it fully before proce
 | List configurations from connected projects | `kbagent config list` |
 | Show detailed information about a specific configuration | `kbagent config detail --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | Search through configuration bodies for a string or pattern | `kbagent config search --query QUERY` |
+| Update a configuration's name and/or description | `kbagent config update --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | Delete a configuration from a project | `kbagent config delete --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | List jobs from connected projects | `kbagent job list` |
 | Show detailed information about a specific job | `kbagent job detail --project PROJECT --job-id JOB-ID` |

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -1,4 +1,4 @@
-"""Configuration commands - list, detail, search, and delete.
+"""Configuration commands - list, detail, search, update, and delete.
 
 Thin CLI layer: parses arguments, calls ConfigService, formats output.
 No business logic belongs here.
@@ -177,6 +177,81 @@ def config_search(
     else:
         format_search_results(formatter.console, result)
         emit_project_warnings(formatter, result)
+
+
+@config_app.command("update")
+def config_update(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    component_id: str = typer.Option(
+        ...,
+        "--component-id",
+        help="Component ID (e.g. keboola.python-transformation-v2)",
+    ),
+    config_id: str = typer.Option(
+        ...,
+        "--config-id",
+        help="Configuration ID to update",
+    ),
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        help="New configuration name",
+    ),
+    description: str | None = typer.Option(
+        None,
+        "--description",
+        help="New configuration description",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Update in a specific dev branch ID (defaults to active branch)",
+    ),
+) -> None:
+    """Update a configuration's name and/or description.
+
+    If a dev branch is active (via 'branch use'), the update targets
+    that branch. Use --branch to override.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "config_service")
+
+    try:
+        result = service.update_config(
+            alias=project,
+            component_id=component_id,
+            config_id=config_id,
+            name=name,
+            description=description,
+            branch_id=branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(
+            message=exc.message,
+            error_code=exc.error_code,
+        )
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        updated_name = result.get("name", "")
+        branch_info = ""
+        if result.get("branch_id"):
+            branch_info = f" (branch {result['branch_id']})"
+        formatter.success(
+            f"Updated config '{updated_name}' "
+            f"({result.get('component_id', component_id)}/{config_id})"
+            f"{branch_info}"
+        )
 
 
 @config_app.command("delete")

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -90,6 +90,14 @@ Then explore:
     Example:
       kbagent --json config detail --project prod --component-id keboola.ex-db-snowflake --config-id 12345
 
+  kbagent config update --project NAME --component-id ID --config-id ID [--name NEW_NAME] [--description NEW_DESC] [--branch BRANCH_ID]
+    Update a configuration's name and/or description.
+    If a dev branch is active, update targets that branch. Use --branch to override.
+    At least one of --name or --description must be provided.
+    Examples:
+      kbagent --json config update --project prod --component-id keboola.python-transformation-v2 --config-id 12345 --name "New Name"
+      kbagent --json config update --project prod --component-id keboola.ex-http --config-id 67890 --name "Renamed" --description "Updated desc" --branch 456
+
   kbagent config delete --project NAME --component-id ID --config-id ID [--branch BRANCH_ID]
     Delete a configuration. If a dev branch is active, deletion targets that branch.
     Use --branch to override. Deleting in a branch marks the config as removed

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -197,6 +197,62 @@ class ConfigService(BaseService):
         detail["project_alias"] = alias
         return detail
 
+    def update_config(
+        self,
+        alias: str,
+        component_id: str,
+        config_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Update a configuration's name and/or description.
+
+        Args:
+            alias: Project alias.
+            component_id: The component ID.
+            config_id: The configuration ID to update.
+            name: New name (if None, not changed).
+            description: New description (if None, not changed).
+            branch_id: If set, update in a specific dev branch.
+                       If None, uses the project's active branch (if any).
+
+        Returns:
+            Dict with the updated configuration from the API.
+
+        Raises:
+            ConfigError: If the alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        if name is None and description is None:
+            raise KeboolaApiError(
+                status_code=400,
+                error_code="VALIDATION_ERROR",
+                message="At least one of --name or --description must be provided.",
+            )
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        effective_branch_id = branch_id or project.active_branch_id
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            result = client.update_config(
+                component_id=component_id,
+                config_id=config_id,
+                name=name,
+                description=description,
+                change_description="Updated via kbagent config update",
+                branch_id=effective_branch_id,
+            )
+        finally:
+            client.close()
+
+        result["project_alias"] = alias
+        result["branch_id"] = effective_branch_id
+        return result
+
     def delete_config(
         self,
         alias: str,


### PR DESCRIPTION
## Summary

Resolves #37

New command: `kbagent config update --project ALIAS --component-id ID --config-id ID [--name NAME] [--description DESC] [--branch ID]`

- Rename configurations and/or update descriptions
- Targets active dev branch by default, `--branch` to override
- Validates that at least `--name` or `--description` is provided
- Uses existing `client.update_config()` (added in sync Phase 2)

## Usage

```bash
# Rename a config
kbagent --json config update --project prod \
  --component-id keboola.python-transformation-v2 \
  --config-id 1248470031 --name "New Name"

# Update description only
kbagent --json config update --project prod \
  --component-id keboola.ex-http --config-id 67890 \
  --description "Updated description"

# Both + specific branch
kbagent --json config update --project prod \
  --component-id keboola.ex-http --config-id 67890 \
  --name "Renamed" --description "New desc" --branch 456
```

## Note

MCP server already has `update_config` tool, but a native CLI command is simpler for scripting/CI and avoids MCP subprocess overhead.

## Test plan

- [x] `kbagent config update --help` shows all options
- [x] All 1045 tests pass, lint clean
- [x] Context and SKILL.md updated