### PR TITLE
Add --preserve flag to workspace load command

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -812,6 +812,7 @@ class KeboolaClient(BaseHttpClient):
         workspace_id: int,
         tables: list[dict[str, Any]],
         branch_id: int | None = None,
+        preserve: bool = False,
     ) -> dict[str, Any]:
         """Load tables into a workspace (async operation).
 
@@ -821,6 +822,8 @@ class KeboolaClient(BaseHttpClient):
                 - source: table ID (e.g. "in.c-bucket.table")
                 - destination: target table name in workspace
             branch_id: Branch ID. Required for workspaces on dev branches.
+            preserve: If True, keep existing tables in the workspace. Default is False
+                (workspace is cleared before loading).
 
         Returns:
             Completed storage job dict (polls until done).
@@ -829,7 +832,7 @@ class KeboolaClient(BaseHttpClient):
             KeboolaApiError: If the load job fails or times out.
         """
         prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
-        body: dict[str, Any] = {"input": tables}
+        body: dict[str, Any] = {"input": tables, "preserve": preserve}
         response = self._request(
             "POST",
             f"{prefix}/workspaces/{workspace_id}/load",

--- a/src/keboola_agent_cli/commands/workspace.py
+++ b/src/keboola_agent_cli/commands/workspace.py
@@ -252,6 +252,11 @@ def workspace_load(
         "--tables",
         help="Table ID to load (can be repeated, e.g. in.c-bucket.table-name)",
     ),
+    preserve: bool = typer.Option(
+        False,
+        "--preserve",
+        help="Keep existing tables in the workspace (default: clear before loading)",
+    ),
 ) -> None:
     """Load tables into a workspace.
 
@@ -261,7 +266,9 @@ def workspace_load(
     service = get_service(ctx, "workspace_service")
 
     try:
-        result = service.load_tables(alias=project, workspace_id=workspace_id, tables=tables)
+        result = service.load_tables(
+            alias=project, workspace_id=workspace_id, tables=tables, preserve=preserve
+        )
         formatter.output(
             result,
             lambda c, d: c.print(f"[bold green]Success:[/bold green] {d['message']}"),

--- a/src/keboola_agent_cli/services/workspace_service.py
+++ b/src/keboola_agent_cli/services/workspace_service.py
@@ -410,6 +410,7 @@ class WorkspaceService(BaseService):
         alias: str,
         workspace_id: int,
         tables: list[str],
+        preserve: bool = False,
     ) -> dict[str, Any]:
         """Load tables into a workspace.
 
@@ -420,6 +421,7 @@ class WorkspaceService(BaseService):
             alias: Project alias.
             workspace_id: Workspace ID.
             tables: List of table IDs (e.g. "in.c-bucket.table-name").
+            preserve: If True, keep existing tables in the workspace.
 
         Returns:
             Dict with load job results.
@@ -443,7 +445,9 @@ class WorkspaceService(BaseService):
 
         client = self._client_factory(project.stack_url, project.token)
         try:
-            job_result = client.load_workspace_tables(workspace_id, table_defs, branch_id=branch_id)
+            job_result = client.load_workspace_tables(
+                workspace_id, table_defs, branch_id=branch_id, preserve=preserve
+            )
         finally:
             client.close()
 
@@ -539,6 +543,7 @@ class WorkspaceService(BaseService):
         config_id: str,
         row_id: str | None = None,
         backend: str = "snowflake",
+        preserve: bool = False,
     ) -> dict[str, Any]:
         """Create a workspace from a transformation config.
 
@@ -551,6 +556,7 @@ class WorkspaceService(BaseService):
             config_id: Configuration ID.
             row_id: Optional row ID for row-based transformations.
             backend: Workspace backend.
+            preserve: If True, keep existing tables in the workspace during load.
 
         Returns:
             Dict with workspace details and loaded tables.
@@ -622,7 +628,9 @@ class WorkspaceService(BaseService):
 
             # Load tables into workspace
             if table_defs:
-                client.load_workspace_tables(workspace_id, table_defs, branch_id=branch_id)
+                client.load_workspace_tables(
+                    workspace_id, table_defs, branch_id=branch_id, preserve=preserve
+                )
 
             return {
                 "project_alias": alias,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1578,3 +1578,87 @@ class TestDeleteConfigBranch:
             token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
         ) as client:
             client.delete_config("keboola.sandboxes", "cfg-1", branch_id=200)
+
+
+class TestLoadWorkspaceTablesPreserve:
+    """Tests for load_workspace_tables() preserve parameter."""
+
+    def test_load_workspace_tables_preserve_false(self, httpx_mock) -> None:
+        """load_workspace_tables sends preserve=False in the request body by default."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/workspaces/42/load",
+            method="POST",
+            json={"id": 900, "status": "success"},
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.load_workspace_tables(
+                workspace_id=42,
+                tables=[{"source": "in.c-main.orders", "destination": "orders"}],
+            )
+            assert result["status"] == "success"
+
+            import json
+
+            request = httpx_mock.get_requests()[0]
+            body = json.loads(request.content)
+            assert body["preserve"] is False
+            assert len(body["input"]) == 1
+            assert body["input"][0]["source"] == "in.c-main.orders"
+
+    def test_load_workspace_tables_preserve_true(self, httpx_mock) -> None:
+        """load_workspace_tables sends preserve=True when requested."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/workspaces/42/load",
+            method="POST",
+            json={"id": 901, "status": "success"},
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.load_workspace_tables(
+                workspace_id=42,
+                tables=[{"source": "in.c-main.orders", "destination": "orders"}],
+                preserve=True,
+            )
+            assert result["status"] == "success"
+
+            import json
+
+            request = httpx_mock.get_requests()[0]
+            body = json.loads(request.content)
+            assert body["preserve"] is True
+
+    def test_load_workspace_tables_preserve_with_branch(self, httpx_mock) -> None:
+        """load_workspace_tables sends preserve in body when branch_id is set."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/200/workspaces/42/load",
+            method="POST",
+            json={"id": 902, "status": "success"},
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.load_workspace_tables(
+                workspace_id=42,
+                tables=[{"source": "in.c-main.orders", "destination": "orders"}],
+                branch_id=200,
+                preserve=True,
+            )
+            assert result["status"] == "success"
+
+            import json
+
+            request = httpx_mock.get_requests()[0]
+            body = json.loads(request.content)
+            assert body["preserve"] is True

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -566,6 +566,116 @@ class TestWorkspaceLoad:
         assert output["data"]["tables_loaded"] == 2
         assert output["data"]["job_status"] == "success"
 
+    def test_workspace_load_with_preserve_flag(self, tmp_path: Path) -> None:
+        """workspace load --preserve passes preserve=True to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_ws = _make_workspace_mock()
+        mock_ws.load_tables.return_value = {
+            "project_alias": "prod",
+            "workspace_id": 42,
+            "tables_loaded": 1,
+            "table_ids": ["in.c-main.orders"],
+            "job_id": 800,
+            "job_status": "success",
+            "message": "Loaded 1 table(s) into workspace 42.",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+            patch("keboola_agent_cli.cli.WorkspaceService") as MockWsService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+            MockJobService.return_value = JobService(config_store=store)
+            MockWsService.return_value = mock_ws
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "workspace",
+                    "load",
+                    "--project",
+                    "prod",
+                    "--workspace-id",
+                    "42",
+                    "--tables",
+                    "in.c-main.orders",
+                    "--preserve",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["tables_loaded"] == 1
+
+        # Verify preserve=True was passed to the service
+        mock_ws.load_tables.assert_called_once_with(
+            alias="prod", workspace_id=42, tables=["in.c-main.orders"], preserve=True
+        )
+
+    def test_workspace_load_without_preserve_flag(self, tmp_path: Path) -> None:
+        """workspace load without --preserve passes preserve=False to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_ws = _make_workspace_mock()
+        mock_ws.load_tables.return_value = {
+            "project_alias": "prod",
+            "workspace_id": 42,
+            "tables_loaded": 1,
+            "table_ids": ["in.c-main.orders"],
+            "job_id": 801,
+            "job_status": "success",
+            "message": "Loaded 1 table(s) into workspace 42.",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+            patch("keboola_agent_cli.cli.WorkspaceService") as MockWsService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+            MockJobService.return_value = JobService(config_store=store)
+            MockWsService.return_value = mock_ws
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "workspace",
+                    "load",
+                    "--project",
+                    "prod",
+                    "--workspace-id",
+                    "42",
+                    "--tables",
+                    "in.c-main.orders",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+
+        # Verify preserve=False was passed to the service (default)
+        mock_ws.load_tables.assert_called_once_with(
+            alias="prod", workspace_id=42, tables=["in.c-main.orders"], preserve=False
+        )
+
 
 class TestWorkspaceQuery:
     """Tests for `kbagent workspace query` command."""

--- a/tests/test_workspace_service.py
+++ b/tests/test_workspace_service.py
@@ -559,9 +559,52 @@ class TestLoadTables:
         assert len(table_defs) == 2
         assert table_defs[0] == {"source": "in.c-main.orders", "destination": "orders"}
         assert table_defs[1] == {"source": "in.c-main.customers", "destination": "customers"}
-        assert call_args[1] == {"branch_id": 123}
+        assert call_args[1] == {"branch_id": 123, "preserve": False}
         # close() called twice: once in _resolve_branch_id, once in load_tables
         assert mock_client.close.call_count == 2
+
+    def test_load_tables_preserve_false(self, tmp_config_dir: Path) -> None:
+        """load_tables passes preserve=False to client by default."""
+        mock_client = MagicMock()
+        mock_client.list_dev_branches.return_value = [{"id": 123, "isDefault": True}]
+        mock_client.load_workspace_tables.return_value = {
+            "id": 778,
+            "status": "success",
+        }
+
+        store = setup_single_project(tmp_config_dir)
+        svc = WorkspaceService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        svc.load_tables(alias="prod", workspace_id=42, tables=["in.c-main.orders"])
+
+        call_kwargs = mock_client.load_workspace_tables.call_args[1]
+        assert call_kwargs["preserve"] is False
+
+    def test_load_tables_preserve_true(self, tmp_config_dir: Path) -> None:
+        """load_tables passes preserve=True to client when requested."""
+        mock_client = MagicMock()
+        mock_client.list_dev_branches.return_value = [{"id": 123, "isDefault": True}]
+        mock_client.load_workspace_tables.return_value = {
+            "id": 779,
+            "status": "success",
+        }
+
+        store = setup_single_project(tmp_config_dir)
+        svc = WorkspaceService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.load_tables(
+            alias="prod", workspace_id=42, tables=["in.c-main.orders"], preserve=True
+        )
+
+        call_kwargs = mock_client.load_workspace_tables.call_args[1]
+        assert call_kwargs["preserve"] is True
+        assert result["job_id"] == 779
 
     def test_load_tables_api_error(self, tmp_config_dir: Path) -> None:
         """load_tables propagates KeboolaApiError when job fails."""


### PR DESCRIPTION
## Summary

- Adds `--preserve` flag to `kbagent workspace load` command
- When set, existing tables in the workspace are kept instead of being dropped before loading
- Propagates `preserve` boolean through all 3 layers: CLI -> Service -> Client -> Storage API

Closes #50

## Usage

```bash
# Default (drop existing tables before load)
kbagent workspace load --project ALIAS --workspace-id ID --tables in.c-bucket.table

# Keep existing tables
kbagent workspace load --project ALIAS --workspace-id ID --tables in.c-bucket.table --preserve
```

## Test plan

- [x] Unit tests for `load_workspace_tables()` with preserve=True/False
- [x] Service tests for `load_tables()` preserve propagation
- [x] CLI tests for `--preserve` flag parsing
- [ ] Manual test against a real Keboola workspace