### PR TITLE
v0.15.3: fix Snowflake path case for linked buckets

### DIFF
--- a/src/keboola_agent_cli/__init__.py
+++ b/src/keboola_agent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Keboola Agent CLI - AI-friendly interface to Keboola projects."""
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -102,7 +102,13 @@ class StorageService(BaseService):
             "is_linked": source is not None,
         }
 
-        # Resolve Snowflake paths
+        # Resolve Snowflake paths using backendPath from API (preserves correct case).
+        # backendPath is an array like ["SAPI_4254", "out.c-account-movements"].
+        # We must NOT construct the DB name ourselves (f"sapi_{id}") because
+        # Snowflake databases may be uppercase or lowercase depending on how
+        # they were created, and double-quoted identifiers are case-sensitive.
+        backend_path = bucket.get("backendPath", [])
+
         if source:
             src_project = source.get("project", {})
             src_project_id = src_project.get("id")
@@ -110,12 +116,18 @@ class StorageService(BaseService):
             result["source_project_id"] = src_project_id
             result["source_project_name"] = src_project.get("name", "")
             result["source_bucket_id"] = src_bucket_id
-            result["snowflake_database"] = f"sapi_{src_project_id}"
-            result["snowflake_schema"] = src_bucket_id
         else:
             result["source_project_id"] = None
             result["source_project_name"] = ""
             result["source_bucket_id"] = ""
+
+        if len(backend_path) >= 2:
+            result["snowflake_database"] = backend_path[0]
+            result["snowflake_schema"] = backend_path[1]
+        elif source:
+            result["snowflake_database"] = f"sapi_{src_project_id}"
+            result["snowflake_schema"] = src_bucket_id
+        else:
             result["snowflake_database"] = f"sapi_{project_id}"
             result["snowflake_schema"] = bucket.get("id", "")
 


### PR DESCRIPTION
## Summary

Fixes #64 -- `bucket-detail` generated wrong-case Snowflake database names for linked buckets.

**Root cause:** We constructed DB names as `f"sapi_{project_id}"` (always lowercase), but Snowflake databases may be uppercase (`SAPI_4254`) or lowercase (`sapi_1507`) depending on how they were created. Since we wrap identifiers in double quotes (case-sensitive in Snowflake), the lowercase path `"sapi_4254"` didn't match the actual `SAPI_4254` database.

**Fix:** Use `backendPath` field from Storage API response (e.g. `["SAPI_4254", "out.c-account-movements"]`) which preserves the correct case. Falls back to the old `f"sapi_{id}"` construction if `backendPath` is not available.

**Before:** `"sapi_4254"."out.c-account-movements"."cz_accounts_voucher_events"` (wrong case)
**After:** `"SAPI_4254"."out.c-account-movements"."cz_accounts_voucher_events"` (matches Snowflake)

## Test plan

- [x] Verified on live project 226 (Slevomat) with linked bucket from project 4254 (Finance)
- [x] Verified non-linked bucket resolves correctly (`sapi_226`)
- [x] Verified linked bucket from project 1507 still works (`sapi_1507`)
- [x] 1119 tests pass, 0 failures