### PR TITLE
v0.15.5: document batch size limit for update_sql_transformation

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.15.2",
+  "version": "0.15.5",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -75,6 +75,20 @@ kbagent looks for configuration in this order:
 
 Use `kbagent init` to create a local `.kbagent/` workspace for per-directory isolation.
 
+## Batch size limits for update_sql_transformation
+
+When using `update_sql_transformation` with `str_replace` operations, **limit batches
+to 50 operations maximum**. Larger batches (150+) may trigger a Storage Events API
+size limit: the replacements are applied and a new version is created, but the MCP
+server fails to log the change event and returns `isError: true` with
+`400 Bad Request: Request too large`. This creates a confusing state where changes
+were saved but the tool reports failure.
+
+Workaround for large refactors (e.g. removing `AS` from 200 table aliases):
+1. Split operations into batches of 50
+2. Call `update_sql_transformation` once per batch
+3. Verify each batch succeeded before sending the next
+
 ## Common mistakes
 
 - **Forgetting `--json`**: without it, output is human-formatted Rich text, not parseable

--- a/src/keboola_agent_cli/__init__.py
+++ b/src/keboola_agent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Keboola Agent CLI - AI-friendly interface to Keboola projects."""
 
-__version__ = "0.15.4"
+__version__ = "0.15.5"


### PR DESCRIPTION
## Summary
- Add gotcha about large `str_replace` batches (150+ ops) causing Storage Events API size limit error while changes are silently applied
- Recommend max 50 operations per batch as workaround until keboola/mcp-server#442 is fixed
- Version bump to 0.15.5 (CLI + plugin)

## Context
Reproduced issue #66: with 2000 ops / 510 KB payload, MCP server applies all replacements but fails to log the change event (`400 Bad Request: Request too large`), returning `isError: true` despite changes being persisted.

## Test plan
- [ ] `make check` passes
- [ ] `kbagent version` shows 0.15.5