### PR TITLE
fix: single source of truth for version in pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,14 @@ jobs:
             exit 1
           fi
 
+      - name: Version consistency check
+        run: |
+          uv run python scripts/sync_version.py > /dev/null 2>&1
+          if ! git diff --quiet plugins/kbagent/.claude-plugin/plugin.json; then
+            echo "::error::plugin.json version mismatch with pyproject.toml. Run 'make version-sync' and commit."
+            git diff plugins/kbagent/.claude-plugin/plugin.json
+            exit 1
+          fi
+
       - name: Tests
         run: uv run pytest tests/ -v -m "not integration"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,10 +137,20 @@ All three inherit from `BaseHttpClient` (`http_base.py`) which provides shared r
 `McpService` wraps `keboola-mcp-server` as a subprocess via MCP SDK (`mcp` package).
 - Read tools run across ALL projects in parallel (one MCP session per project)
 - Write tools target a single project (default or `--project`)
-- **Auto-expand**: tools like `list_tables` that require `bucket_id` automatically
-  resolve it by calling `list_buckets` first (configured in `AUTO_EXPAND_TOOLS` dict)
+- **Auto-expand**: tools like `get_tables` that require `bucket_ids` automatically
+  resolve them by calling `get_buckets` first (configured in `AUTO_EXPAND_TOOLS` dict)
 - Upfront parameter validation against tool's `inputSchema` before multi-project dispatch
 - **Branch support**: `--branch ID` passes `KBC_BRANCH_ID` env var to MCP subprocess, forces single-project mode
+
+## Versioning
+
+**Single source of truth: `pyproject.toml`** (`version = "X.Y.Z"`).
+
+- `src/keboola_agent_cli/__init__.py` reads the version at runtime via `importlib.metadata.version("keboola-agent-cli")`. **Never hardcode a version string in `__init__.py`.**
+- `plugins/kbagent/.claude-plugin/plugin.json` must match. Run `make version-sync` (or `python scripts/sync_version.py`) to update it.
+- The pre-commit hook and CI automatically check version consistency.
+
+**When bumping the version**: only edit `pyproject.toml`, then run `make version-sync`. That's it. Do not edit `__init__.py` or `plugin.json` manually.
 
 ## Coding Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-mcp sync test test-unit test-integration test-file lint lint-fix format format-check skill-check skill-gen check clean hooks
+.PHONY: help install install-mcp sync test test-unit test-integration test-file lint lint-fix format format-check skill-check skill-gen version-sync version-check check clean hooks
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -51,12 +51,25 @@ skill-check: ## Check SKILL.md is up-to-date (fails if stale)
 		exit 1; \
 	fi
 
+version-sync: ## Sync version from pyproject.toml to plugin.json
+	uv run python scripts/sync_version.py
+
+version-check: ## Check plugin.json version matches pyproject.toml (fails if mismatched)
+	@uv run python scripts/sync_version.py > /dev/null 2>&1
+	@if git diff --quiet plugins/kbagent/.claude-plugin/plugin.json; then \
+		echo "plugin.json version is in sync"; \
+	else \
+		echo "ERROR: plugin.json version mismatch. Run 'make version-sync' and commit."; \
+		git diff plugins/kbagent/.claude-plugin/plugin.json; \
+		exit 1; \
+	fi
+
 hooks: ## Install git pre-commit hook (lint + format on staged files)
 	cp scripts/pre-commit .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 	@echo "Pre-commit hook installed."
 
-check: lint format-check skill-check test ## Run all checks (lint + format + skill + test)
+check: lint format-check skill-check version-check test ## Run all checks (lint + format + skill + version + test)
 
 clean: ## Remove build artifacts and caches
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.7.5"
+version = "0.16.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -34,3 +34,13 @@ if [ -f "scripts/generate_skill.py" ]; then
         echo "pre-commit: auto-updated $SKILL_FILE"
     fi
 fi
+
+# Auto-sync plugin.json version from pyproject.toml
+PLUGIN_JSON="plugins/kbagent/.claude-plugin/plugin.json"
+if [ -f "scripts/sync_version.py" ]; then
+    uv run python scripts/sync_version.py > /dev/null 2>&1
+    if ! git diff --quiet "$PLUGIN_JSON" 2>/dev/null; then
+        git add "$PLUGIN_JSON"
+        echo "pre-commit: auto-synced $PLUGIN_JSON version"
+    fi
+fi

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Sync version from pyproject.toml to plugin.json.
+
+Ensures the plugin marketplace version matches the package version.
+Safe to run repeatedly (idempotent).
+
+Usage:
+    python scripts/sync_version.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PLUGIN_JSON = REPO_ROOT / "plugins" / "kbagent" / ".claude-plugin" / "plugin.json"
+
+
+def get_pyproject_version() -> str:
+    """Extract version from pyproject.toml."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: could not find version in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def sync_plugin_json(version: str) -> bool:
+    """Update plugin.json version. Returns True if changed."""
+    data = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    if data.get("version") == version:
+        return False
+    data["version"] = version
+    PLUGIN_JSON.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def main() -> None:
+    version = get_pyproject_version()
+    changed = sync_plugin_json(version)
+    if changed:
+        print(f"Updated plugin.json to {version}")
+    else:
+        print(f"plugin.json already at {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/keboola_agent_cli/__init__.py
+++ b/src/keboola_agent_cli/__init__.py
@@ -1,3 +1,8 @@
 """Keboola Agent CLI - AI-friendly interface to Keboola projects."""
 
-__version__ = "0.16.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("keboola-agent-cli")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.7.5"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `pyproject.toml` is now the **only** place to set the version (was stuck at `0.7.5` while `__init__.py` had `0.16.0`)
- `__init__.py` reads version at runtime via `importlib.metadata`
- `plugin.json` auto-synced by `scripts/sync_version.py`
- Pre-commit hook, CI check, and `make version-check` prevent drift

## How to bump version going forward
1. Edit `version` in `pyproject.toml`
2. Run `make version-sync`
3. Commit

## Test plan
- [x] `uv run python -c "from keboola_agent_cli import __version__; print(__version__)"` → `0.16.0`
- [x] `make version-check` → passes
- [x] 1136 tests pass
- [x] Lint + format clean

Closes #75