### PR TITLE
fix: update AUTO_EXPAND for current MCP server tool names

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -57,7 +57,7 @@ One project failing does not block others. Check the `errors` array:
 
 - **Read tools** (multi_project=true): automatically query all projects. No `--project` needed.
 - **Write tools** (multi_project=false): require `--project` to specify the target.
-- **Auto-expand**: tools like `list_tables` that need `bucket_id` auto-resolve it by calling `list_buckets` first.
+- **Auto-expand**: tools like `get_tables` that need `bucket_ids` auto-resolve them by calling `get_buckets` first.
 - **Input validation**: tool input is validated against the tool's `inputSchema` before dispatch.
   Only pass parameters defined in the schema. Unexpected parameters cause Pydantic validation errors.
 - **Branch scope**: when active branch is set, MCP tools automatically scope to that branch.

--- a/plugins/kbagent/skills/kbagent/references/mcp-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/mcp-workflow.md
@@ -8,7 +8,7 @@ running components, fetching schemas -- through the keboola-mcp-server.
 Every tool has a `multi_project` flag (visible in `tool list` output):
 
 - **multi_project=true** (read tools): Runs across ALL connected projects in parallel.
-  No `--project` needed. Examples: `list_configs`, `list_buckets`, `list_tables`.
+  No `--project` needed. Examples: `get_configs`, `get_buckets`, `get_tables`.
 - **multi_project=false** (write tools): Targets a single project. Requires `--project`
   (or a default project). Examples: `create_config`, `update_configuration`, `run_component`.
 

--- a/src/keboola_agent_cli/services/mcp_service.py
+++ b/src/keboola_agent_cli/services/mcp_service.py
@@ -71,13 +71,13 @@ WRITE_PREFIXES = (
 )
 
 # Tools that auto-expand when a required param is missing.
-# Maps tool_name -> (missing_param, resolve_tool) pairs.
-# When the param is not provided, the resolve_tool is called first,
-# then the target tool is called once per result item.
+# Maps tool_name -> config dict. When the param is absent from user input,
+# the resolve_tool is called first to collect IDs, then the target tool
+# is called once with all resolved IDs as an array.
 AUTO_EXPAND_TOOLS = {
-    "list_tables": {
-        "param": "bucket_id",
-        "resolve_tool": "list_buckets",
+    "get_tables": {
+        "param": "bucket_ids",
+        "resolve_tool": "get_buckets",
         "resolve_key": "id",
     },
 }
@@ -650,23 +650,17 @@ async def _http_auto_expand(
             if not item_ids:
                 return {"content": [], "isError": False}
 
-            # Step 2: Call target tool for each resolved ID
-            all_content: list[Any] = []
-            has_error = False
+            # Step 2: Call target tool with all resolved IDs as array
+            call_input = {**tool_input, param_name: list(item_ids)}
+            result = await asyncio.wait_for(
+                session.call_tool(tool_name, call_input),
+                timeout=_get_tool_timeout(),
+            )
 
-            for item_id in item_ids:
-                call_input = {**tool_input, param_name: item_id}
-                result = await asyncio.wait_for(
-                    session.call_tool(tool_name, call_input),
-                    timeout=_get_tool_timeout(),
-                )
-
-                content = _parse_content(result)
-                if result.isError:
-                    has_error = True
-                all_content.extend(content)
-
-            return {"content": all_content, "isError": has_error}
+            return {
+                "content": _parse_content(result),
+                "isError": bool(result.isError),
+            }
 
 
 async def _connect_and_auto_expand(
@@ -683,7 +677,7 @@ async def _connect_and_auto_expand(
 
     Args:
         project: Project config.
-        tool_name: Target tool name (e.g. "list_tables").
+        tool_name: Target tool name (e.g. "get_tables").
         tool_input: Base input for the target tool (without the auto-expanded param).
         expand_config: Dict with "param", "resolve_tool", "resolve_key".
         branch_id: Optional development branch ID.
@@ -700,7 +694,7 @@ async def _connect_and_auto_expand(
     try:
         session = await _open_session(project, exit_stack, branch_id=branch_id)
 
-        # Step 1: Call resolve tool (e.g. list_buckets)
+        # Step 1: Call resolve tool (e.g. get_buckets)
         resolve_result = await asyncio.wait_for(
             session.call_tool(resolve_tool, {}),
             timeout=_get_tool_timeout(),
@@ -719,36 +713,70 @@ async def _connect_and_auto_expand(
         if not item_ids:
             return {"content": [], "isError": False}
 
-        # Step 2: Call target tool for each resolved ID
-        all_content: list[Any] = []
-        has_error = False
+        # Step 2: Call target tool with all resolved IDs as array
+        call_input = {**tool_input, param_name: list(item_ids)}
+        result = await asyncio.wait_for(
+            session.call_tool(tool_name, call_input),
+            timeout=_get_tool_timeout(),
+        )
 
-        for item_id in item_ids:
-            call_input = {**tool_input, param_name: item_id}
-            result = await asyncio.wait_for(
-                session.call_tool(tool_name, call_input),
-                timeout=_get_tool_timeout(),
-            )
-
-            content = _parse_content(result)
-            if result.isError:
-                has_error = True
-            all_content.extend(content)
-
-        return {"content": all_content, "isError": has_error}
+        return {
+            "content": _parse_content(result),
+            "isError": bool(result.isError),
+        }
     finally:
         await exit_stack.aclose()
+
+
+def _extract_ids_from_toon(text: str, key: str) -> list[str]:
+    """Extract ID values from a TOON-formatted string.
+
+    Parses TOON array headers like ``items[N]{field1,field2,...}:`` to find
+    the column position of *key*, then reads each indented data line using
+    CSV parsing (handles quoted values with commas).
+    """
+    import csv
+    import io
+    import re
+
+    ids: list[str] = []
+    header_re = re.compile(r"\w+\[\d+\]\{([^}]+)\}:")
+    field_index: int | None = None
+
+    for line in text.split("\n"):
+        m = header_re.search(line)
+        if m:
+            fields = [f.strip() for f in m.group(1).split(",")]
+            try:
+                field_index = fields.index(key)
+            except ValueError:
+                field_index = None
+            continue
+
+        if field_index is not None and line.startswith("  "):
+            stripped = line.strip()
+            if stripped:
+                try:
+                    values = next(csv.reader(io.StringIO(stripped)))
+                    if len(values) > field_index:
+                        ids.append(values[field_index])
+                except Exception:
+                    pass
+
+    return ids
 
 
 def _extract_ids(content_items: list[Any], key: str) -> list[str]:
     """Extract unique ID values from parsed MCP tool content.
 
-    Handles both list-of-dicts format and single-dict-with-list format.
+    Handles JSON dicts/lists **and** TOON-formatted text strings.
     Deduplicates while preserving insertion order.
     """
-    ids = []
+    ids: list[str] = []
     for item in content_items:
-        if isinstance(item, list):
+        if isinstance(item, str):
+            ids.extend(_extract_ids_from_toon(item, key))
+        elif isinstance(item, list):
             for sub in item:
                 if isinstance(sub, dict) and key in sub:
                     ids.append(str(sub[key]))

--- a/tests/test_mcp_service.py
+++ b/tests/test_mcp_service.py
@@ -14,6 +14,7 @@ from keboola_agent_cli.services.mcp_service import (
     McpService,
     _build_server_params,
     _extract_ids,
+    _extract_ids_from_toon,
     _get_max_sessions,
     _is_write_tool,
     _semaphored,
@@ -981,6 +982,67 @@ class TestExtractIdsDeduplication:
         ]
         result = _extract_ids(content, "id")
         assert result == ["x", "y"]
+
+
+# ---------------------------------------------------------------------------
+# TestExtractIdsFromToon
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIdsFromToon:
+    """Tests for _extract_ids_from_toon() TOON format parsing."""
+
+    def test_parse_bucket_ids(self) -> None:
+        """Extracts bucket IDs from a real TOON get_buckets response."""
+        toon = (
+            "buckets[3]{id,name,display_name,stage,created,data_size_bytes,source_project}:\n"
+            '  in.c-STG_Telemetry,c-STG_Telemetry,STG_Telemetry,in,"2026-03-24T13:41:37+0100",0,"Source (ID: 2741)"\n'
+            '  in.c-STG_Ownership,c-STG_Ownership,STG_Ownership,in,"2026-03-24T13:41:32+0100",0,"Source (ID: 2741)"\n'
+            '  out.c-OUT_Report,c-OUT_Report,OUT_Report,out,"2026-03-19T17:49:02+0100",1376477583,null\n'
+            "links[1]{type,title,url}:\n"
+            '  ui-dashboard,Buckets in the project,"https://example.com/storage"'
+        )
+        result = _extract_ids_from_toon(toon, "id")
+        assert result == ["in.c-STG_Telemetry", "in.c-STG_Ownership", "out.c-OUT_Report"]
+
+    def test_parse_different_key(self) -> None:
+        """Extracts values from a non-first column."""
+        toon = "items[2]{id,name,status}:\n  abc,My Item,active\n  def,Other Item,disabled\n"
+        assert _extract_ids_from_toon(toon, "name") == ["My Item", "Other Item"]
+        assert _extract_ids_from_toon(toon, "status") == ["active", "disabled"]
+
+    def test_key_not_in_header(self) -> None:
+        """Returns empty list when key is not in the TOON header."""
+        toon = "items[1]{id,name}:\n  x,foo\n"
+        assert _extract_ids_from_toon(toon, "missing") == []
+
+    def test_empty_array(self) -> None:
+        """Handles TOON with zero items."""
+        toon = "tables[0]:\nlinks[1]{type,title,url}:\n  ui-dashboard,Dashboard,https://x.com\n"
+        assert _extract_ids_from_toon(toon, "id") == []
+
+    def test_quoted_values_with_commas(self) -> None:
+        """Handles CSV-quoted values that contain commas."""
+        toon = 'items[1]{id,description}:\n  bucket-1,"Has commas, inside quotes"\n'
+        result = _extract_ids_from_toon(toon, "id")
+        assert result == ["bucket-1"]
+        desc = _extract_ids_from_toon(toon, "description")
+        assert desc == ["Has commas, inside quotes"]
+
+    def test_extract_ids_delegates_to_toon(self) -> None:
+        """_extract_ids handles string items by delegating to TOON parser."""
+        toon = "buckets[2]{id,name}:\n  b1,Bucket One\n  b2,Bucket Two\n"
+        result = _extract_ids([toon], "id")
+        assert result == ["b1", "b2"]
+
+    def test_extract_ids_mixed_formats(self) -> None:
+        """_extract_ids handles mix of TOON strings and JSON dicts."""
+        items: list = [
+            "items[1]{id,name}:\n  toon-id,TOON Item\n",
+            {"id": "dict-id", "name": "Dict Item"},
+        ]
+        result = _extract_ids(items, "id")
+        assert result == ["toon-id", "dict-id"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **AUTO_EXPAND_TOOLS** referenced non-existent MCP tools (`list_tables`, `list_buckets`) and wrong param name (`bucket_id`). Updated to `get_tables`, `get_buckets`, `bucket_ids` to match keboola-mcp-server v1.48+.
- Added TOON format parsing to `_extract_ids()` — MCP server now returns TOON-serialized responses instead of JSON, so the old JSON-only parser always returned empty results.
- Auto-expand now batches all bucket IDs into a single `get_tables` call instead of N per-bucket calls.

## Test plan
- [x] `kbagent tool call get_tables` (no params) auto-expands via `get_buckets` and returns all tables
- [x] `kbagent tool call get_tables --input '{"bucket_ids": ["out.c-XXX"]}'` still works (no auto-expand)
- [x] 84 unit tests pass (7 new for TOON parsing)
- [x] Lint + format clean