### PR TITLE
v0.16.1: fix AUTO_EXPAND for MCP tool names, version source of truth

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.16.0"
+version = "0.16.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
Patch release with two fixes since v0.16.0:

- **#77** — AUTO_EXPAND_TOOLS referenced non-existent MCP tools (`list_tables`/`list_buckets`) and wrong param (`bucket_id`). Updated to `get_tables`/`get_buckets`/`bucket_ids`. Added TOON format parsing and batched auto-expand into single call.
- **#76** — Single source of truth for version in `pyproject.toml` (removed hardcoded string from `__init__.py`).

## Test plan
- [x] `kbagent tool call get_tables` (no params) auto-expands correctly
- [x] 84 MCP service tests pass (7 new for TOON parsing)
- [x] `make check` clean
- [x] `make version-sync` confirms plugin.json matches