### PR TITLE
fix: script array format and writeback pollution

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -90,6 +90,43 @@ Workaround for large refactors (e.g. removing `AS` from 200 table aliases):
 2. Call `update_sql_transformation` once per batch
 3. Verify each batch succeeded before sending the next
 
+## SQL transformation file layout
+
+When creating or editing SQL transformations via sync, SQL code must go in
+`transform.sql`, NOT in `_config.yml`. The `_config.yml` for transformations
+should have `parameters: {}` (empty).
+
+**Wrong** -- putting SQL in `_config.yml` parameters:
+```yaml
+# DO NOT DO THIS -- SQL will be split per line and each line executed separately
+parameters:
+  blocks:
+    - name: Block 1
+      codes:
+        - name: Code 1
+          script:
+            - CREATE TABLE foo AS
+            - "    SELECT col1"
+            - "    FROM bar;"
+```
+
+**Correct** -- SQL in `transform.sql`, config has empty parameters:
+```yaml
+# _config.yml
+parameters: {}
+```
+```sql
+-- transform.sql
+/* ===== BLOCK: Block 1 ===== */
+
+/* ===== CODE: Code 1 ===== */
+CREATE TABLE foo AS
+    SELECT col1
+    FROM bar;
+```
+
+See `scaffold-workflow.md` for the complete file structure reference.
+
 ## Common mistakes
 
 - **Forgetting `--json`**: without it, output is human-formatted Rich text, not parseable
@@ -97,3 +134,4 @@ Workaround for large refactors (e.g. removing `AS` from 200 table aliases):
 - **Passing manage token as argument**: use env var `KBC_MANAGE_API_TOKEN` instead
 - **Polling after branch create**: kbagent already waits for async completion
 - **Not saving workspace password**: only returned once on creation
+- **Putting SQL in _config.yml**: SQL transformations must use `transform.sql` with block markers (see above)

--- a/plugins/kbagent/skills/kbagent/references/scaffold-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/scaffold-workflow.md
@@ -63,6 +63,63 @@ This automatically:
 - Creates the configuration in Keboola and gets a config_id
 - Writes back encrypted values + config_id to local `_config.yml`
 
+## SQL transformation file structure
+
+SQL transformations use a two-file layout. **SQL code lives ONLY in `transform.sql`,
+never in `_config.yml`.**
+
+```
+my-transformation/
+  _config.yml      # metadata + parameters: {} (empty! no blocks here)
+  transform.sql    # all SQL code with block/code markers
+```
+
+### _config.yml for SQL transformations
+
+```yaml
+version: 2
+name: My Transformation
+description: ''
+parameters: {}          # MUST be empty -- blocks are in transform.sql
+output:
+  tables:
+  - source: out_table
+    destination: out.c-bucket.table
+_keboola:
+  component_id: keboola.snowflake-transformation
+```
+
+### transform.sql format
+
+SQL is organized into blocks and codes using marker comments:
+
+```sql
+/* ===== BLOCK: Staging ===== */
+
+/* ===== CODE: Create staging table ===== */
+CREATE TABLE "staging" AS
+    SELECT *
+    FROM "raw_data"
+    WHERE "active" = true;
+
+/* ===== BLOCK: Output ===== */
+
+/* ===== CODE: Final output ===== */
+CREATE TABLE "out_result" AS
+    SELECT
+        "id",
+        "name",
+        SUM("amount") AS "total"
+    FROM "staging"
+    GROUP BY "id", "name";
+```
+
+Rules:
+- Each `/* ===== BLOCK: Name ===== */` starts a new block
+- Each `/* ===== CODE: Name ===== */` starts a new code section within the current block
+- Multi-line SQL is fine -- the entire code section is sent as one statement
+- If no markers are present, the whole file is treated as a single block/code
+
 ## Important notes
 
 - `_config.yml` format follows the kbc CLI dev-friendly YAML structure

--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -4,6 +4,7 @@ Handles downloading Keboola project configurations to the local filesystem
 in a dev-friendly format (YAML configs), and tracking local changes.
 """
 
+import copy
 import hashlib
 import json
 import logging
@@ -1004,6 +1005,11 @@ class SyncService(BaseService):
         if local_data is None:
             return None
 
+        # Preserve pristine data for writeback (merge_code_files mutates
+        # local_data by injecting parameters.blocks which should not end
+        # up in _config.yml).
+        pristine_data = copy.deepcopy(local_data)
+
         # Merge code files (transform.sql, transform.py, code.py) back into config
         merge_code_files(component_id, local_data, config_dir)
 
@@ -1030,8 +1036,9 @@ class SyncService(BaseService):
             new_config_id,
         )
 
-        # Write back: update local file with config_id + encrypted secrets
-        self._writeback_after_push(local_data, config_dir, new_config_id, configuration)
+        # Write back: update local file with config_id + encrypted secrets.
+        # Use pristine_data so blocks/code stay only in their code files.
+        self._writeback_after_push(pristine_data, config_dir, new_config_id, configuration)
 
         return result
 
@@ -1051,6 +1058,11 @@ class SyncService(BaseService):
         local_data = self._read_config_file(config_dir)
         if local_data is None:
             raise FileNotFoundError(f"Config file not found: {config_dir / CONFIG_FILENAME}")
+
+        # Preserve pristine data for writeback (merge_code_files mutates
+        # local_data by injecting parameters.blocks which should not end
+        # up in _config.yml).
+        pristine_data = copy.deepcopy(local_data)
 
         # Merge code files (transform.sql, transform.py, code.py) back into config
         merge_code_files(component_id, local_data, config_dir)
@@ -1074,8 +1086,9 @@ class SyncService(BaseService):
         )
         logger.info("Updated config %s/%s", component_id, config_id)
 
-        # Write back: update local file with encrypted secrets
-        self._writeback_after_push(local_data, config_dir, config_id, configuration)
+        # Write back: update local file with encrypted secrets.
+        # Use pristine_data so blocks/code stay only in their code files.
+        self._writeback_after_push(pristine_data, config_dir, config_id, configuration)
 
     def _writeback_after_push(
         self,

--- a/src/keboola_agent_cli/sync/code_extraction.py
+++ b/src/keboola_agent_cli/sync/code_extraction.py
@@ -18,6 +18,20 @@ def _strip_trailing_empty(lines: list[str]) -> list[str]:
     return result
 
 
+def _lines_to_script(lines: list[str]) -> list[str]:
+    """Convert collected lines into a single-string script element.
+
+    The Keboola transformation runner treats each element of the ``script``
+    array as a separate executable statement.  Joining all lines of a CODE
+    block into one string ensures multi-line SQL/Python is executed as a
+    single unit.
+    """
+    stripped = _strip_trailing_empty(lines)
+    if not stripped:
+        return []
+    return ["\n".join(stripped)]
+
+
 # Component patterns that contain SQL transformations
 SQL_TRANSFORMATION_COMPONENTS: set[str] = {
     "keboola.snowflake-transformation",
@@ -170,7 +184,7 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
         if stripped.startswith("/* ===== BLOCK:") and stripped.endswith("===== */"):
             # Save previous code if any
             if current_code is not None and current_block is not None:
-                current_code["script"] = _strip_trailing_empty(current_script_lines)
+                current_code["script"] = _lines_to_script(current_script_lines)
                 current_block.setdefault("codes", []).append(current_code)
                 current_code = None
                 current_script_lines = []
@@ -184,7 +198,7 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
         if stripped.startswith("/* ===== CODE:") and stripped.endswith("===== */"):
             # Save previous code if any
             if current_code is not None and current_block is not None:
-                current_code["script"] = _strip_trailing_empty(current_script_lines)
+                current_code["script"] = _lines_to_script(current_script_lines)
                 current_block.setdefault("codes", []).append(current_code)
                 current_script_lines = []
 
@@ -198,7 +212,7 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
 
     # Don't forget the last code block
     if current_code is not None and current_block is not None:
-        current_code["script"] = _strip_trailing_empty(current_script_lines)
+        current_code["script"] = _lines_to_script(current_script_lines)
         current_block.setdefault("codes", []).append(current_code)
 
     # If no markers found, treat entire content as single block/code
@@ -206,7 +220,7 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
         blocks = [
             {
                 "name": "Block 1",
-                "codes": [{"name": "Code 1", "script": _strip_trailing_empty(content.split("\n"))}],
+                "codes": [{"name": "Code 1", "script": _lines_to_script(content.split("\n"))}],
             }
         ]
 
@@ -287,7 +301,7 @@ def _parse_python_blocks(content: str) -> list[dict[str, Any]]:
 
         if stripped.startswith("# ===== BLOCK:") and stripped.endswith("====="):
             if current_code is not None and current_block is not None:
-                current_code["script"] = _strip_trailing_empty(current_script_lines)
+                current_code["script"] = _lines_to_script(current_script_lines)
                 current_block.setdefault("codes", []).append(current_code)
                 current_code = None
                 current_script_lines = []
@@ -299,7 +313,7 @@ def _parse_python_blocks(content: str) -> list[dict[str, Any]]:
 
         if stripped.startswith("# ===== CODE:") and stripped.endswith("====="):
             if current_code is not None and current_block is not None:
-                current_code["script"] = _strip_trailing_empty(current_script_lines)
+                current_code["script"] = _lines_to_script(current_script_lines)
                 current_block.setdefault("codes", []).append(current_code)
                 current_script_lines = []
 
@@ -311,14 +325,14 @@ def _parse_python_blocks(content: str) -> list[dict[str, Any]]:
             current_script_lines.append(line)
 
     if current_code is not None and current_block is not None:
-        current_code["script"] = _strip_trailing_empty(current_script_lines)
+        current_code["script"] = _lines_to_script(current_script_lines)
         current_block.setdefault("codes", []).append(current_code)
 
     if not blocks and content.strip():
         blocks = [
             {
                 "name": "Block 1",
-                "codes": [{"name": "Code 1", "script": _strip_trailing_empty(content.split("\n"))}],
+                "codes": [{"name": "Code 1", "script": _lines_to_script(content.split("\n"))}],
             }
         ]
 

--- a/src/keboola_agent_cli/sync/config_format.py
+++ b/src/keboola_agent_cli/sync/config_format.py
@@ -20,8 +20,11 @@ def _normalize_scripts(parameters: Any) -> Any:
     - ``["line1", "line2", ...]`` (per-line array)
     - ``["full\\ncode\\nwith\\nnewlines"]`` (single multiline string)
 
-    This normalizes to per-line format so that local merge (which always
-    produces per-line) and remote data compare identically.
+    This normalizes to single-string-per-code-block format so that local
+    merge (which produces single-string via ``_lines_to_script``) and
+    remote data compare identically.  The Keboola transformation runner
+    treats each array element as a separate executable statement, so each
+    CODE block must be a single joined string.
     """
     if not isinstance(parameters, dict):
         return parameters
@@ -34,18 +37,20 @@ def _normalize_scripts(parameters: Any) -> Any:
                 continue
             scripts = code.get("script")
             if isinstance(scripts, list) and scripts:
-                normalized: list[str] = []
+                # Flatten everything into individual lines first.
+                all_lines: list[str] = []
                 for s in scripts:
                     if isinstance(s, str) and "\n" in s:
-                        normalized.extend(s.split("\n"))
+                        all_lines.extend(s.split("\n"))
                     else:
-                        normalized.append(s)
+                        all_lines.append(s)
                 # Strip trailing whitespace per line (YAML roundtrip
                 # strips it) and remove trailing empty lines.
-                normalized = [line.rstrip() for line in normalized]
-                while normalized and normalized[-1] == "":
-                    normalized.pop()
-                code["script"] = normalized
+                all_lines = [line.rstrip() for line in all_lines]
+                while all_lines and all_lines[-1] == "":
+                    all_lines.pop()
+                # Join into a single string per code block.
+                code["script"] = ["\n".join(all_lines)] if all_lines else []
     return params
 
 

--- a/tests/test_sync_code_extraction.py
+++ b/tests/test_sync_code_extraction.py
@@ -225,7 +225,110 @@ class TestSqlExtraction:
         assert len(blocks) == 1
         assert blocks[0]["name"] == "Block 1"
         assert blocks[0]["codes"][0]["name"] == "Code 1"
-        assert "SELECT 1;" in blocks[0]["codes"][0]["script"][0]
+        script = blocks[0]["codes"][0]["script"]
+        # Must be a single joined string, not per-line
+        assert len(script) == 1
+        assert "SELECT 1;" in script[0]
+        assert "SELECT 2;" in script[0]
+
+    def test_multiline_sql_produces_single_string(self, tmp_path: Path) -> None:
+        """Multi-line SQL statement is joined into a single script element."""
+        config_dir = tmp_path / "sql-multiline"
+        config_dir.mkdir(parents=True)
+
+        sql_content = (
+            "/* ===== BLOCK: ETL ===== */\n"
+            "\n"
+            "/* ===== CODE: Create table ===== */\n"
+            "CREATE TABLE foo AS\n"
+            "    SELECT col1,\n"
+            "           col2\n"
+            "    FROM bar\n"
+            "    WHERE active = true;\n"
+        )
+        (config_dir / "transform.sql").write_text(sql_content, encoding="utf-8")
+
+        config_data: dict = {"parameters": {}}
+        result = merge_code_files("keboola.snowflake-transformation", config_data, config_dir)
+
+        blocks = result["parameters"]["blocks"]
+        script = blocks[0]["codes"][0]["script"]
+        # Must be exactly one element (not one per line)
+        assert len(script) == 1
+        # Must contain newlines (multi-line preserved)
+        assert "\n" in script[0]
+        # Must contain the full statement
+        assert "CREATE TABLE foo AS" in script[0]
+        assert "FROM bar" in script[0]
+        assert "WHERE active = true;" in script[0]
+
+    def test_multiline_sql_round_trip(self, tmp_path: Path) -> None:
+        """Round-trip with multi-line statements preserves SQL integrity."""
+        config_data = {
+            "parameters": {
+                "blocks": [
+                    {
+                        "name": "ETL",
+                        "codes": [
+                            {
+                                "name": "Create",
+                                "script": ["CREATE TABLE foo AS\n    SELECT col1\n    FROM bar;"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        config_dir = tmp_path / "sql-multiline-rt"
+
+        extract_code_files("keboola.snowflake-transformation", config_data, config_dir)
+        assert "blocks" not in config_data["parameters"]
+
+        merge_code_files("keboola.snowflake-transformation", config_data, config_dir)
+
+        script = config_data["parameters"]["blocks"][0]["codes"][0]["script"]
+        assert len(script) == 1
+        assert script[0] == "CREATE TABLE foo AS\n    SELECT col1\n    FROM bar;"
+
+    def test_empty_code_block(self, tmp_path: Path) -> None:
+        """Empty CODE block produces an empty script list."""
+        config_dir = tmp_path / "sql-empty-code"
+        config_dir.mkdir(parents=True)
+
+        sql_content = (
+            "/* ===== BLOCK: ETL ===== */\n"
+            "\n"
+            "/* ===== CODE: Empty ===== */\n"
+            "\n"
+            "/* ===== CODE: Has content ===== */\n"
+            "SELECT 1;\n"
+        )
+        (config_dir / "transform.sql").write_text(sql_content, encoding="utf-8")
+
+        config_data: dict = {"parameters": {}}
+        result = merge_code_files("keboola.snowflake-transformation", config_data, config_dir)
+
+        codes = result["parameters"]["blocks"][0]["codes"]
+        assert len(codes) == 2
+        assert codes[0]["name"] == "Empty"
+        assert codes[0]["script"] == []
+        assert codes[1]["name"] == "Has content"
+        assert codes[1]["script"] == ["SELECT 1;"]
+
+    def test_whitespace_only_code_block(self, tmp_path: Path) -> None:
+        """Whitespace-only CODE block produces an empty script list."""
+        config_dir = tmp_path / "sql-ws-code"
+        config_dir.mkdir(parents=True)
+
+        sql_content = "/* ===== BLOCK: ETL ===== */\n\n/* ===== CODE: Spaces ===== */\n   \n  \n\n"
+        (config_dir / "transform.sql").write_text(sql_content, encoding="utf-8")
+
+        config_data: dict = {"parameters": {}}
+        result = merge_code_files("keboola.snowflake-transformation", config_data, config_dir)
+
+        codes = result["parameters"]["blocks"][0]["codes"]
+        assert codes[0]["name"] == "Spaces"
+        assert codes[0]["script"] == []
 
 
 # ===================================================================
@@ -318,6 +421,32 @@ class TestPythonTransformExtraction:
         result = merge_code_files("keboola.python-transformation-v2", config_data, config_dir)
 
         assert result["parameters"]["packages"] == ["pandas==2.1.0", "numpy>=1.24"]
+
+    def test_multiline_python_produces_single_string(self, tmp_path: Path) -> None:
+        """Multi-line Python code is joined into a single script element."""
+        config_dir = tmp_path / "py-multiline"
+        config_dir.mkdir(parents=True)
+
+        py_content = (
+            "# ===== BLOCK: Analysis =====\n"
+            "\n"
+            "# ===== CODE: Process =====\n"
+            "import pandas as pd\n"
+            "\n"
+            "df = pd.read_csv('data.csv')\n"
+            "result = df.groupby('category').sum()\n"
+        )
+        (config_dir / "transform.py").write_text(py_content, encoding="utf-8")
+
+        config_data: dict = {"parameters": {}}
+        result = merge_code_files("keboola.python-transformation-v2", config_data, config_dir)
+
+        blocks = result["parameters"]["blocks"]
+        script = blocks[0]["codes"][0]["script"]
+        assert len(script) == 1
+        assert "import pandas as pd" in script[0]
+        assert "result = df.groupby" in script[0]
+        assert "\n" in script[0]
 
     def test_python_transform_round_trip(self, tmp_path: Path) -> None:
         """Extract then merge produces equivalent blocks and packages."""

--- a/tests/test_sync_config_format.py
+++ b/tests/test_sync_config_format.py
@@ -3,6 +3,7 @@
 import pytest
 
 from keboola_agent_cli.sync.config_format import (
+    _normalize_scripts,
     api_config_to_local,
     api_row_to_local,
     classify_component_type,
@@ -165,6 +166,68 @@ class TestLocalConfigToApiRoundTrip:
 
         assert configuration["runtime"] == {"imageTag": "latest"}
         assert configuration["parameters"] == {"key": "val"}
+
+
+class TestNormalizeScripts:
+    """Tests for _normalize_scripts() -- script array normalization."""
+
+    def test_per_line_array_joined_to_single_string(self) -> None:
+        """Per-line script array is joined into a single string."""
+        params = {
+            "blocks": [
+                {"codes": [{"script": ["CREATE TABLE foo AS", "    SELECT col1", "    FROM bar;"]}]}
+            ]
+        }
+        result = _normalize_scripts(params)
+        script = result["blocks"][0]["codes"][0]["script"]
+        assert len(script) == 1
+        assert script[0] == "CREATE TABLE foo AS\n    SELECT col1\n    FROM bar;"
+
+    def test_single_multiline_string_preserved(self) -> None:
+        """A script that is already a single multiline string stays as one element."""
+        params = {
+            "blocks": [
+                {"codes": [{"script": ["CREATE TABLE foo AS\n    SELECT col1\n    FROM bar;"]}]}
+            ]
+        }
+        result = _normalize_scripts(params)
+        script = result["blocks"][0]["codes"][0]["script"]
+        assert len(script) == 1
+        assert script[0] == "CREATE TABLE foo AS\n    SELECT col1\n    FROM bar;"
+
+    def test_trailing_whitespace_stripped(self) -> None:
+        """Trailing whitespace per line is stripped during normalization."""
+        params = {"blocks": [{"codes": [{"script": ["SELECT 1  ", "FROM bar   "]}]}]}
+        result = _normalize_scripts(params)
+        script = result["blocks"][0]["codes"][0]["script"]
+        assert len(script) == 1
+        assert script[0] == "SELECT 1\nFROM bar"
+
+    def test_empty_script_preserved(self) -> None:
+        """Empty script array stays empty."""
+        params = {"blocks": [{"codes": [{"script": []}]}]}
+        result = _normalize_scripts(params)
+        assert result["blocks"][0]["codes"][0]["script"] == []
+
+    def test_no_blocks_passthrough(self) -> None:
+        """Parameters without blocks are returned unchanged."""
+        params = {"key": "value"}
+        result = _normalize_scripts(params)
+        assert result == {"key": "value"}
+
+    def test_non_dict_passthrough(self) -> None:
+        """Non-dict input is returned as-is."""
+        assert _normalize_scripts("not a dict") == "not a dict"
+        assert _normalize_scripts(42) == 42
+
+    def test_does_not_mutate_input(self) -> None:
+        """Original parameters are not mutated."""
+        params = {"blocks": [{"codes": [{"script": ["line1", "line2"]}]}]}
+        import copy
+
+        original = copy.deepcopy(params)
+        _normalize_scripts(params)
+        assert params == original
 
 
 class TestRowConversion:


### PR DESCRIPTION
## Summary

- **Script array bug**: `_parse_sql_blocks()` produced one element per LINE in the `script` array. The Keboola transformation runner treats each element as a separate SQL statement, so multi-line SQL failed with `unexpected '<EOF>'` errors. Fixed by joining all lines of each CODE block into a single string.
- **Writeback pollution**: After push, `_writeback_after_push()` wrote SQL blocks back into `_config.yml` (because `merge_code_files()` mutated `local_data` in place). Fixed by deep-copying before merge and using pristine data for writeback.
- **Documentation gap**: Added SQL transformation file structure docs to `scaffold-workflow.md` and a gotcha about SQL belonging in `transform.sql`, not `_config.yml`.

## Root cause

Discovered by analyzing a colleague's Claude Code session where creating a unified SQL transformation via `sync push` repeatedly failed. Claude iterated 4 times on SQL syntax fixes but the real problem was in the transport layer -- how script arrays were formatted for the API.

## Test plan

- [x] 13 new unit tests (multiline SQL/Python, empty/whitespace blocks, round-trips, normalize)
- [x] All 1155 existing tests pass (`make check`)
- [x] E2E test via CLI: `sync push` + `run_job` on real Keboola project -- transformation ran successfully
- [x] Verified `_config.yml` stays clean after push (no blocks/SQL code)