### PR TITLE
v0.16.2: fix script array format, writeback pollution, add sync docs

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.16.1"
+version = "0.16.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Version bump to 0.16.2 for release.

See #80 for the full changeset:
- Fix SQL/Python script array format (join lines per CODE block)
- Fix writeback pollution (_config.yml no longer gets SQL blocks)
- Fix _normalize_scripts for correct diff comparison
- Add SQL transformation file structure docs to plugin skill
- 13 new tests, E2E verified on real Keboola project