### PR TITLE
feat: add --branch flag to config list/detail/search

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -186,20 +186,26 @@ class KeboolaClient(BaseHttpClient):
             default_backend=owner.get("defaultBackend", "snowflake"),
         )
 
-    def list_components(self, component_type: str | None = None) -> list[dict[str, Any]]:
+    def list_components(
+        self,
+        component_type: str | None = None,
+        branch_id: int | None = None,
+    ) -> list[dict[str, Any]]:
         """List components with their configurations.
 
         Args:
             component_type: Optional filter (extractor, writer, transformation, application).
+            branch_id: If set, list components from a specific dev branch.
 
         Returns:
             List of component dicts from the API.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         params: dict[str, str] = {"include": "configuration"}
         if component_type:
             params["componentType"] = component_type
 
-        response = self._request("GET", "/v2/storage/components", params=params)
+        response = self._request("GET", f"{prefix}/components", params=params)
         return response.json()
 
     def list_components_with_configs(self, branch_id: int | None = None) -> list[dict[str, Any]]:
@@ -268,21 +274,28 @@ class KeboolaClient(BaseHttpClient):
         )
         return resp.json()
 
-    def get_config_detail(self, component_id: str, config_id: str) -> dict[str, Any]:
+    def get_config_detail(
+        self,
+        component_id: str,
+        config_id: str,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
         """Get detailed information about a specific configuration.
 
         Args:
             component_id: The component ID (e.g. keboola.ex-db-snowflake).
             config_id: The configuration ID.
+            branch_id: If set, get detail from a specific dev branch.
 
         Returns:
             Configuration detail dict from the API.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_component_id = quote(component_id, safe="")
         safe_config_id = quote(config_id, safe="")
         response = self._request(
             "GET",
-            f"/v2/storage/components/{safe_component_id}/configs/{safe_config_id}",
+            f"{prefix}/components/{safe_component_id}/configs/{safe_config_id}",
         )
         return response.json()
 

--- a/src/keboola_agent_cli/commands/_helpers.py
+++ b/src/keboola_agent_cli/commands/_helpers.py
@@ -4,12 +4,14 @@ Provides common patterns used by all CLI commands:
 - Context extraction (formatter, services)
 - Exit code mapping for API errors
 - Warning emission for multi-project operations
+- Branch resolution for --branch flag
 """
 
 from typing import Any
 
 import typer
 
+from ..config_store import ConfigStore
 from ..errors import KeboolaApiError
 from ..output import OutputFormatter
 
@@ -49,3 +51,77 @@ def emit_project_warnings(formatter: OutputFormatter, result: dict) -> None:
         alias = err.get("project_alias", "unknown")
         message = err.get("message", "Unknown error")
         formatter.warning(f"Project '{alias}': {message}")
+
+
+def validate_branch_requires_project(
+    formatter: OutputFormatter,
+    branch: int | None,
+    project: str | None,
+) -> None:
+    """Validate that --branch is always accompanied by --project.
+
+    Raises:
+        typer.Exit: With code 2 if branch is set but project is not.
+    """
+    if branch is not None and not project:
+        formatter.error(
+            message="--branch requires --project (branch ID is per-project)",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2) from None
+
+
+def resolve_branch(
+    config_store: ConfigStore,
+    formatter: OutputFormatter,
+    project: str | None,
+    branch: int | None,
+) -> tuple[str | None, int | None]:
+    """Resolve the effective branch and project.
+
+    Resolution order:
+    1. Explicit --branch always wins (no change)
+    2. If no --branch, check active_branch_id from config for the resolved project
+    3. If active branch found, use it and print info message in human mode
+
+    When an active branch is resolved from config, --project is also set
+    to the project alias (branch is per-project).
+
+    Args:
+        config_store: Config store for looking up project configs.
+        formatter: Output formatter for info messages.
+        project: Explicit --project alias or None.
+        branch: Explicit --branch integer or None.
+
+    Returns:
+        Tuple of (effective_project, effective_branch_id).
+    """
+    if branch is not None:
+        return project, branch
+
+    if project is not None:
+        proj_config = config_store.get_project(project)
+        if proj_config and proj_config.active_branch_id is not None:
+            if not formatter.json_mode:
+                formatter.err_console.print(
+                    f"[bold blue]Info:[/bold blue] Using active branch "
+                    f"(ID: {proj_config.active_branch_id}) for project '{project}'"
+                )
+            return project, proj_config.active_branch_id
+    else:
+        config = config_store.load()
+        active_projects = [
+            (alias, proj)
+            for alias, proj in config.projects.items()
+            if proj.active_branch_id is not None
+        ]
+        if len(active_projects) == 1:
+            alias, proj = active_projects[0]
+            if not formatter.json_mode:
+                formatter.err_console.print(
+                    f"[bold blue]Info:[/bold blue] Using active branch "
+                    f"(ID: {proj.active_branch_id}) for project '{alias}'"
+                )
+            return alias, proj.active_branch_id
+
+    return project, None

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -12,10 +12,17 @@ from pathlib import Path
 import typer
 from rich.syntax import Syntax
 
+from ..config_store import ConfigStore
 from ..constants import KEBOOLA_DIR_NAME, MANIFEST_FILENAME, VALID_COMPONENT_TYPES
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_config_detail, format_configs_table, format_search_results
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+    resolve_branch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +76,35 @@ def config_list(
         "--component-id",
         help="Filter by specific component ID (e.g. keboola.ex-db-snowflake)",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="List configs from a specific dev branch ID (defaults to active branch)",
+    ),
 ) -> None:
-    """List configurations from connected projects."""
+    """List configurations from connected projects.
+
+    If a dev branch is active (via 'branch use'), configs from that branch
+    are listed. Use --branch to override.
+    """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "config_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+
+    # --branch requires --project (branch ID is per-project)
+    # For list with multiple projects, only validate if explicit --branch given
+    if branch is not None and (not project or len(project) != 1):
+        formatter.error(
+            message="--branch requires exactly one --project (branch ID is per-project)",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    # Resolve active branch (only for single-project queries)
+    effective_branch: int | None = branch
+    effective_project = project
+    if branch is None and project and len(project) == 1:
+        _, effective_branch = resolve_branch(config_store, formatter, project[0], None)
 
     # Validate component_type if provided
     if component_type and component_type not in VALID_COMPONENT_TYPES:
@@ -85,9 +117,10 @@ def config_list(
 
     try:
         result = service.list_configs(
-            aliases=project,
+            aliases=effective_project,
             component_type=component_type,
             component_id=component_id,
+            branch_id=effective_branch,
         )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
@@ -108,16 +141,29 @@ def config_detail(
     project: str = typer.Option(..., "--project", help="Project alias"),
     component_id: str = typer.Option(..., "--component-id", help="Component ID"),
     config_id: str = typer.Option(..., "--config-id", help="Configuration ID"),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Get detail from a specific dev branch ID (defaults to active branch)",
+    ),
 ) -> None:
-    """Show detailed information about a specific configuration."""
+    """Show detailed information about a specific configuration.
+
+    If a dev branch is active (via 'branch use'), the detail is fetched
+    from that branch. Use --branch to override.
+    """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "config_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     try:
         result = service.get_config_detail(
             alias=project,
             component_id=component_id,
             config_id=config_id,
+            branch_id=effective_branch,
         )
         formatter.output(result, format_config_detail)
     except ConfigError as exc:
@@ -165,14 +211,36 @@ def config_search(
         "-r",
         help="Interpret query as a regular expression",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Search configs in a specific dev branch ID (defaults to active branch)",
+    ),
 ) -> None:
     """Search through configuration bodies for a string or pattern.
 
     Searches config names, descriptions, parameters, and row definitions.
     Reports which configurations match and where in the JSON tree.
+
+    If a dev branch is active (via 'branch use'), configs from that branch
+    are searched. Use --branch to override.
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "config_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+
+    # --branch requires exactly one --project
+    if branch is not None and (not project or len(project) != 1):
+        formatter.error(
+            message="--branch requires exactly one --project (branch ID is per-project)",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    # Resolve active branch (only for single-project queries)
+    effective_branch: int | None = branch
+    if branch is None and project and len(project) == 1:
+        _, effective_branch = resolve_branch(config_store, formatter, project[0], None)
 
     # Validate component_type
     if component_type and component_type not in VALID_COMPONENT_TYPES:
@@ -202,6 +270,7 @@ def config_search(
             component_id=component_id,
             ignore_case=ignore_case,
             use_regex=use_regex,
+            branch_id=effective_branch,
         )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")

--- a/src/keboola_agent_cli/commands/tool.py
+++ b/src/keboola_agent_cli/commands/tool.py
@@ -13,7 +13,13 @@ import typer
 from ..config_store import ConfigStore
 from ..errors import ConfigError
 from ..output import OutputFormatter, format_tool_result, format_tools_table
-from ._helpers import emit_project_warnings, get_formatter, get_service
+from ._helpers import (
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    resolve_branch,
+    validate_branch_requires_project,
+)
 
 tool_app = typer.Typer(help="MCP tools - interact with Keboola via MCP server")
 
@@ -42,83 +48,15 @@ def _read_input(value: str, formatter: OutputFormatter) -> str:
     return value
 
 
-def _validate_branch_requires_project(
-    formatter: OutputFormatter,
-    branch: int | None,
-    project: str | None,
-) -> None:
-    """Validate that --branch is always accompanied by --project.
-
-    Raises:
-        typer.Exit: With code 2 if branch is set but project is not.
-    """
-    if branch is not None and not project:
-        formatter.error(
-            message="--branch requires --project (branch ID is per-project)",
-            error_code="INVALID_ARGUMENT",
-        )
-        raise typer.Exit(code=2) from None
-
-
-def _resolve_branch(
+def _resolve_branch_str(
     config_store: ConfigStore,
     formatter: OutputFormatter,
     project: str | None,
     branch: int | None,
 ) -> tuple[str | None, str | None]:
-    """Resolve the effective branch and project for tool commands.
-
-    Resolution order:
-    1. Explicit --branch always wins (no change)
-    2. If no --branch, check active_branch_id from config for the resolved project
-    3. If active branch found, use it and print info message in human mode
-
-    When an active branch is resolved from config, --project is also set
-    to the project alias (branch is per-project).
-
-    Args:
-        config_store: Config store for looking up project configs.
-        formatter: Output formatter for info messages.
-        project: Explicit --project alias or None.
-        branch: Explicit --branch integer or None.
-
-    Returns:
-        Tuple of (effective_project, effective_branch_as_str).
-    """
-    if branch is not None:
-        return project, str(branch)
-
-    if project is not None:
-        # Specific project requested - check its active branch
-        proj_config = config_store.get_project(project)
-        if proj_config and proj_config.active_branch_id is not None:
-            branch_id_str = str(proj_config.active_branch_id)
-            if not formatter.json_mode:
-                formatter.err_console.print(
-                    f"[bold blue]Info:[/bold blue] Using active branch "
-                    f"(ID: {proj_config.active_branch_id}) for project '{project}'"
-                )
-            return project, branch_id_str
-    else:
-        # No project specified - check all projects for an active branch.
-        # If exactly one project has an active branch, use it to avoid ambiguity.
-        config = config_store.load()
-        active_projects = [
-            (alias, proj)
-            for alias, proj in config.projects.items()
-            if proj.active_branch_id is not None
-        ]
-        if len(active_projects) == 1:
-            alias, proj = active_projects[0]
-            branch_id_str = str(proj.active_branch_id)
-            if not formatter.json_mode:
-                formatter.err_console.print(
-                    f"[bold blue]Info:[/bold blue] Using active branch "
-                    f"(ID: {proj.active_branch_id}) for project '{alias}'"
-                )
-            return alias, branch_id_str
-
-    return project, None
+    """Resolve branch and return branch_id as string (for MCP service compatibility)."""
+    proj, branch_id = resolve_branch(config_store, formatter, project, branch)
+    return proj, str(branch_id) if branch_id is not None else None
 
 
 @tool_app.command("list")
@@ -140,10 +78,10 @@ def tool_list(
     service = get_service(ctx, "mcp_service")
     config_store: ConfigStore = ctx.obj["config_store"]
 
-    _validate_branch_requires_project(formatter, branch, project)
+    validate_branch_requires_project(formatter, branch, project)
 
     # Auto-resolve active branch from config
-    project, branch_str = _resolve_branch(config_store, formatter, project, branch)
+    project, branch_str = _resolve_branch_str(config_store, formatter, project, branch)
 
     if branch_str and not project:
         formatter.error(
@@ -202,10 +140,10 @@ def tool_call(
     service = get_service(ctx, "mcp_service")
     config_store: ConfigStore = ctx.obj["config_store"]
 
-    _validate_branch_requires_project(formatter, branch, project)
+    validate_branch_requires_project(formatter, branch, project)
 
     # Auto-resolve active branch from config
-    project, branch_str = _resolve_branch(config_store, formatter, project, branch)
+    project, branch_str = _resolve_branch_str(config_store, formatter, project, branch)
 
     if branch_str and not project:
         formatter.error(

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -53,6 +53,7 @@ class ConfigService(BaseService):
         project: ProjectConfig,
         component_type: str | None = None,
         component_id: str | None = None,
+        branch_id: int | None = None,
     ) -> tuple[str, list[dict[str, Any]], bool] | tuple[str, dict[str, str]]:
         """Fetch configurations for a single project (runs in a worker thread).
 
@@ -63,21 +64,25 @@ class ConfigService(BaseService):
         """
         client = self._client_factory(project.stack_url, project.token)
         try:
-            components = client.list_components(component_type=component_type)
+            effective_branch_id = branch_id or project.active_branch_id
+            components = client.list_components(
+                component_type=component_type,
+                branch_id=effective_branch_id,
+            )
 
             # Fetch folder metadata (requires branch ID — search endpoint is branch-only)
             folder_map: dict[str, str] = {}
             try:
-                # Use active branch or find the default branch ID
-                branch_id = project.active_branch_id
-                if not branch_id:
+                # Use effective branch, active branch, or find the default branch ID
+                folder_branch_id = effective_branch_id
+                if not folder_branch_id:
                     # Fetch default branch ID from dev-branches endpoint
                     branches = client.list_dev_branches()
                     default = next((b for b in branches if b.get("isDefault")), None)
                     if default:
-                        branch_id = default["id"]
-                if branch_id:
-                    result = client.list_config_folder_metadata(branch_id=branch_id)
+                        folder_branch_id = default["id"]
+                if folder_branch_id:
+                    result = client.list_config_folder_metadata(branch_id=folder_branch_id)
                     folder_map = result if isinstance(result, dict) else {}
             except Exception:
                 pass  # graceful fallback if search endpoint unavailable
@@ -141,6 +146,7 @@ class ConfigService(BaseService):
         aliases: list[str] | None = None,
         component_type: str | None = None,
         component_id: str | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """List configurations across one or multiple projects.
 
@@ -154,6 +160,8 @@ class ConfigService(BaseService):
                 (extractor, writer, transformation, application).
             component_id: Optional filter by specific component ID
                 (e.g. keboola.ex-db-snowflake).
+            branch_id: If set, list configs from a specific dev branch.
+                       If None, uses each project's active branch (if any).
 
         Returns:
             Dict with keys:
@@ -169,7 +177,9 @@ class ConfigService(BaseService):
         projects = self.resolve_projects(aliases)
 
         def worker(alias: str, project: ProjectConfig) -> tuple[Any, ...]:
-            return self._fetch_project_configs(alias, project, component_type, component_id)
+            return self._fetch_project_configs(
+                alias, project, component_type, component_id, branch_id=branch_id
+            )
 
         successes, errors = self._run_parallel(projects, worker)
 
@@ -189,6 +199,7 @@ class ConfigService(BaseService):
         alias: str,
         component_id: str,
         config_id: str,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Get detailed information about a specific configuration.
 
@@ -196,6 +207,8 @@ class ConfigService(BaseService):
             alias: Project alias to query.
             component_id: The component ID (e.g. keboola.ex-db-snowflake).
             config_id: The configuration ID.
+            branch_id: If set, get detail from a specific dev branch.
+                       If None, uses the project's active branch (if any).
 
         Returns:
             Dict with the full configuration detail from the API,
@@ -208,13 +221,18 @@ class ConfigService(BaseService):
         projects = self.resolve_projects([alias])
         project = projects[alias]
 
+        effective_branch_id = branch_id or project.active_branch_id
+
         client = self._client_factory(project.stack_url, project.token)
         try:
-            detail = client.get_config_detail(component_id, config_id)
+            detail = client.get_config_detail(
+                component_id, config_id, branch_id=effective_branch_id
+            )
         finally:
             client.close()
 
         detail["project_alias"] = alias
+        detail["branch_id"] = effective_branch_id
         return detail
 
     def update_config(
@@ -328,6 +346,7 @@ class ConfigService(BaseService):
         component_id: str | None = None,
         ignore_case: bool = False,
         use_regex: bool = False,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Search through configuration bodies across projects.
 
@@ -342,6 +361,8 @@ class ConfigService(BaseService):
             component_id: Optional filter by specific component ID.
             ignore_case: If True, match case-insensitively.
             use_regex: If True, interpret query as a regular expression.
+            branch_id: If set, search configs from a specific dev branch.
+                       If None, uses each project's active branch (if any).
 
         Returns:
             Dict with "matches", "errors", and "stats" keys.
@@ -363,7 +384,7 @@ class ConfigService(BaseService):
             alias: str, project: ProjectConfig
         ) -> tuple[str, dict[str, Any], bool] | tuple[str, dict[str, str]]:
             return self._search_project_configs(
-                alias, project, match_fn, component_type, component_id
+                alias, project, match_fn, component_type, component_id, branch_id=branch_id
             )
 
         successes, errors = self._run_parallel(projects, worker)
@@ -394,11 +415,16 @@ class ConfigService(BaseService):
         match_fn: Any,
         component_type: str | None = None,
         component_id: str | None = None,
+        branch_id: int | None = None,
     ) -> tuple[str, dict[str, Any], bool] | tuple[str, dict[str, str]]:
         """Search configs in a single project (worker thread)."""
         client = self._client_factory(project.stack_url, project.token)
         try:
-            components = client.list_components(component_type=component_type)
+            effective_branch_id = branch_id or project.active_branch_id
+            components = client.list_components(
+                component_type=component_type,
+                branch_id=effective_branch_id,
+            )
             matches: list[dict[str, Any]] = []
             configs_searched = 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1143,6 +1143,90 @@ class TestConfigList:
         assert output["status"] == "error"
         assert "INVALID_ARGUMENT" in output["error"]["code"]
 
+    def test_config_list_with_branch_flag(self, tmp_path: Path) -> None:
+        """config list --branch 123 --project prod passes branch_id to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            config_service = MagicMock()
+            config_service.list_configs.return_value = {
+                "configs": [],
+                "errors": [],
+            }
+            MockCfgService.return_value = config_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "config",
+                    "list",
+                    "--project",
+                    "prod",
+                    "--branch",
+                    "123",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        config_service.list_configs.assert_called_once()
+        call_kwargs = config_service.list_configs.call_args
+        assert call_kwargs.kwargs.get("branch_id") == 123 or (
+            call_kwargs[1].get("branch_id") == 123 if call_kwargs[1] else call_kwargs[0][-1] == 123
+        )
+
+    def test_config_list_branch_requires_project(self, tmp_path: Path) -> None:
+        """config list --branch 123 without --project returns exit code 2."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "config",
+                    "list",
+                    "--branch",
+                    "123",
+                ],
+            )
+
+        assert result.exit_code == 2
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert "INVALID_ARGUMENT" in output["error"]["code"]
+
 
 class TestConfigDetail:
     """Tests for `kbagent config detail` command."""
@@ -1408,6 +1492,62 @@ class TestConfigDetail:
         output = json.loads(result.output)
         assert output["status"] == "error"
         assert output["error"]["code"] == "INVALID_TOKEN"
+
+    def test_config_detail_with_branch_flag(self, tmp_path: Path) -> None:
+        """config detail --branch 123 passes branch_id to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+
+            config_service = MagicMock()
+            config_service.get_config_detail.return_value = {
+                "id": "101",
+                "name": "Production Load",
+                "description": "Loads production data",
+                "component_id": "keboola.ex-db-snowflake",
+                "project_alias": "prod",
+                "configuration": {"parameters": {"db": "prod"}},
+                "rows": [],
+            }
+            MockCfgService.return_value = config_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "config",
+                    "detail",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--config-id",
+                    "101",
+                    "--branch",
+                    "123",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        config_service.get_config_detail.assert_called_once()
+        call_kwargs = config_service.get_config_detail.call_args
+        assert call_kwargs.kwargs.get("branch_id") == 123 or (
+            call_kwargs[1].get("branch_id") == 123 if call_kwargs[1] else call_kwargs[0][-1] == 123
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -415,6 +415,25 @@ class TestListComponents:
             result = client.list_components(component_type="extractor")
             assert result == []
 
+    def test_list_components_with_branch_id(self, httpx_mock) -> None:
+        """list_components(branch_id) uses branch prefix in URL."""
+        components = [
+            {"id": "keboola.ex-db-snowflake", "type": "extractor", "name": "Snowflake"},
+        ]
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/123/components?include=configuration",
+            json=components,
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.list_components(branch_id=123)
+            assert len(result) == 1
+            assert result[0]["id"] == "keboola.ex-db-snowflake"
+
 
 class TestGetConfigDetail:
     """Tests for get_config_detail()."""
@@ -433,6 +452,23 @@ class TestGetConfigDetail:
             token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
         ) as client:
             result = client.get_config_detail("keboola.ex-db-snowflake", "42")
+            assert result["id"] == "42"
+            assert result["name"] == "My Config"
+
+    def test_get_config_detail_with_branch_id(self, httpx_mock) -> None:
+        """get_config_detail(branch_id) uses branch prefix in URL."""
+        config_data = {"id": "42", "name": "My Config", "configuration": {}}
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/123/components/keboola.ex-db-snowflake/configs/42",
+            json=config_data,
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.get_config_detail("keboola.ex-db-snowflake", "42", branch_id=123)
             assert result["id"] == "42"
             assert result["name"] == "My Config"
 

--- a/tests/test_config_search.py
+++ b/tests/test_config_search.py
@@ -343,4 +343,6 @@ class TestSearchConfigs:
             assert m["component_type"] == "extractor"
 
         # The client was called with the component_type filter
-        mock_client.list_components.assert_called_once_with(component_type="extractor")
+        mock_client.list_components.assert_called_once_with(
+            component_type="extractor", branch_id=None
+        )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,7 @@
 """Tests for commands._helpers shared command-layer utilities."""
 
+import pytest
+
 from keboola_agent_cli.commands._helpers import map_error_to_exit_code
 from keboola_agent_cli.errors import KeboolaApiError, map_error_code_to_type
 
@@ -101,3 +103,127 @@ class TestMapErrorCodeToType:
     def test_generic_error_maps_to_api(self) -> None:
         """Generic ERROR code falls back to api type."""
         assert map_error_code_to_type("ERROR") == "api"
+
+
+class TestValidateBranchRequiresProject:
+    """Tests for validate_branch_requires_project."""
+
+    def test_validate_branch_requires_project_passes_when_both_set(self) -> None:
+        """No error when both branch and project are provided."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import validate_branch_requires_project
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+        # Should not raise
+        validate_branch_requires_project(formatter, branch=123, project="prod")
+
+    def test_validate_branch_requires_project_raises_when_branch_without_project(
+        self,
+    ) -> None:
+        """Raises typer.Exit(code=2) when branch is set but project is not."""
+        from unittest.mock import MagicMock
+
+        import typer
+
+        from keboola_agent_cli.commands._helpers import validate_branch_requires_project
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        with pytest.raises(typer.Exit) as exc_info:
+            validate_branch_requires_project(formatter, branch=123, project=None)
+        assert exc_info.value.exit_code == 2
+        formatter.error.assert_called_once()
+
+    def test_validate_branch_requires_project_passes_when_neither_set(self) -> None:
+        """No error when neither branch nor project are provided."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import validate_branch_requires_project
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+        # Should not raise
+        validate_branch_requires_project(formatter, branch=None, project=None)
+
+
+class TestResolveBranch:
+    """Tests for resolve_branch."""
+
+    def test_resolve_branch_explicit_branch_wins(self, tmp_config_dir) -> None:
+        """Explicit --branch value is returned as-is, regardless of config."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+                active_branch_id=999,
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(store, formatter, "prod", 123)
+        assert project == "prod"
+        assert branch_id == 123
+
+    def test_resolve_branch_uses_active_branch(self, tmp_config_dir) -> None:
+        """When no explicit --branch, active_branch_id from config is used."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+                active_branch_id=555,
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(store, formatter, "prod", None)
+        assert project == "prod"
+        assert branch_id == 555
+        # Should print info message in human mode
+        formatter.err_console.print.assert_called_once()
+
+    def test_resolve_branch_no_branch_returns_none(self, tmp_config_dir) -> None:
+        """When no explicit --branch and no active branch, returns None."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(store, formatter, "prod", None)
+        assert project == "prod"
+        assert branch_id is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -633,7 +633,9 @@ class TestConfigServiceListConfigs:
         assert all(c["component_type"] == "extractor" for c in configs)
 
         # Verify the type filter was passed to the client
-        mock_client.list_components.assert_called_once_with(component_type="extractor")
+        mock_client.list_components.assert_called_once_with(
+            component_type="extractor", branch_id=None
+        )
 
     def test_list_configs_filter_by_component_id(self, tmp_config_dir: Path) -> None:
         """list_configs filters configs to only the specified component_id."""
@@ -863,7 +865,9 @@ class TestConfigServiceListConfigs:
         assert all(c["component_id"] == "keboola.ex-db-snowflake" for c in configs)
 
         # component_type was passed to client
-        mock_client.list_components.assert_called_once_with(component_type="extractor")
+        mock_client.list_components.assert_called_once_with(
+            component_type="extractor", branch_id=None
+        )
 
     def test_list_configs_multiple_aliases(self, tmp_config_dir: Path) -> None:
         """list_configs with multiple aliases queries exactly those projects."""
@@ -916,6 +920,53 @@ class TestConfigServiceListConfigs:
         # proj-c should not have been queried
         client_c.list_components.assert_not_called()
 
+    def test_list_configs_with_branch_id(self, tmp_config_dir: Path) -> None:
+        """list_configs passes explicit branch_id to client.list_components."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+            ),
+        )
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.list_configs(branch_id=42)
+        configs = result["configs"]
+
+        assert len(configs) == 3
+        mock_client.list_components.assert_called_once_with(component_type=None, branch_id=42)
+
+    def test_list_configs_uses_active_branch(self, tmp_config_dir: Path) -> None:
+        """list_configs uses project.active_branch_id when no explicit branch_id."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+                active_branch_id=99,
+            ),
+        )
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.list_configs()
+        configs = result["configs"]
+
+        assert len(configs) == 3
+        mock_client.list_components.assert_called_once_with(component_type=None, branch_id=99)
+
 
 class TestConfigServiceGetConfigDetail:
     """Tests for ConfigService.get_config_detail()."""
@@ -958,7 +1009,9 @@ class TestConfigServiceGetConfigDetail:
         assert result["name"] == "Production Load"
         assert result["project_alias"] == "prod"
         assert result["configuration"] == {"parameters": {"db": "prod"}}
-        mock_client.get_config_detail.assert_called_once_with("keboola.ex-db-snowflake", "101")
+        mock_client.get_config_detail.assert_called_once_with(
+            "keboola.ex-db-snowflake", "101", branch_id=None
+        )
         mock_client.close.assert_called_once()
 
     def test_get_config_detail_unknown_alias(self, tmp_config_dir: Path) -> None:
@@ -1034,6 +1087,144 @@ class TestConfigServiceGetConfigDetail:
         with pytest.raises(KeboolaApiError):
             service.get_config_detail("prod", "comp-x", "cfg-y")
 
+        mock_client.close.assert_called_once()
+
+    def test_get_config_detail_with_branch_id(self, tmp_config_dir: Path) -> None:
+        """get_config_detail passes branch_id to client and includes it in result."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+            ),
+        )
+
+        detail_response = {
+            "id": "101",
+            "name": "Branch Config",
+            "description": "Config on a dev branch",
+            "componentId": "keboola.ex-db-snowflake",
+            "configuration": {"parameters": {"db": "branch_db"}},
+            "rows": [],
+        }
+
+        mock_client = MagicMock()
+        mock_client.get_config_detail.return_value = detail_response
+
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.get_config_detail(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="101",
+            branch_id=55,
+        )
+
+        assert result["id"] == "101"
+        assert result["name"] == "Branch Config"
+        assert result["project_alias"] == "prod"
+        assert result["branch_id"] == 55
+        mock_client.get_config_detail.assert_called_once_with(
+            "keboola.ex-db-snowflake", "101", branch_id=55
+        )
+        mock_client.close.assert_called_once()
+
+    def test_get_config_detail_uses_active_branch(self, tmp_config_dir: Path) -> None:
+        """get_config_detail uses project.active_branch_id when no explicit branch_id."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+                active_branch_id=77,
+            ),
+        )
+
+        detail_response = {
+            "id": "101",
+            "name": "Active Branch Config",
+            "componentId": "keboola.ex-db-snowflake",
+            "configuration": {},
+            "rows": [],
+        }
+
+        mock_client = MagicMock()
+        mock_client.get_config_detail.return_value = detail_response
+
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.get_config_detail(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="101",
+        )
+
+        assert result["branch_id"] == 77
+        mock_client.get_config_detail.assert_called_once_with(
+            "keboola.ex-db-snowflake", "101", branch_id=77
+        )
+        mock_client.close.assert_called_once()
+
+
+class TestConfigServiceSearchConfigs:
+    """Tests for ConfigService.search_configs() with branch_id support."""
+
+    def test_search_configs_with_branch_id(self, tmp_config_dir: Path) -> None:
+        """search_configs passes branch_id to client.list_components."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+            ),
+        )
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.search_configs(query="Production", branch_id=123)
+        matches = result["matches"]
+
+        # "Production Load" config name matches the query
+        assert len(matches) == 1
+        assert matches[0]["config_name"] == "Production Load"
+
+        mock_client.list_components.assert_called_once_with(component_type=None, branch_id=123)
+        mock_client.close.assert_called_once()
+
+    def test_search_configs_uses_active_branch(self, tmp_config_dir: Path) -> None:
+        """search_configs uses project.active_branch_id when no explicit branch_id."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+                active_branch_id=88,
+            ),
+        )
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        service.search_configs(query="nonexistent-query")
+
+        mock_client.list_components.assert_called_once_with(component_type=None, branch_id=88)
         mock_client.close.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- Add `--branch` flag to `config list`, `config detail`, and `config search` commands
- Auto-resolve `active_branch_id` for single-project config read commands (consistent with `tool list/call`)
- Extract shared `resolve_branch()` and `validate_branch_requires_project()` helpers from `tool.py` to `_helpers.py` to eliminate duplication
- All 3 layers updated: client (`list_components`, `get_config_detail`), service (`list_configs`, `get_config_detail`, `search_configs`), and CLI commands

## Test plan

- [x] Unit tests: client layer (branch URL prefix)
- [x] Unit tests: service layer (branch_id propagation, active_branch fallback)
- [x] Unit tests: CLI layer (--branch flag parsing, validation)
- [x] Unit tests: shared helpers (resolve_branch, validate_branch_requires_project)
- [x] Existing tests updated for new `branch_id=None` parameter
- [x] E2E: `config list --branch ID` returns branch-scoped configs
- [x] E2E: `config detail --branch ID` returns config from branch
- [x] E2E: `config search --branch ID` searches branch configs
- [x] E2E: active branch auto-resolves when set via `branch use`
- [x] E2E: `--branch` without `--project` fails with exit code 2
- [x] All 1172 tests pass, lint clean

Closes #83