### PR TITLE
docs: update refs for config --branch flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,9 +220,9 @@ kbagent project remove --project NAME
 kbagent project edit --project NAME [--url URL] [--token TOKEN]
 kbagent project status [--project NAME]
 
-kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID]
-kbagent config detail --project NAME --component-id ID --config-id ID
-kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [--ignore-case] [--regex]
+kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]
+kbagent config detail --project NAME --component-id ID --config-id ID [--branch ID]
+kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [--ignore-case] [--regex] [--branch ID]
 
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID

--- a/plugins/kbagent/skills/kbagent/references/branch-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/branch-workflow.md
@@ -38,4 +38,5 @@ kbagent --json branch merge --project ALIAS
 - **Merge is manual**: `branch merge` returns a URL for the Keboola UI. It does NOT merge via API. This is intentional for safe review.
 - **Active branch persistence**: stored in kbagent config. Survives between sessions.
 - **MCP tools respect active branch**: tool calls automatically use the active branch without extra flags.
+- **Config commands respect active branch**: `config list`, `config detail`, and `config search` auto-scope to the active branch. Use `--branch ID` to override.
 - **Workspaces respect active branch**: `workspace create` and `workspace delete` operate in the active branch context.

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -18,9 +18,9 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `component detail --component-id ID [--project NAME]` -- show component schema, docs URL, examples
 
 ## Configuration Browsing
-- `config list [--project NAME] [--component-type TYPE] [--component-id ID]` -- list configs across projects
-- `config detail --project NAME --component-id ID --config-id ID` -- full config with parameters and rows
-- `config search --query PATTERN [--project NAME] [-i] [-r]` -- search config bodies for string/regex
+- `config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]` -- list configs across projects (branch-aware)
+- `config detail --project NAME --component-id ID --config-id ID [--branch ID]` -- full config with parameters and rows (branch-aware)
+- `config search --query PATTERN [--project NAME] [-i] [-r] [--branch ID]` -- search config bodies for string/regex (branch-aware)
 - `config update --project NAME --component-id ID --config-id ID [--name N] [--description D]` -- update name/description
 - `config delete --project NAME --component-id ID --config-id ID [--branch ID]` -- delete a configuration
 - `config new --component-id ID [--project NAME] [--name NAME] [--output-dir DIR]` -- scaffold new config from component schema

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -60,8 +60,9 @@ One project failing does not block others. Check the `errors` array:
 - **Auto-expand**: tools like `get_tables` that need `bucket_ids` auto-resolve them by calling `get_buckets` first.
 - **Input validation**: tool input is validated against the tool's `inputSchema` before dispatch.
   Only pass parameters defined in the schema. Unexpected parameters cause Pydantic validation errors.
-- **Branch scope**: when active branch is set, MCP tools automatically scope to that branch.
+- **Branch scope**: when active branch is set, MCP tools and config commands automatically scope to that branch.
   `branch_id` is a **CLI flag** (`--branch`), NOT a tool input parameter -- do not pass it inside `--input`.
+  Config read commands (`config list`, `config detail`, `config search`) also support `--branch`.
 - **Schema discovery**: use `kbagent --json tool list` to inspect each tool's `inputSchema` and find
   accepted parameters. For example, `get_configs` takes `configs` (a list of `{component_id, configuration_id}`
   objects), not a flat `config_id` string.

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -71,11 +71,11 @@ Use `kbagent <command> --help` for full flag details and examples.
 
 ### Configuration Browsing
 
-  kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID]
-    List configs from one/many/all projects. --project repeatable.
+  kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]
+    List configs from one/many/all projects. --project repeatable. Branch-aware.
 
-  kbagent config detail --project NAME --component-id ID --config-id ID
-    Full config detail including parameters and rows.
+  kbagent config detail --project NAME --component-id ID --config-id ID [--branch ID]
+    Full config detail including parameters and rows. Branch-aware.
 
   kbagent config update --project NAME --component-id ID --config-id ID [--name N] [--description D] [--branch ID]
     Update config name/description. Targets active dev branch if set.
@@ -86,8 +86,8 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent config new --component-id ID [--name NAME] [--project NAME] [--output-dir DIR]
     Generate boilerplate config from component schema. Use --output-dir to write files.
 
-  kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [-i] [-r]
-    Search config bodies for string/regex. Reports match location in JSON tree.
+  kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [-i] [-r] [--branch ID]
+    Search config bodies for string/regex. Reports match location in JSON tree. Branch-aware.
 
 ### Job History
 


### PR DESCRIPTION
## Summary

- Update `kbagent context` output to show `--branch` flag on `config list/detail/search`
- Update `CLAUDE.md` CLI commands reference
- Update plugin `commands-reference.md`, `gotchas.md`, and `branch-workflow.md`

Follow-up to #84