### PR TITLE
v0.16.3: --branch for config reads, X-Conversation-ID header

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.16.2"
+version = "0.16.3"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Version bump to 0.16.3. Changes since v0.16.2:

### Features
- **`--branch` flag for config read commands** (#84, closes #83): `config list`, `config detail`, and `config search` now support `--branch` and auto-resolve active branch set via `branch use`
- **X-Conversation-ID header** (#86, closes #82): `KBAGENT_CONVERSATION_ID` env var propagates as `X-Conversation-ID` header on all API requests (Storage, Queue, Manage, AI Service, MCP HTTP transport)
- **Doctor check**: `kbagent doctor` warns when conversation ID is not set

### Refactoring
- Shared `resolve_branch()` / `validate_branch_requires_project()` helpers extracted from `tool.py` to `_helpers.py`

### Docs
- Updated `kbagent context`, SKILL.md, gotchas.md, branch-workflow.md, commands-reference.md, CLAUDE.md

### Stats
- 23 files changed, +918/-122 lines
- 1179 tests pass