### PR TITLE
chore: update uv.lock for v0.16.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Sync lockfile version after v0.16.3 release.