### PR TITLE
feat: firewall-style permissions for AI agent sandboxing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,12 @@ kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID
 
+kbagent storage buckets [--project NAME]
+kbagent storage bucket-detail --project NAME --bucket-id ID
+kbagent storage tables --project NAME [--bucket-id ID]
+kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes]
+kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes]
+
 kbagent lineage show [--project NAME]   # also works as just: kbagent lineage
 
 kbagent sharing list [--project NAME]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kbagent org       setup
 kbagent component list | detail
 kbagent config    list | detail | search | update | delete | new
 kbagent job       list | detail
-kbagent storage   buckets | bucket-detail | tables
+kbagent storage   buckets | bucket-detail | tables | delete-table | delete-bucket
 kbagent sharing   list | share | unshare | link | unlink
 kbagent lineage   show
 kbagent branch    list | create | use | reset | delete | merge

--- a/README.md
+++ b/README.md
@@ -135,49 +135,47 @@ kbagent permissions reset            # Remove restrictions (requires confirmatio
 
 ### Layered security
 
-`kbagent init --read-only` applies three independent protection layers. Each layer stops a different bypass vector -- an agent would have to defeat all three simultaneously:
+`kbagent init --read-only` applies three independent protection layers. Each stops a different bypass vector:
 
 | Layer | What it does | What it stops |
 |-------|-------------|---------------|
-| **kbagent policy** | Deny rules in `config.json` block write commands and MCP tools at the CLI level | Agent running `kbagent branch create`, `kbagent tool call create_config`, etc. |
-| **Filesystem `chmod 0440`** | `config.json` set to read-only on disk | Agent editing `config.json` directly (via `Write`, `Edit`, or `cat >`) to remove the policy |
-| **`.claude/settings.json`** | Auto-generated deny rules block Claude Code from editing the config file or running `permissions set/reset` via Bash | Claude Code specifically -- the deny rules are evaluated before any tool executes |
+| **kbagent policy** | Deny rules in `config.json` block write commands and MCP tools | Agent running `kbagent branch create`, `tool call create_config`, etc. |
+| **Filesystem `chmod 0400`** | `config.json` owner-read-only | Agent editing the file directly; ideally, run the agent as a different OS user so it can't even read the config |
+| **`.claude/settings.json`** | Deny rules block Claude Code from touching the config, running `chmod`, `permissions set/reset`, or using `--config-dir` | Claude Code specifically -- deny rules are evaluated before any tool executes |
 
-**Why each layer alone is not enough:**
-- Policy alone: agent could edit `config.json` directly and remove the policy
-- `chmod` alone: agent could run `chmod u+w` and then edit the file
-- `.claude/settings.json` alone: only works for Claude Code, not other AI agents
+**Recommended setup for production:**
+
+Run the AI agent as a separate OS user (or in a container/sandbox). The human sets up the workspace:
+```bash
+kbagent init --from-global --read-only   # creates config (0400) + .claude/settings.json
+```
+The agent can run `kbagent --json config list` etc. but cannot read, modify, or bypass the config.
 
 **How `.claude/settings.json` works:**
 
-Claude Code loads project settings from `.claude/settings.json` in the working directory (project root). Deny rules always take precedence over allow rules, regardless of where they're defined. The generated file contains:
+Claude Code loads settings from `.claude/settings.json` in the project root. Deny rules always win over allow rules. The generated file blocks:
 
 ```json
 {
   "permissions": {
     "deny": [
+      "Read(.kbagent/config.json)",
       "Edit(.kbagent/config.json)",
       "Write(.kbagent/config.json)",
+      "Bash(*.kbagent/config.json*)",
+      "Bash(*chmod*.kbagent*)",
       "Bash(kbagent permissions set*)",
       "Bash(kbagent permissions reset*)",
       "Bash(*permissions set*)",
-      "Bash(*permissions reset*)"
+      "Bash(*permissions reset*)",
+      "Bash(*--config-dir*)",
+      "Bash(*KBAGENT_CONFIG_DIR*)"
     ]
   }
 }
 ```
 
-Claude Code settings are loaded in this precedence order (highest wins):
-
-| Priority | Source | Scope |
-|----------|--------|-------|
-| 5 (highest) | Managed policy | Enterprise/organization |
-| 4 | CLI flags | Session |
-| 3 | `.claude/settings.local.json` | Personal (gitignored) |
-| 2 | `.claude/settings.json` | **Project (committable, shared with team)** |
-| 1 (lowest) | `~/.claude/settings.json` | Global user default |
-
-Commit `.claude/settings.json` to git so the protection applies for everyone who clones the repo.
+Settings precedence (highest wins): Managed policy > CLI flags > `.claude/settings.local.json` > **`.claude/settings.json`** > `~/.claude/settings.json`. Commit it to git so the protection applies for everyone.
 
 **To unlock (human only):**
 
@@ -186,8 +184,6 @@ chmod u+w .kbagent/config.json          # 1. restore write permission
 kbagent permissions reset               # 2. type random confirmation code
 # optionally: edit .claude/settings.json to remove deny rules
 ```
-
-An AI agent cannot perform step 1 (blocked by `.claude/settings.json` Bash deny rules) or step 2 (cannot type the unpredictable confirmation code, and non-interactive stdin fails immediately).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,61 @@ kbagent permissions check "branch.delete"  # Test if operation is allowed (exit 
 kbagent permissions reset            # Remove restrictions (requires confirmation code)
 ```
 
-**Defense in depth:** `--read-only` applies three layers of protection:
-1. **kbagent policy** -- blocks write commands and MCP tools at the CLI level
-2. **Filesystem permissions** -- `config.json` set to read-only (`0440`), agent can't overwrite it
-3. **Claude Code settings** -- auto-creates `.claude/settings.json` with deny rules that prevent Claude from editing the config or running `permissions set/reset`
+### Layered security
 
-Changing or removing the policy requires typing a random confirmation code and `chmod u+w` on the config file -- an AI agent cannot do either.
+`kbagent init --read-only` applies three independent protection layers. Each layer stops a different bypass vector -- an agent would have to defeat all three simultaneously:
+
+| Layer | What it does | What it stops |
+|-------|-------------|---------------|
+| **kbagent policy** | Deny rules in `config.json` block write commands and MCP tools at the CLI level | Agent running `kbagent branch create`, `kbagent tool call create_config`, etc. |
+| **Filesystem `chmod 0440`** | `config.json` set to read-only on disk | Agent editing `config.json` directly (via `Write`, `Edit`, or `cat >`) to remove the policy |
+| **`.claude/settings.json`** | Auto-generated deny rules block Claude Code from editing the config file or running `permissions set/reset` via Bash | Claude Code specifically -- the deny rules are evaluated before any tool executes |
+
+**Why each layer alone is not enough:**
+- Policy alone: agent could edit `config.json` directly and remove the policy
+- `chmod` alone: agent could run `chmod u+w` and then edit the file
+- `.claude/settings.json` alone: only works for Claude Code, not other AI agents
+
+**How `.claude/settings.json` works:**
+
+Claude Code loads project settings from `.claude/settings.json` in the working directory (project root). Deny rules always take precedence over allow rules, regardless of where they're defined. The generated file contains:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Edit(.kbagent/config.json)",
+      "Write(.kbagent/config.json)",
+      "Bash(kbagent permissions set*)",
+      "Bash(kbagent permissions reset*)",
+      "Bash(*permissions set*)",
+      "Bash(*permissions reset*)"
+    ]
+  }
+}
+```
+
+Claude Code settings are loaded in this precedence order (highest wins):
+
+| Priority | Source | Scope |
+|----------|--------|-------|
+| 5 (highest) | Managed policy | Enterprise/organization |
+| 4 | CLI flags | Session |
+| 3 | `.claude/settings.local.json` | Personal (gitignored) |
+| 2 | `.claude/settings.json` | **Project (committable, shared with team)** |
+| 1 (lowest) | `~/.claude/settings.json` | Global user default |
+
+Commit `.claude/settings.json` to git so the protection applies for everyone who clones the repo.
+
+**To unlock (human only):**
+
+```bash
+chmod u+w .kbagent/config.json          # 1. restore write permission
+kbagent permissions reset               # 2. type random confirmation code
+# optionally: edit .claude/settings.json to remove deny rules
+```
+
+An AI agent cannot perform step 1 (blocked by `.claude/settings.json` Bash deny rules) or step 2 (cannot type the unpredictable confirmation code, and non-interactive stdin fails immediately).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ kbagent permissions check "branch.delete"  # Test if operation is allowed (exit 
 kbagent permissions reset            # Remove restrictions (requires confirmation code)
 ```
 
-Changing or removing the policy requires typing a random confirmation code -- an AI agent cannot bypass this programmatically.
+**Defense in depth:** `--read-only` applies three layers of protection:
+1. **kbagent policy** -- blocks write commands and MCP tools at the CLI level
+2. **Filesystem permissions** -- `config.json` set to read-only (`0440`), agent can't overwrite it
+3. **Claude Code settings** -- auto-creates `.claude/settings.json` with deny rules that prevent Claude from editing the config or running `permissions set/reset`
+
+Changing or removing the policy requires typing a random confirmation code and `chmod u+w` on the config file -- an AI agent cannot do either.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ kbagent branch    list | create | use | reset | delete | merge
 kbagent workspace create | list | detail | delete | password | load | query | from-transformation
 kbagent tool      list | call
 kbagent sync      init | pull | status | diff | push | branch-link | branch-unlink | branch-status
+kbagent permissions list | show | set | reset | check
 kbagent           init | context | doctor | version | update
 ```
 
@@ -87,6 +88,52 @@ Tokens are always masked in output.
 For per-directory isolation (e.g. separate clients), run `kbagent init` to create a local `.kbagent/` workspace. Resolution: `--config-dir` flag > `KBAGENT_CONFIG_DIR` env > `.kbagent/` in CWD/parents > global default.
 
 Run `kbagent doctor` to verify your setup.
+
+## Permissions (AI agent sandboxing)
+
+Control which commands and MCP tools your AI agent can use -- like a firewall with allow/deny rules.
+
+**Quick start -- read-only mode:**
+
+```bash
+# New workspace: read-only from the start
+kbagent init --from-global --read-only
+
+# Existing setup: switch to read-only
+kbagent permissions set --mode allow --deny "cli:write" --deny "tool:write"
+```
+
+The agent can browse configs, list jobs, trace lineage, and read MCP tools -- but cannot create branches, delete workspaces, modify configs, or call write MCP tools. Any blocked command returns exit code 6 with a clear error message.
+
+**How it works:**
+
+| Mode | Meaning |
+|------|---------|
+| `--mode allow --deny "..."` | Everything allowed except denied patterns |
+| `--mode deny --allow "..."` | Everything blocked except allowed patterns |
+
+**Pattern examples:**
+
+| Pattern | Matches |
+|---------|---------|
+| `cli:write` | All write/delete/admin CLI commands |
+| `cli:read` | All read-only CLI commands |
+| `tool:write` | All MCP write tools (create_\*, update_\*, delete_\*) |
+| `tool:read` | All MCP read tools (get_\*, list_\*) |
+| `branch.delete` | Exact command |
+| `sync.*` | All sync subcommands |
+| `tool:create_*` | MCP tools matching glob |
+
+**Management commands:**
+
+```bash
+kbagent permissions list             # See all operations with risk categories
+kbagent permissions show             # Show current policy
+kbagent permissions check "branch.delete"  # Test if operation is allowed (exit 0 or 6)
+kbagent permissions reset            # Remove restrictions (requires confirmation code)
+```
+
+Changing or removing the policy requires typing a random confirmation code -- an AI agent cannot bypass this programmatically.
 
 ## Development
 

--- a/docs/concept-check-command.md
+++ b/docs/concept-check-command.md
@@ -1,0 +1,498 @@
+# Concept: `kbagent check` - Platform Observability & Anomaly Detection
+
+## Problem Statement
+
+Users have Keboola projects running dozens of components on schedules. They need to
+know when something goes wrong — not just "a job failed", but patterns like:
+
+- "Credits consumption doubled this week vs. last week"
+- "This extractor is getting slower every day"
+- "Data imports dropped 80% on Tuesday — pipeline is broken"
+- "Betka from Marketing is firing prompts with 30 iterations, costing $420/day vs usual $15"
+
+Today they write SQL transformations for detection, then manually investigate in GCP
+Cost Explorer or Keboola UI. The painful part is the investigation — understanding WHY
+something changed.
+
+## Core Idea: Three Phases, AI Only Where Needed
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  PHASE 1: DEFINE (human + AI, one-time)                        │
+│                                                                │
+│  Vojta + Claude Code pick from templates, customize thresholds │
+│  → .kbagent/checks/credit-spike.yaml                          │
+│  → kbagent check push → Keboola Storage Files (permanent)      │
+│                                                                │
+│  AI is involved HERE. After this, it's pure automation.        │
+└────────────────────────┬───────────────────────────────────────┘
+                         │
+┌────────────────────────▼───────────────────────────────────────┐
+│  PHASE 2: RUN (automated, NO AI, deterministic)                │
+│                                                                │
+│  kbagent check run --all                                       │
+│                                                                │
+│  1. Fetch job history + storage events via Keboola APIs        │
+│  2. Load into in-memory DuckDB                                 │
+│  3. Execute check SQL queries                                  │
+│  4. Evaluate pass/fail                                         │
+│  5. On failure: produce structured briefing JSON               │
+│                                                                │
+│  No AI. No cloud compute. No workspaces. Pure SQL on metadata. │
+└────────────────────────┬───────────────────────────────────────┘
+                         │
+                ┌────────┴────────┐
+                │  All passed?     │
+                │  YES → log, done │
+                │  NO ↓            │
+                └────────┬────────┘
+                         │
+┌────────────────────────▼───────────────────────────────────────┐
+│  PHASE 3: INVESTIGATE (AI picks up the briefing)               │
+│                                                                │
+│  The briefing JSON contains:                                   │
+│  - What check failed and why (violations data)                 │
+│  - Historical context (last 14 days of the metric)             │
+│  - Investigation hints (what to look at next)                  │
+│  - Related API calls to make for drill-down                    │
+│                                                                │
+│  WHO investigates (any of these):                              │
+│  - Vojta + Claude Code (interactive)                           │
+│  - Claude Code /schedule agent (automated)                     │
+│  - KAI bot in Keboola (platform-native)                        │
+│  - Claude Agent SDK app (custom)                               │
+│                                                                │
+│  AI reads the briefing and runs further kbagent commands        │
+│  to drill down into root cause.                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Design Principles
+
+- **Checks are code**: YAML files derived from templates, version-controlled, reviewable
+- **No AI at runtime**: check execution is deterministic SQL on DuckDB. Zero LLM calls.
+- **No cloud compute**: all analysis runs locally on API metadata via DuckDB. No workspaces.
+- **One SQL dialect**: DuckDB (PostgreSQL-compatible) regardless of project backend
+- **Briefing as handoff**: when a check fails, it produces a self-contained JSON briefing
+  that any AI agent can pick up and investigate. The check doesn't know or care WHO investigates.
+- **Templates over raw SQL**: users pick from strategy templates, not write SQL from scratch
+
+## Data Sources (all from existing APIs)
+
+Everything `kbagent check` needs is already available through Keboola APIs:
+
+| Data | API endpoint | What it tells us |
+|------|-------------|------------------|
+| Component jobs | Queue API `/jobs` | runs, duration, status, credits, component, config |
+| Storage events | Storage API `/events` | imports, exports, bytes moved, table operations |
+| Table metadata | Storage API `/tables` | rowsCount, dataSizeBytes, lastImportDate |
+| Token/project stats | Storage API `/tokens/verify` | project info, backend, features |
+
+Data volume is small — thousands of job records, not millions of data rows.
+DuckDB handles this in milliseconds with zero setup.
+
+## Strategy Templates
+
+Users don't write SQL. They pick a **strategy template** and set parameters.
+
+### Template: `credit-spike`
+
+Detects when a component's daily credit consumption deviates from its baseline.
+
+```yaml
+# .kbagent/checks/credit-spike.yaml
+apiVersion: kbagent/v1
+kind: Check
+metadata:
+  name: credit-spike
+  description: "Alert when any component burns >50% more credits than usual"
+  severity: warning
+  tags: [credits, cost-monitoring]
+
+spec:
+  project: my-project
+  template: credit-spike
+  params:
+    lookback_days: 14          # baseline period
+    threshold_pct: 50          # alert if >50% above average
+    min_daily_credits: 0.5     # ignore components with negligible usage
+    group_by: component_id     # or: [component_id, config_id] for finer grain
+```
+
+The template expands to DuckDB SQL internally. Users never see or edit the SQL
+unless they want to (via `template: custom`).
+
+### Template: `job-slowdown`
+
+Detects jobs running significantly slower than their historical median.
+
+```yaml
+apiVersion: kbagent/v1
+kind: Check
+metadata:
+  name: etl-slowdown
+  description: "Alert when any job takes >3x its median runtime"
+  severity: warning
+
+spec:
+  project: my-project
+  template: job-slowdown
+  params:
+    lookback_days: 30
+    slowdown_factor: 3         # alert if duration > 3x median
+    min_duration_seconds: 60   # ignore short jobs
+    status_filter: [success]   # only compare successful runs
+```
+
+### Template: `import-volume-drop`
+
+Detects when data import volume drops compared to the same day last week.
+
+```yaml
+apiVersion: kbagent/v1
+kind: Check
+metadata:
+  name: tuesday-imports
+  description: "Alert when daily import volume drops >50% vs same day last week"
+  severity: critical
+
+spec:
+  project: my-project
+  template: import-volume-drop
+  params:
+    lookback_weeks: 4          # compare against 4-week average for same weekday
+    drop_threshold_pct: 50     # alert if volume dropped >50%
+    compare_by: weekday        # seasonal comparison (Mon vs Mon, Tue vs Tue)
+```
+
+### Template: `error-rate`
+
+Detects when component error rates exceed a threshold.
+
+```yaml
+apiVersion: kbagent/v1
+kind: Check
+metadata:
+  name: error-rate
+  description: "Alert when any component has >20% error rate over 24h"
+  severity: critical
+
+spec:
+  project: my-project
+  template: error-rate
+  params:
+    window_hours: 24
+    threshold_pct: 20
+    min_jobs: 5                # ignore components with <5 runs (noisy)
+```
+
+### Template: `data-freshness`
+
+Detects when tables haven't been updated within their expected schedule.
+
+```yaml
+apiVersion: kbagent/v1
+kind: Check
+metadata:
+  name: stale-tables
+  description: "Alert when key tables are >2x their usual update interval behind"
+  severity: warning
+
+spec:
+  project: my-project
+  template: data-freshness
+  params:
+    staleness_factor: 2        # alert if gap > 2x the usual interval
+    tables:                    # specific tables to monitor (optional: all if omitted)
+      - in.c-billing.daily_costs
+      - in.c-crm.contacts
+```
+
+### Template: `custom`
+
+For power users who want raw SQL.
+
+```yaml
+apiVersion: kbagent/v1
+kind: Check
+metadata:
+  name: my-custom-check
+  description: "Custom check with raw DuckDB SQL"
+  severity: info
+
+spec:
+  project: my-project
+  template: custom
+  data_sources: [jobs, storage_events, table_metadata]  # what to fetch from API
+  query: |
+    -- DuckDB SQL. Available tables: jobs, storage_events, table_metadata
+    -- Query must return rows that VIOLATE the rule (empty = pass)
+    SELECT component_id, daily_credits, avg_credits, pct_change
+    FROM (
+      WITH daily AS (
+        SELECT component_id, DATE_TRUNC('day', start_time) as day,
+               SUM(credits_consumed) as daily_credits
+        FROM jobs
+        WHERE start_time >= CURRENT_DATE - INTERVAL '14 days'
+        GROUP BY 1, 2
+      ),
+      stats AS (
+        SELECT component_id, AVG(daily_credits) as avg_credits
+        FROM daily WHERE day < CURRENT_DATE - INTERVAL '1 day'
+        GROUP BY 1
+      )
+      SELECT d.component_id, d.daily_credits, s.avg_credits,
+             ROUND((d.daily_credits - s.avg_credits) /
+                   NULLIF(s.avg_credits, 0) * 100, 1) as pct_change
+      FROM daily d JOIN stats s USING (component_id)
+      WHERE d.day = CURRENT_DATE - INTERVAL '1 day'
+    )
+    WHERE pct_change > 50
+
+  # Expect: query returns 0 rows = pass, 1+ rows = fail
+  expect:
+    type: empty
+```
+
+## The Briefing (check failure output)
+
+When a check fails, `kbagent check run` produces a **briefing** — structured JSON
+designed to be consumed by an AI agent (or a human) for investigation.
+
+The briefing is self-contained: it has everything needed to understand the problem
+and start investigating, without requiring the reader to re-fetch data.
+
+```json
+{
+  "briefing_version": "1",
+  "generated_at": "2026-03-29T07:00:12Z",
+  "project": {
+    "alias": "billing-prod",
+    "id": 12345,
+    "stack": "connection.north-europe.azure.keboola.com"
+  },
+  "check": {
+    "name": "credit-spike",
+    "description": "Alert when any component burns >50% more credits than usual",
+    "severity": "warning",
+    "template": "credit-spike",
+    "params": {
+      "lookback_days": 14,
+      "threshold_pct": 50
+    }
+  },
+  "result": {
+    "status": "fail",
+    "violations_count": 2,
+    "violations": [
+      {
+        "component_id": "keboola.ex-google-bigquery-v2",
+        "config_id": "894231",
+        "yesterday_credits": 42.5,
+        "baseline_avg_credits": 8.3,
+        "pct_change": 412.0,
+        "z_score": 4.8
+      },
+      {
+        "component_id": "keboola.python-transformation-v2",
+        "config_id": "901122",
+        "yesterday_credits": 15.2,
+        "baseline_avg_credits": 9.1,
+        "pct_change": 67.0,
+        "z_score": 2.1
+      }
+    ]
+  },
+  "context": {
+    "metric_history": [
+      {"date": "2026-03-15", "component_id": "keboola.ex-google-bigquery-v2", "credits": 8.1},
+      {"date": "2026-03-16", "component_id": "keboola.ex-google-bigquery-v2", "credits": 7.9},
+      {"date": "2026-03-27", "component_id": "keboola.ex-google-bigquery-v2", "credits": 9.2},
+      {"date": "2026-03-28", "component_id": "keboola.ex-google-bigquery-v2", "credits": 42.5}
+    ],
+    "recent_config_changes": [
+      {
+        "component_id": "keboola.ex-google-bigquery-v2",
+        "config_id": "894231",
+        "config_name": "BQ Marketing Extract",
+        "changed_at": "2026-03-27T14:30:00Z",
+        "changed_by": "betka@company.com"
+      }
+    ]
+  },
+  "investigation_hints": [
+    "Config 894231 was modified 1 day before the spike — check what changed",
+    "Credits jumped from ~8 to 42 — a 5x increase, likely a query/table scope change",
+    "Use: kbagent --json job list --project billing-prod --component-id keboola.ex-google-bigquery-v2 --limit 50",
+    "Use: kbagent --json config detail --project billing-prod --component-id keboola.ex-google-bigquery-v2 --config-id 894231"
+  ]
+}
+```
+
+Key properties of the briefing:
+- **Self-contained**: includes the violation data AND the historical context
+- **Actionable hints**: suggests specific `kbagent` commands for drill-down
+- **Config change correlation**: automatically cross-references with recent config changes
+- **AI-ready**: any LLM can read this and start investigating immediately
+
+## CLI Commands
+
+```bash
+# === Define (with AI assistance) ===
+
+# List available templates
+kbagent check templates
+
+# Create from template (AI helps pick params)
+kbagent check create --template credit-spike --project billing-prod
+# → interactive: AI suggests thresholds based on project's actual data
+# → saves to .kbagent/checks/credit-spike.yaml
+
+# Validate a check definition
+kbagent check validate .kbagent/checks/credit-spike.yaml
+
+# === Sync with Keboola ===
+
+# Push checks to Keboola Storage Files (permanent, tagged)
+kbagent check push [--name NAME | --all] --project ALIAS
+# Tags: kbagent:check, kbagent:check:<name>
+
+# Pull checks from Keboola
+kbagent check pull [--project ALIAS]
+
+# List checks (local + remote)
+kbagent check list [--project ALIAS] [--remote]
+
+# === Run (no AI, deterministic) ===
+
+# Run specific check
+kbagent check run --name credit-spike
+# exit 0 = pass, exit 1 = fail (with briefing on stdout)
+
+# Run all checks for a project
+kbagent check run --all [--project ALIAS]
+
+# JSON output (for automation / AI consumption)
+kbagent --json check run --all
+# → {"status": "ok", "data": {"total": 5, "passed": 4, "failed": 1,
+#    "checks": [...], "briefings": [<briefing JSONs for failures>]}}
+
+# Store results in Keboola for audit trail
+kbagent check run --all --store-results
+
+# === History ===
+
+# View past results
+kbagent check history [--name NAME] [--limit 10]
+```
+
+## Runner Options (who calls `check run`)
+
+`kbagent check run` is a plain CLI command with a JSON exit. Anything can call it:
+
+### A) Local cron
+```bash
+# crontab -e
+0 7 * * * kbagent --json check run --all --store-results >> /var/log/kbagent-checks.log
+```
+
+### B) Claude Code /schedule
+```
+Schedule daily at 7:00:
+  Run `kbagent --json check run --all`.
+  If any check fails, read the briefings and investigate using the suggested
+  kbagent commands. Produce a report and send via Slack/email.
+```
+
+### C) Keboola component (Python transformation)
+```python
+import subprocess, json
+result = subprocess.run(["kbagent", "--json", "check", "run", "--all"], capture_output=True, text=True)
+data = json.loads(result.stdout)
+if data["data"]["failed"] > 0:
+    # write briefings to output table for downstream notification
+    ...
+```
+
+### D) KAI bot
+KAI calls `kbagent check run`, gets briefings, investigates autonomously, notifies user.
+
+## Storage: Check Definitions & Results
+
+Both stored as **permanent** Storage Files with tags:
+
+```
+Check definitions:
+  Tags: ["kbagent:check", "kbagent:check:credit-spike"]
+  isPermanent: true
+
+Check results (audit trail):
+  Tags: ["kbagent:check-result", "kbagent:check:credit-spike", "kbagent:run:2026-03-29"]
+  isPermanent: true  (or with TTL for old results)
+```
+
+Local cache in `.kbagent/checks/` for fast access and git version control.
+
+## DuckDB as the Engine
+
+All check SQL runs on DuckDB (in-memory, in-process). No external compute.
+
+**Available tables** (auto-populated from API responses):
+
+| DuckDB table | Source | Key columns |
+|-------------|--------|-------------|
+| `jobs` | Queue API `/jobs` | id, component_id, config_id, config_name, status, duration_seconds, credits_consumed, start_time, end_time, result_message |
+| `storage_events` | Storage API `/events` | id, type (tableImport, tableExport, ...), table_id, bytes, created, creator_token_description |
+| `table_metadata` | Storage API `/tables` | id, bucket_id, name, rows_count, data_size_bytes, last_import_date, last_change_date |
+| `config_versions` | Storage API `/components/*/configs/*/versions` | version, created, creator_token_description, change_description |
+
+Templates generate SQL against these tables. Custom checks can use any of them.
+
+**Why DuckDB:**
+- PostgreSQL-compatible SQL with window functions, MEDIAN, PERCENTILE, etc.
+- Handles analytical queries on thousands of rows in <100ms
+- Single `pip install duckdb` dependency (~12MB), no server
+- Same SQL dialect regardless of project backend (Snowflake/BigQuery)
+- Perfect for the kind of analysis needed: aggregations, trends, outlier detection
+
+## Implementation Plan
+
+### Phase 1: MVP — templates + run + briefing
+- DuckDB dependency
+- API data fetchers (jobs, storage events, table metadata)
+- 3 templates: `credit-spike`, `error-rate`, `custom`
+- `kbagent check run` — fetch data, run in DuckDB, produce briefing
+- `kbagent check list` — list local checks
+- `kbagent check validate` — parse and validate YAML
+
+### Phase 2: Full templates + persistence
+- All 5 templates: add `job-slowdown`, `import-volume-drop`, `data-freshness`
+- Storage Files integration (`push`, `pull`, `--store-results`)
+- `check history` command
+- Config change correlation in briefings
+
+### Phase 3: Assisted creation + plugin
+- `kbagent check create` with AI-assisted parameter tuning
+- `kbagent check templates` listing with descriptions
+- Plugin playbook for investigation patterns
+- Integration guide for Claude Code /schedule + KAI
+
+## Open Questions
+
+1. **Data fetch scope**: how many days of job history to fetch? Default 30 days?
+   Queue API has pagination — need to handle large projects with many jobs.
+
+2. **Multi-project checks**: should one check span multiple projects?
+   E.g., "compare credit usage across prod and dev". MVP: single project.
+
+3. **Notification**: part of check YAML or runner responsibility?
+   Leaning toward runner-handles-notification. Check just produces briefing.
+
+4. **Config versions API**: fetching config change history for correlation
+   requires extra API calls per component/config. Worth it for briefing quality,
+   but may be slow for projects with hundreds of configs. Fetch only for
+   components that appear in violations?
+
+5. **DuckDB SQL in templates**: templates generate SQL from params. Should the
+   generated SQL be visible/editable by the user? (e.g., `check render --name X`
+   to see the SQL that would run). Useful for debugging and trust.

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -68,6 +68,8 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | List storage buckets with sharing/linked bucket information | `kbagent storage buckets` |
 | Show detailed bucket info including Snowflake direct access paths | `kbagent storage bucket-detail --project PROJECT --bucket-id BUCKET-ID` |
 | List storage tables from a project | `kbagent storage tables --project PROJECT` |
+| Delete one or more storage tables | `kbagent storage delete-table --project PROJECT --table-id TABLE-ID` |
+| Delete one or more storage buckets | `kbagent storage delete-bucket --project PROJECT --bucket-id BUCKET-ID` |
 | List shared buckets available for linking | `kbagent sharing list` |
 | Enable sharing on a bucket | `kbagent sharing share --project PROJECT --bucket-id BUCKET-ID --type SHARING-TYPE` |
 | Disable sharing on a bucket | `kbagent sharing unshare --project PROJECT --bucket-id BUCKET-ID` |

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -44,6 +44,11 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Goal | Command |
 |------|---------|
 | Update kbagent to the latest version | `kbagent update` |
+| List all operations with their risk category and current allowed/denied status | `kbagent permissions list` |
+| Show the current active permission policy | `kbagent permissions show` |
+| Set the permission policy (firewall rules) | `kbagent permissions set --mode MODE` |
+| Remove all permission restrictions | `kbagent permissions reset` |
+| Check if a specific operation is allowed | `kbagent permissions check <OPERATION>` |
 | Add a new Keboola project connection | `kbagent project add --project ALIAS` |
 | List all connected Keboola projects | `kbagent project list` |
 | Remove a Keboola project connection | `kbagent project remove --project ALIAS` |

--- a/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
@@ -23,6 +23,62 @@ The agent CANNOT:
 - Call write MCP tools (create_*, update_*, delete_*)
 - Modify or remove the permission policy (requires confirmation code)
 
+## Common restriction recipes
+
+### Block all writes (read-only agent)
+```bash
+kbagent permissions set --mode allow --deny "cli:write" --deny "tool:write"
+```
+
+### Block all MCP tool calls (CLI only, no MCP)
+```bash
+kbagent permissions set --mode allow --deny "tool.call" --deny "tool:*"
+```
+Blocks both the `tool call` CLI command and any MCP tool execution via the service layer.
+
+### Block config deletion
+```bash
+kbagent permissions set --mode allow --deny "config.delete" --deny "tool:delete_configuration"
+```
+Blocks both the CLI command and the MCP tool. The agent can still create and update configs.
+
+### Block storage operations
+```bash
+kbagent permissions set --mode allow --deny "storage.*"
+```
+Blocks `storage buckets`, `storage bucket-detail`, and `storage tables`. Note: MCP tools like `get_buckets` are separate -- add `--deny "tool:*bucket*"` to block those too.
+
+### Block workspace SQL queries
+```bash
+kbagent permissions set --mode allow --deny "workspace.query"
+```
+The agent can still create/list/delete workspaces and load tables, but cannot execute SQL. To block all workspace writes:
+```bash
+kbagent permissions set --mode allow --deny "workspace.create" --deny "workspace.delete" --deny "workspace.load" --deny "workspace.query" --deny "workspace.from-transformation"
+```
+
+### Block sync push (prevent pushing changes to Keboola)
+```bash
+kbagent permissions set --mode allow --deny "sync.push"
+```
+The agent can still pull configs and view diffs, but cannot push changes back. Note: `sync.push` pushes to whatever branch is active (main or dev). There is no way to block "push to main only" -- use `branch.create` + `branch.use` workflow to ensure the agent works on a dev branch, then block `branch.reset` to prevent switching back to main.
+
+### Block destructive operations only (allow creates/updates)
+```bash
+kbagent permissions set --mode allow --deny "cli:destructive" --deny "tool:destructive"
+```
+Blocks `branch.delete`, `workspace.delete`, `config.delete` and MCP tools like `delete_*`, `remove_*`. The agent can still create and modify resources.
+
+### Allow only specific commands (strict allowlist)
+```bash
+kbagent permissions set --mode deny \
+  --allow "project.list" --allow "project.status" \
+  --allow "config.list" --allow "config.detail" --allow "config.search" \
+  --allow "job.list" --allow "job.detail" \
+  --allow "tool.list" --allow "tool:read"
+```
+Everything else is blocked. This is the most restrictive approach.
+
 ## Checking permissions before acting
 
 ```bash

--- a/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
@@ -1,0 +1,55 @@
+# Permissions Workflow -- AI Agent Sandboxing
+
+Firewall-style allow/deny rules that control which CLI commands and MCP tools can be used.
+Use this to restrict AI agents to read-only mode or block specific destructive operations.
+
+## Setting up read-only mode
+
+```bash
+# Option A: New workspace with read-only from the start
+kbagent init --from-global --read-only
+
+# Option B: Existing setup -- set policy interactively (requires typing a confirmation code)
+kbagent permissions set --mode allow --deny "cli:write" --deny "tool:write"
+```
+
+After this, the agent can:
+- Browse configs, jobs, lineage, storage, components
+- List and read MCP tools (get_*, list_*)
+- Use `kbagent permissions check` to test what's allowed
+
+The agent CANNOT:
+- Create/delete branches, workspaces, configs
+- Call write MCP tools (create_*, update_*, delete_*)
+- Modify or remove the permission policy (requires confirmation code)
+
+## Checking permissions before acting
+
+```bash
+# Before attempting a write operation, check if it's allowed
+kbagent --json permissions check "branch.create"
+# Exit 0 = allowed, exit 6 = denied
+
+# List all operations with current status
+kbagent --json permissions list
+```
+
+## Pattern reference
+
+| Pattern | Matches |
+|---------|---------|
+| `cli:write` | All write, destructive, and admin CLI commands |
+| `cli:read` | All read-only CLI commands |
+| `tool:write` | All MCP write tools (create_*, update_*, delete_*, add_*, set_*, remove_*) |
+| `tool:read` | All MCP read tools (get_*, list_*, search, find_*) |
+| `branch.delete` | Exact command match |
+| `sync.*` | All sync subcommands (glob) |
+| `tool:create_*` | MCP tools matching glob pattern |
+
+## Key details
+
+- **Exit code 6** = operation blocked by permission policy
+- **`permissions` commands always work** -- you can never lock yourself out of checking/listing
+- **Changing or removing the policy requires interactive confirmation** (random code typed by human)
+- **New commands not in the registry** are treated as write operations (fail-closed)
+- Policy is stored in `config.json` alongside project configs

--- a/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
@@ -102,6 +102,23 @@ kbagent --json permissions list
 | `sync.*` | All sync subcommands (glob) |
 | `tool:create_*` | MCP tools matching glob pattern |
 
+## Defense in depth (`--read-only`)
+
+`kbagent init --read-only` applies three layers of protection:
+
+| Layer | What it does | Who it stops |
+|-------|-------------|-------------|
+| kbagent policy | Blocks write CLI commands and MCP tools | Any agent using kbagent |
+| Filesystem `chmod 0440` | config.json is read-only on disk | Any process trying to overwrite the file |
+| `.claude/settings.json` | Deny rules for Edit/Write config + Bash permission commands | Claude Code specifically |
+
+To unlock (human only):
+```bash
+chmod u+w .kbagent/config.json          # restore write permission
+kbagent permissions reset               # type confirmation code
+# optionally remove .claude/settings.json deny rules
+```
+
 ## Key details
 
 - **Exit code 6** = operation blocked by permission policy

--- a/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/permissions-workflow.md
@@ -109,8 +109,10 @@ kbagent --json permissions list
 | Layer | What it does | Who it stops |
 |-------|-------------|-------------|
 | kbagent policy | Blocks write CLI commands and MCP tools | Any agent using kbagent |
-| Filesystem `chmod 0440` | config.json is read-only on disk | Any process trying to overwrite the file |
-| `.claude/settings.json` | Deny rules for Edit/Write config + Bash permission commands | Claude Code specifically |
+| Filesystem `chmod 0400` | config.json owner-read-only | Other users/processes; run agent as separate OS user for full isolation |
+| `.claude/settings.json` | Deny rules block: Read/Edit/Write config, any Bash mentioning config path, chmod, --config-dir, KBAGENT_CONFIG_DIR, permissions set/reset | Claude Code specifically |
+
+For production: run the agent as a separate OS user so it cannot even read config.json (tokens stay invisible to the agent process).
 
 To unlock (human only):
 ```bash

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -14,6 +14,7 @@ from .commands.init import init_command
 from .commands.job import job_app
 from .commands.lineage import lineage_app
 from .commands.org import org_app
+from .commands.permissions import permissions_app
 from .commands.project import project_app
 from .commands.repl import repl_command
 from .commands.sharing import sharing_app
@@ -23,7 +24,10 @@ from .commands.tool import tool_app
 from .commands.version import update_command, version_command
 from .commands.workspace import workspace_app
 from .config_store import ConfigStore, resolve_config_dir
+from .constants import EXIT_PERMISSION_DENIED
+from .errors import PermissionDeniedError
 from .output import OutputFormatter
+from .permissions import PermissionEngine
 from .services.branch_service import BranchService
 from .services.component_service import ComponentService
 from .services.config_service import ConfigService
@@ -53,6 +57,7 @@ app.command("version", rich_help_panel=_SETUP)(version_command)
 app.command("update", rich_help_panel=_SETUP)(update_command)
 app.command("context", rich_help_panel=_SETUP)(context_command)
 app.command("repl", rich_help_panel=_SETUP)(repl_command)
+app.add_typer(permissions_app, name="permissions", rich_help_panel=_SETUP)
 
 # -- Project Management --
 _PROJ = "Project Management"
@@ -151,9 +156,17 @@ def main(
     doctor_service = DoctorService(config_store=config_store, mcp_service=mcp_service)
     version_service = VersionService()
 
+    try:
+        config = config_store.load()
+        permission_engine = PermissionEngine(config.permissions)
+    except Exception:
+        # Config may be invalid (e.g. corrupted JSON) -- skip permission check
+        permission_engine = PermissionEngine(None)
+
     ctx.ensure_object(dict)
     ctx.obj["formatter"] = formatter
     ctx.obj["json_output"] = json_output
+    ctx.obj["permission_engine"] = permission_engine
     ctx.obj["verbose"] = verbose
     ctx.obj["no_color"] = effective_no_color
     ctx.obj["config_store"] = config_store
@@ -171,6 +184,16 @@ def main(
     ctx.obj["workspace_service"] = workspace_service
     ctx.obj["doctor_service"] = doctor_service
     ctx.obj["version_service"] = version_service
+
+    # Enforce permissions for top-level commands (sub-app commands use callbacks)
+    _top_level_commands = {"init", "doctor", "version", "update", "context", "repl"}
+    _is_help = "--help" in sys.argv or "-h" in sys.argv
+    if ctx.invoked_subcommand in _top_level_commands and not _is_help:
+        try:
+            permission_engine.check_or_raise(ctx.invoked_subcommand)
+        except PermissionDeniedError as exc:
+            formatter.error(message=exc.message, error_code="PERMISSION_DENIED")
+            raise typer.Exit(code=EXIT_PERMISSION_DENIED) from None
 
     # Launch REPL if no subcommand was given (set above)
     if ctx.obj.get("_launch_repl"):

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -806,6 +806,21 @@ class KeboolaClient(BaseHttpClient):
         response = self._request("DELETE", f"/v2/storage/buckets/{safe_id}", params=params)
         return self._wait_for_storage_job(response.json())
 
+    def delete_table(self, table_id: str) -> dict[str, Any]:
+        """Delete a storage table (async, waits for completion).
+
+        Args:
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+
+        Returns:
+            Completed storage job dict.
+        """
+        safe_id = quote(table_id, safe="")
+        response = self._request(
+            "DELETE", f"/v2/storage/tables/{safe_id}", params={"async": "true"}
+        )
+        return self._wait_for_storage_job(response.json())
+
     def list_tables_with_metadata(self) -> list[dict[str, Any]]:
         """List all storage tables with columns and metadata.
 

--- a/src/keboola_agent_cli/commands/_helpers.py
+++ b/src/keboola_agent_cli/commands/_helpers.py
@@ -12,7 +12,8 @@ from typing import Any
 import typer
 
 from ..config_store import ConfigStore
-from ..errors import KeboolaApiError
+from ..constants import EXIT_PERMISSION_DENIED
+from ..errors import KeboolaApiError, PermissionDeniedError
 from ..output import OutputFormatter
 
 
@@ -51,6 +52,54 @@ def emit_project_warnings(formatter: OutputFormatter, result: dict) -> None:
         alias = err.get("project_alias", "unknown")
         message = err.get("message", "Unknown error")
         formatter.warning(f"Project '{alias}': {message}")
+
+
+def _is_help_request(ctx: typer.Context) -> bool:
+    """Check if the current invocation is a --help request.
+
+    The group callback fires before Click parses subcommand arguments,
+    so --help for a subcommand (e.g. 'branch delete --help') is still
+    in sys.argv at this point. We allow help through even for blocked commands.
+
+    Also respects Click's resilient_parsing mode (tab completions).
+    """
+    import sys
+
+    if "--help" in sys.argv or "-h" in sys.argv:
+        return True
+    return bool(ctx.resilient_parsing)
+
+
+def check_cli_permission(ctx: typer.Context, group_name: str) -> None:
+    """Check CLI command permissions using the active policy.
+
+    Called from sub-app callbacks. Constructs operation name as
+    '{group_name}.{subcommand}' and checks against the permission engine.
+    Always allows --help through so users can read docs for blocked commands.
+
+    Args:
+        ctx: Typer context (must have permission_engine in obj).
+        group_name: The sub-app name (e.g., 'branch', 'config').
+    """
+    if _is_help_request(ctx):
+        return
+
+    engine = ctx.obj.get("permission_engine")
+    if engine is None or not engine.active:
+        return
+
+    subcommand = ctx.invoked_subcommand
+    if subcommand is None:
+        return
+
+    operation = f"{group_name}.{subcommand}"
+
+    try:
+        engine.check_or_raise(operation)
+    except PermissionDeniedError as exc:
+        formatter = get_formatter(ctx)
+        formatter.error(message=exc.message, error_code="PERMISSION_DENIED")
+        raise typer.Exit(code=EXIT_PERMISSION_DENIED) from None
 
 
 def validate_branch_requires_project(

--- a/src/keboola_agent_cli/commands/branch.py
+++ b/src/keboola_agent_cli/commands/branch.py
@@ -8,9 +8,20 @@ import typer
 
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_branches_table
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
 
 branch_app = typer.Typer(help="Manage development branches")
+
+
+@branch_app.callback(invoke_without_command=True)
+def _branch_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "branch")
 
 
 @branch_app.command("list")

--- a/src/keboola_agent_cli/commands/component.py
+++ b/src/keboola_agent_cli/commands/component.py
@@ -11,9 +11,20 @@ from rich.table import Table
 
 from ..constants import VALID_COMPONENT_TYPES
 from ..errors import ConfigError, KeboolaApiError
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
 
 component_app = typer.Typer(help="Discover and inspect Keboola components")
+
+
+@component_app.callback(invoke_without_command=True)
+def _component_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "component")
 
 
 def _format_components_table(console: Console, data: dict) -> None:

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -17,6 +17,7 @@ from ..constants import KEBOOLA_DIR_NAME, MANIFEST_FILENAME, VALID_COMPONENT_TYP
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_config_detail, format_configs_table, format_search_results
 from ._helpers import (
+    check_cli_permission,
     emit_project_warnings,
     get_formatter,
     get_service,
@@ -56,6 +57,11 @@ def _detect_branch_prefix(output_dir: Path) -> str | None:
 
 
 config_app = typer.Typer(help="Browse and inspect configurations")
+
+
+@config_app.callback(invoke_without_command=True)
+def _config_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "config")
 
 
 @config_app.command("list")

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -116,6 +116,12 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent storage tables --project NAME [--bucket-id BUCKET_ID]
     List storage tables, optionally filtered by bucket.
 
+  kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes]
+    Delete one or more tables. Batch: repeat --table-id. --dry-run to preview.
+
+  kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes]
+    Delete one or more buckets. --force cascade-deletes tables. Linked/shared buckets protected.
+
 ### Sharing (Cross-Project)
 
   kbagent sharing list [--project NAME]

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -250,6 +250,22 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent update
     Self-update kbagent to latest version (via uv tool install --upgrade).
 
+  kbagent permissions list [--category read|write|destructive|admin]
+    List all operations with risk categories and current allowed/denied status.
+
+  kbagent permissions show
+    Show current active permission policy.
+
+  kbagent permissions set --mode allow|deny [--allow PATTERN ...] [--deny PATTERN ...]
+    Set firewall-style permission policy. Patterns: exact (branch.delete),
+    glob (sync.*), category (cli:write, tool:read).
+
+  kbagent permissions reset
+    Remove all restrictions.
+
+  kbagent permissions check OPERATION
+    Check if operation is allowed. Exit 0=allowed, 6=denied.
+
 ## Tips for AI Agents
 
 1. ALWAYS use --json flag for reliable, parseable output:
@@ -284,6 +300,7 @@ Use `kbagent <command> --help` for full flag details and examples.
      KBC_MASTER_TOKEN         Master token for sharing ops (global fallback)
      KBC_MASTER_TOKEN_*       Per-project master token (e.g. KBC_MASTER_TOKEN_PROD)
      KBAGENT_CONFIG_DIR       Override config directory
+     KBAGENT_MAX_PARALLEL_WORKERS  Max concurrent threads for multi-project ops (default 10, max 100)
 
 8. Config resolution order:
      --config-dir flag > KBAGENT_CONFIG_DIR env > .kbagent/ in CWD/parents > ~/.config/keboola-agent-cli/
@@ -303,6 +320,7 @@ Use `kbagent <command> --help` for full flag details and examples.
   3  Authentication error (invalid or expired token)
   4  Network error (timeout, unreachable server)
   5  Configuration error (corrupt config, missing alias)
+  6  Permission denied (operation blocked by policy)
 
 When you receive a non-zero exit code, use --json to get structured error details.
 

--- a/src/keboola_agent_cli/commands/init.py
+++ b/src/keboola_agent_cli/commands/init.py
@@ -63,8 +63,9 @@ def init_command(
     local_store.save(config)
 
     if read_only:
-        # Make config.json read-only on filesystem so agents can't bypass via direct file edit
-        config_path.chmod(stat.S_IRUSR | stat.S_IRGRP)  # 0440
+        # Make config.json owner-read-only so other users (agent) can't read or write it.
+        # kbagent itself runs as the owner and can still read it.
+        config_path.chmod(stat.S_IRUSR)  # 0400
         # Create .claude/settings.json to prevent Claude Code from touching the config
         _create_claude_settings(cwd, local_dir)
 
@@ -112,14 +113,24 @@ def _create_claude_settings(project_dir: Path, kbagent_dir: Path) -> None:
     permissions = settings.setdefault("permissions", {})
     deny_list: list[str] = permissions.get("deny", [])
 
-    # Rules to add: block editing config.json and running permission-changing commands
+    # Rules to add:
+    # 1. Block direct file operations on config.json
+    # 2. Block any Bash command that mentions the config file (chmod, cat >, python, sed, etc.)
+    # 3. Block permission-changing CLI commands
+    # 4. Block --config-dir bypass (pointing to global config without policy)
+    # 5. Block reading the config (agent doesn't need to -- kbagent reads it internally)
     new_rules = [
+        f"Read({config_rel})",
         f"Edit({config_rel})",
         f"Write({config_rel})",
+        f"Bash(*{config_rel}*)",
+        f"Bash(*chmod*{kbagent_dir.name}*)",
         "Bash(kbagent permissions set*)",
         "Bash(kbagent permissions reset*)",
         "Bash(*permissions set*)",
         "Bash(*permissions reset*)",
+        "Bash(*--config-dir*)",
+        "Bash(*KBAGENT_CONFIG_DIR*)",
     ]
     for rule in new_rules:
         if rule not in deny_list:

--- a/src/keboola_agent_cli/commands/init.py
+++ b/src/keboola_agent_cli/commands/init.py
@@ -1,5 +1,7 @@
 """Init command - initialize a local .kbagent/ workspace in the current directory."""
 
+import json
+import stat
 from pathlib import Path
 
 import typer
@@ -60,6 +62,12 @@ def init_command(
     local_store = ConfigStore(config_dir=local_dir, source="local")
     local_store.save(config)
 
+    if read_only:
+        # Make config.json read-only on filesystem so agents can't bypass via direct file edit
+        config_path.chmod(stat.S_IRUSR | stat.S_IRGRP)  # 0440
+        # Create .claude/settings.json to prevent Claude Code from touching the config
+        _create_claude_settings(cwd, local_dir)
+
     _update_gitignore(cwd)
 
     project_count = len(config.projects)
@@ -77,6 +85,52 @@ def init_command(
             "projects_copied": project_count if from_global else 0,
             "read_only": read_only,
         }
+    )
+
+
+def _create_claude_settings(project_dir: Path, kbagent_dir: Path) -> None:
+    """Create .claude/settings.json to prevent Claude Code from modifying the config.
+
+    This is a defense-in-depth measure: even if Claude Code somehow bypasses
+    the permission policy, it cannot edit the config file or run commands
+    that would change the policy.
+    """
+    claude_dir = project_dir / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+
+    # Relative path from project root to kbagent config
+    config_rel = f"{kbagent_dir.name}/config.json"
+
+    settings: dict = {}
+    if settings_path.is_file():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            settings = {}
+
+    permissions = settings.setdefault("permissions", {})
+    deny_list: list[str] = permissions.get("deny", [])
+
+    # Rules to add: block editing config.json and running permission-changing commands
+    new_rules = [
+        f"Edit({config_rel})",
+        f"Write({config_rel})",
+        "Bash(kbagent permissions set*)",
+        "Bash(kbagent permissions reset*)",
+        "Bash(*permissions set*)",
+        "Bash(*permissions reset*)",
+    ]
+    for rule in new_rules:
+        if rule not in deny_list:
+            deny_list.append(rule)
+
+    permissions["deny"] = deny_list
+    settings["permissions"] = permissions
+
+    settings_path.write_text(
+        json.dumps(settings, indent=2) + "\n",
+        encoding="utf-8",
     )
 
 

--- a/src/keboola_agent_cli/commands/init.py
+++ b/src/keboola_agent_cli/commands/init.py
@@ -6,7 +6,7 @@ import typer
 
 from ..config_store import ConfigStore
 from ..constants import LOCAL_CONFIG_DIR_NAME
-from ..models import AppConfig
+from ..models import AppConfig, PermissionPolicy
 from ._helpers import get_formatter, get_service
 
 
@@ -16,6 +16,11 @@ def init_command(
         False,
         "--from-global",
         help="Copy projects from the global config into the new local workspace.",
+    ),
+    read_only: bool = typer.Option(
+        False,
+        "--read-only",
+        help="Set read-only permission policy (blocks all write CLI commands and MCP tools).",
     ),
 ) -> None:
     """Initialize a local .kbagent/ workspace in the current directory."""
@@ -46,6 +51,12 @@ def init_command(
             raise typer.Exit(code=5)
         config = global_store.load()
 
+    if read_only:
+        config.permissions = PermissionPolicy(
+            mode="allow",
+            deny=["cli:write", "tool:write"],
+        )
+
     local_store = ConfigStore(config_dir=local_dir, source="local")
     local_store.save(config)
 
@@ -55,6 +66,8 @@ def init_command(
     message = f"Initialized local workspace at {local_dir}"
     if from_global and project_count > 0:
         message += f" (copied {project_count} project(s) from global config)"
+    if read_only:
+        message += " [read-only mode]"
 
     formatter.output(
         {
@@ -62,6 +75,7 @@ def init_command(
             "path": str(local_dir),
             "created": True,
             "projects_copied": project_count if from_global else 0,
+            "read_only": read_only,
         }
     )
 

--- a/src/keboola_agent_cli/commands/job.py
+++ b/src/keboola_agent_cli/commands/job.py
@@ -9,9 +9,20 @@ import typer
 from ..constants import DEFAULT_JOB_LIMIT, MAX_JOB_LIMIT, VALID_STATUSES
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_job_detail, format_jobs_table
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
 
 job_app = typer.Typer(help="Browse job history")
+
+
+@job_app.callback(invoke_without_command=True)
+def _job_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "job")
 
 
 @job_app.command("list")

--- a/src/keboola_agent_cli/commands/lineage.py
+++ b/src/keboola_agent_cli/commands/lineage.py
@@ -8,9 +8,14 @@ import typer
 
 from ..errors import ConfigError
 from ..output import format_lineage_table
-from ._helpers import emit_project_warnings, get_formatter, get_service
+from ._helpers import check_cli_permission, emit_project_warnings, get_formatter, get_service
 
 lineage_app = typer.Typer(help="Analyze cross-project data lineage via bucket sharing")
+
+
+@lineage_app.callback(invoke_without_command=True)
+def _lineage_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "lineage")
 
 
 @lineage_app.command("show")

--- a/src/keboola_agent_cli/commands/org.py
+++ b/src/keboola_agent_cli/commands/org.py
@@ -13,9 +13,14 @@ from rich.table import Table
 
 from ..constants import DEFAULT_TOKEN_DESCRIPTION, ENV_KBC_MANAGE_API_TOKEN, ENV_KBC_STORAGE_API_URL
 from ..errors import KeboolaApiError
-from ._helpers import get_formatter, get_service, map_error_to_exit_code
+from ._helpers import check_cli_permission, get_formatter, get_service, map_error_to_exit_code
 
 org_app = typer.Typer(help="Organization management")
+
+
+@org_app.callback(invoke_without_command=True)
+def _org_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "org")
 
 
 def _resolve_manage_token() -> str:

--- a/src/keboola_agent_cli/commands/permissions.py
+++ b/src/keboola_agent_cli/commands/permissions.py
@@ -1,0 +1,310 @@
+"""Permission management commands - list, show, set, reset, check.
+
+Thin CLI layer for managing the firewall-style permission policy.
+No business logic belongs here -- the PermissionEngine handles evaluation.
+
+Security: set and reset require interactive confirmation (type a random code)
+so that an AI agent constrained by the policy cannot bypass it programmatically.
+"""
+
+import secrets
+import sys
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..config_store import ConfigStore
+from ..constants import EXIT_PERMISSION_DENIED
+from ..models import PermissionPolicy
+from ..permissions import PermissionEngine
+from ._helpers import get_formatter, get_service
+
+permissions_app = typer.Typer(help="Manage operation permissions (firewall rules)")
+
+# Length of the random confirmation code
+_CONFIRM_CODE_LENGTH = 4
+
+
+def _require_interactive_confirmation(action_description: str) -> bool:
+    """Require the user to type a random code to confirm a destructive permission change.
+
+    This prevents AI agents from programmatically bypassing permission policies.
+    The agent cannot predict the code, and cannot type it into stdin.
+
+    Returns True if confirmed, False if cancelled or non-interactive.
+    """
+    is_tty = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
+    if not is_tty:
+        return False
+
+    code = secrets.token_hex(_CONFIRM_CODE_LENGTH)
+    sys.stderr.write(f"\nTo {action_description}, type this code: {code}\n")
+    sys.stderr.write("Confirmation: ")
+    sys.stderr.flush()
+
+    try:
+        user_input = input().strip()
+    except (EOFError, KeyboardInterrupt):
+        return False
+
+    return user_input == code
+
+
+def _format_operations_table(
+    console: Console,
+    operations: list[dict[str, Any]],
+    category_filter: str | None = None,
+) -> None:
+    """Render a Rich table of operations with their status."""
+    if category_filter:
+        operations = [op for op in operations if op["category"] == category_filter]
+
+    table = Table(title="Operations")
+    table.add_column("Operation", style="bold cyan")
+    table.add_column("Type", style="dim")
+    table.add_column("Category")
+    table.add_column("Status", justify="center")
+    table.add_column("Description", style="dim")
+
+    category_styles = {
+        "read": "green",
+        "write": "yellow",
+        "destructive": "red",
+        "admin": "bold red",
+    }
+
+    for op in operations:
+        cat = op["category"]
+        cat_styled = f"[{category_styles.get(cat, '')}]{cat}[/{category_styles.get(cat, '')}]"
+        status = op["status"]
+        status_styled = (
+            f"[green]{status}[/green]" if status == "allowed" else f"[red]{status}[/red]"
+        )
+        desc = op.get("description", "")
+        table.add_row(op["name"], op["type"], cat_styled, status_styled, desc)
+
+    console.print(table)
+
+
+@permissions_app.command("list")
+def permissions_list(
+    ctx: typer.Context,
+    category: str | None = typer.Option(
+        None,
+        "--category",
+        "-c",
+        help="Filter by risk category: read, write, destructive, admin",
+    ),
+) -> None:
+    """List all operations with their risk category and current allowed/denied status."""
+    formatter = get_formatter(ctx)
+    config_store: ConfigStore = get_service(ctx, "config_store")
+    config = config_store.load()
+
+    engine = PermissionEngine(config.permissions)
+    ops = engine.list_operations()
+
+    if formatter.json_mode:
+        if category:
+            ops = [op for op in ops if op["category"] == category]
+        formatter.output(ops)
+    else:
+        _format_operations_table(formatter.console, ops, category_filter=category)
+        if not engine.active:
+            formatter.err_console.print(
+                "\n[dim]No permission policy active. All operations are allowed.[/dim]"
+            )
+
+
+@permissions_app.command("show")
+def permissions_show(
+    ctx: typer.Context,
+) -> None:
+    """Show the current active permission policy."""
+    formatter = get_formatter(ctx)
+    config_store: ConfigStore = get_service(ctx, "config_store")
+    config = config_store.load()
+
+    if config.permissions is None:
+        if formatter.json_mode:
+            formatter.output({"active": False, "message": "No permission policy configured"})
+        else:
+            formatter.console.print("No permission policy configured. All operations are allowed.")
+        return
+
+    policy_data = {
+        "active": True,
+        "mode": config.permissions.mode,
+        "allow": config.permissions.allow,
+        "deny": config.permissions.deny,
+    }
+
+    if formatter.json_mode:
+        formatter.output(policy_data)
+    else:
+        mode_desc = (
+            "default-allow (everything allowed unless denied)"
+            if config.permissions.mode == "allow"
+            else "default-deny (everything denied unless allowed)"
+        )
+        formatter.console.print(f"[bold]Mode:[/bold] {mode_desc}")
+        if config.permissions.allow:
+            formatter.console.print(f"[bold]Allow:[/bold] {', '.join(config.permissions.allow)}")
+        if config.permissions.deny:
+            formatter.console.print(f"[bold]Deny:[/bold] {', '.join(config.permissions.deny)}")
+
+
+@permissions_app.command("set")
+def permissions_set(
+    ctx: typer.Context,
+    mode: str = typer.Option(
+        ...,
+        "--mode",
+        "-m",
+        help="Base mode: 'allow' (default-allow) or 'deny' (default-deny)",
+    ),
+    allow: list[str] | None = typer.Option(
+        None,
+        "--allow",
+        "-a",
+        help="Allowed operation patterns (repeatable)",
+    ),
+    deny: list[str] | None = typer.Option(
+        None,
+        "--deny",
+        "-d",
+        help="Denied operation patterns (repeatable)",
+    ),
+) -> None:
+    """Set the permission policy (firewall rules).
+
+    Requires interactive confirmation (type a random code) to prevent
+    AI agents from modifying permissions programmatically.
+
+    Examples:
+      # Block all write operations (Vojta's use case):
+      kbagent permissions set --mode allow --deny "cli:write" --deny "tool:write"
+
+      # Allow only read operations:
+      kbagent permissions set --mode deny --allow "cli:read" --allow "tool:read"
+
+      # Block specific operations:
+      kbagent permissions set --mode allow --deny "branch.delete" --deny "tool:delete_*"
+    """
+    formatter = get_formatter(ctx)
+
+    if mode not in ("allow", "deny"):
+        formatter.error(
+            message="Mode must be 'allow' or 'deny'",
+            error_code="VALIDATION_ERROR",
+        )
+        raise typer.Exit(code=2) from None
+
+    if not _require_interactive_confirmation("update permission policy"):
+        formatter.error(
+            message="Confirmation failed. Permission policy not changed.",
+            error_code="PERMISSION_DENIED",
+        )
+        raise typer.Exit(code=EXIT_PERMISSION_DENIED) from None
+
+    config_store: ConfigStore = get_service(ctx, "config_store")
+    config = config_store.load()
+
+    policy = PermissionPolicy(
+        mode=mode,
+        allow=allow or [],
+        deny=deny or [],
+    )
+    config.permissions = policy
+    config_store.save(config)
+
+    if formatter.json_mode:
+        formatter.output(
+            {
+                "status": "ok",
+                "mode": mode,
+                "allow": policy.allow,
+                "deny": policy.deny,
+            }
+        )
+    else:
+        formatter.console.print("[green]Permission policy updated.[/green]")
+        mode_desc = (
+            "default-allow (everything allowed unless denied)"
+            if mode == "allow"
+            else "default-deny (everything denied unless allowed)"
+        )
+        formatter.console.print(f"  Mode: {mode_desc}")
+        if policy.allow:
+            formatter.console.print(f"  Allow: {', '.join(policy.allow)}")
+        if policy.deny:
+            formatter.console.print(f"  Deny: {', '.join(policy.deny)}")
+
+
+@permissions_app.command("reset")
+def permissions_reset(
+    ctx: typer.Context,
+) -> None:
+    """Remove all permission restrictions.
+
+    Requires interactive confirmation (type a random code) to prevent
+    AI agents from removing the policy programmatically.
+    """
+    formatter = get_formatter(ctx)
+
+    if not _require_interactive_confirmation("remove permission policy"):
+        formatter.error(
+            message="Confirmation failed. Permission policy not changed.",
+            error_code="PERMISSION_DENIED",
+        )
+        raise typer.Exit(code=EXIT_PERMISSION_DENIED) from None
+
+    config_store: ConfigStore = get_service(ctx, "config_store")
+    config = config_store.load()
+
+    config.permissions = None
+    config_store.save(config)
+
+    if formatter.json_mode:
+        formatter.output({"status": "ok", "message": "Permission policy removed"})
+    else:
+        formatter.console.print(
+            "[green]Permission policy removed. All operations are allowed.[/green]"
+        )
+
+
+@permissions_app.command("check")
+def permissions_check(
+    ctx: typer.Context,
+    operation: str = typer.Argument(
+        help="Operation to check, e.g. 'branch.delete', 'tool:create_config'",
+    ),
+) -> None:
+    """Check if a specific operation is allowed.
+
+    Exit code 0 = allowed, 6 = denied.
+    """
+    formatter = get_formatter(ctx)
+    config_store: ConfigStore = get_service(ctx, "config_store")
+    config = config_store.load()
+
+    engine = PermissionEngine(config.permissions)
+    allowed = engine.is_allowed(operation)
+
+    if formatter.json_mode:
+        formatter.output(
+            {
+                "operation": operation,
+                "allowed": allowed,
+            }
+        )
+    else:
+        if allowed:
+            formatter.console.print(f"[green]ALLOWED[/green] {operation}")
+        else:
+            formatter.console.print(f"[red]DENIED[/red] {operation}")
+
+    if not allowed:
+        raise typer.Exit(code=EXIT_PERMISSION_DENIED) from None

--- a/src/keboola_agent_cli/commands/project.py
+++ b/src/keboola_agent_cli/commands/project.py
@@ -13,9 +13,14 @@ from rich.table import Table
 
 from ..constants import DEFAULT_STACK_URL, ENV_KBC_STORAGE_API_URL, ENV_KBC_TOKEN
 from ..errors import ConfigError, KeboolaApiError
-from ._helpers import get_formatter, get_service, map_error_to_exit_code
+from ._helpers import check_cli_permission, get_formatter, get_service, map_error_to_exit_code
 
 project_app = typer.Typer(help="Manage connected Keboola projects")
+
+
+@project_app.callback(invoke_without_command=True)
+def _project_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "project")
 
 
 def _format_project_table(console: Console, projects: list[dict[str, Any]]) -> None:

--- a/src/keboola_agent_cli/commands/sharing.py
+++ b/src/keboola_agent_cli/commands/sharing.py
@@ -9,7 +9,13 @@ Enable data sharing between Keboola projects:
 import typer
 
 from ..errors import ConfigError, KeboolaApiError
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
 
 sharing_app = typer.Typer(
     help=(
@@ -19,6 +25,11 @@ sharing_app = typer.Typer(
         "list/link/unlink work with the regular project token."
     )
 )
+
+
+@sharing_app.callback(invoke_without_command=True)
+def _sharing_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "sharing")
 
 
 @sharing_app.command("list")

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -7,9 +7,20 @@ that is not available via MCP tools.
 import typer
 
 from ..errors import ConfigError, KeboolaApiError
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
 
 storage_app = typer.Typer(help="Browse storage buckets and tables")
+
+
+@storage_app.callback(invoke_without_command=True)
+def _storage_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "storage")
 
 
 @storage_app.command("buckets")

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -15,7 +15,7 @@ from ._helpers import (
     map_error_to_exit_code,
 )
 
-storage_app = typer.Typer(help="Browse storage buckets and tables")
+storage_app = typer.Typer(help="Browse and manage storage buckets and tables")
 
 
 @storage_app.callback(invoke_without_command=True)
@@ -217,3 +217,140 @@ def storage_tables(
             )
 
         formatter.console.print(table)
+
+
+@storage_app.command("delete-table")
+def storage_delete_table(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    table_id: list[str] = typer.Option(
+        ...,
+        "--table-id",
+        help="Table ID to delete (e.g. 'in.c-bucket.table'). Can be repeated.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be deleted without executing",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Delete one or more storage tables.
+
+    Supports batch deletion with multiple --table-id flags.
+    All deletes are async and wait for completion.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    if dry_run:
+        try:
+            result = service.delete_tables(alias=project, table_ids=table_id, dry_run=True)
+        except ConfigError as exc:
+            formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+            raise typer.Exit(code=5) from None
+
+        if formatter.json_mode:
+            formatter.output(result)
+        else:
+            for tid in result.get("would_delete", []):
+                formatter.console.print(f"[bold blue]Would delete:[/bold blue] {tid}")
+        return
+
+    if (
+        not yes
+        and not formatter.json_mode
+        and not typer.confirm(f"Delete {len(table_id)} table(s) from project '{project}'?")
+    ):
+        formatter.console.print("Aborted.")
+        raise typer.Exit(code=0)
+
+    try:
+        result = service.delete_tables(alias=project, table_ids=table_id)
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        for tid in result["deleted"]:
+            formatter.console.print(f"[bold green]Deleted:[/bold green] {tid}")
+        for f in result["failed"]:
+            formatter.console.print(f"[bold red]Failed:[/bold red] {f['id']}: {f['error']}")
+
+    if result["failed"]:
+        raise typer.Exit(code=1)
+
+
+@storage_app.command("delete-bucket")
+def storage_delete_bucket(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    bucket_id: list[str] = typer.Option(
+        ...,
+        "--bucket-id",
+        help="Bucket ID to delete (e.g. 'in.c-my-bucket'). Can be repeated.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force delete even if bucket contains tables (cascade)",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be deleted without executing",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Delete one or more storage buckets.
+
+    Without --force, fails if a bucket contains tables.
+    With --force, cascade-deletes all tables in the bucket.
+    Linked and shared buckets are protected (use sharing unlink/unshare).
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    try:
+        result = service.delete_buckets(
+            alias=project, bucket_ids=bucket_id, force=force, dry_run=dry_run
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        if dry_run:
+            for bid in result.get("would_delete", []):
+                force_hint = " [force]" if force else ""
+                formatter.console.print(f"[bold blue]Would delete:[/bold blue] {bid}{force_hint}")
+        else:
+            for bid in result["deleted"]:
+                formatter.console.print(f"[bold green]Deleted:[/bold green] {bid}")
+        for f in result["failed"]:
+            formatter.console.print(f"[bold red]Failed:[/bold red] {f['id']}: {f['error']}")
+
+    if result["failed"]:
+        raise typer.Exit(code=1)

--- a/src/keboola_agent_cli/commands/sync.py
+++ b/src/keboola_agent_cli/commands/sync.py
@@ -10,9 +10,15 @@ from typing import Any
 import typer
 
 from ..errors import ConfigError, KeboolaApiError
-from ._helpers import get_formatter, get_service, map_error_to_exit_code
+from ._helpers import check_cli_permission, get_formatter, get_service, map_error_to_exit_code
 
 sync_app = typer.Typer(help="(BETA) Sync project configurations with local filesystem")
+
+
+@sync_app.callback(invoke_without_command=True)
+def _sync_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "sync")
+
 
 KEBOOLA_DIR = ".keboola"
 MANIFEST_FILE = "manifest.json"

--- a/src/keboola_agent_cli/commands/tool.py
+++ b/src/keboola_agent_cli/commands/tool.py
@@ -14,6 +14,7 @@ from ..config_store import ConfigStore
 from ..errors import ConfigError
 from ..output import OutputFormatter, format_tool_result, format_tools_table
 from ._helpers import (
+    check_cli_permission,
     emit_project_warnings,
     get_formatter,
     get_service,
@@ -22,6 +23,11 @@ from ._helpers import (
 )
 
 tool_app = typer.Typer(help="MCP tools - interact with Keboola via MCP server")
+
+
+@tool_app.callback(invoke_without_command=True)
+def _tool_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "tool")
 
 
 def _read_input(value: str, formatter: OutputFormatter) -> str:

--- a/src/keboola_agent_cli/commands/workspace.py
+++ b/src/keboola_agent_cli/commands/workspace.py
@@ -10,9 +10,20 @@ import typer
 
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_query_results, format_workspaces_table
-from ._helpers import emit_project_warnings, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    emit_project_warnings,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
 
 workspace_app = typer.Typer(help="Workspace lifecycle for SQL debugging")
+
+
+@workspace_app.callback(invoke_without_command=True)
+def _workspace_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "workspace")
 
 
 @workspace_app.command("create")

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -83,6 +83,9 @@ KBAGENT_INSTALL_SOURCE: str = "git+https://github.com/padak/keboola_agent_cli"
 AI_SERVICE_TIMEOUT: httpx.Timeout = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
 SECRET_PLACEHOLDER: str = "<YOUR_SECRET>"
 
+# --- Permission Exit Code ---
+EXIT_PERMISSION_DENIED: int = 6
+
 # --- Domain Validation Constants ---
 VALID_COMPONENT_TYPES: list[str] = ["extractor", "writer", "transformation", "application"]
 VALID_STATUSES: list[str] = ["processing", "terminated", "cancelled", "success", "error"]

--- a/src/keboola_agent_cli/errors.py
+++ b/src/keboola_agent_cli/errors.py
@@ -51,6 +51,17 @@ class ConfigError(Exception):
         self.message = message
 
 
+class PermissionDeniedError(Exception):
+    """Raised when an operation is blocked by the permission policy."""
+
+    def __init__(self, operation: str, message: str = "") -> None:
+        if not message:
+            message = f"Operation '{operation}' is blocked by the active permission policy."
+        super().__init__(message)
+        self.operation = operation
+        self.message = message
+
+
 _ERROR_CODE_TO_TYPE: dict[str, str] = {
     "INVALID_TOKEN": "authentication",
     "TIMEOUT": "network",
@@ -59,6 +70,7 @@ _ERROR_CODE_TO_TYPE: dict[str, str] = {
     "NOT_FOUND": "not_found",
     "CONFIG_ERROR": "configuration",
     "VALIDATION_ERROR": "validation",
+    "PERMISSION_DENIED": "authorization",
 }
 
 

--- a/src/keboola_agent_cli/models.py
+++ b/src/keboola_agent_cli/models.py
@@ -33,6 +33,41 @@ class ProjectConfig(BaseModel):
         return v
 
 
+class PermissionPolicy(BaseModel):
+    """Firewall-style permission policy for CLI and MCP operations.
+
+    Controls which operations are allowed/blocked:
+    - mode='allow' (default-allow): everything allowed unless in deny list
+    - mode='deny' (default-deny): everything denied unless in allow list
+
+    Patterns support exact names, globs, and categories:
+    - Exact: 'branch.delete', 'tool:create_config'
+    - Glob: 'sync.*', 'tool:create_*'
+    - Category: 'cli:write', 'cli:read', 'tool:write', 'tool:read'
+    """
+
+    mode: str = Field(
+        default="allow",
+        description="Base mode: 'allow' (default-allow) or 'deny' (default-deny)",
+    )
+    allow: list[str] = Field(
+        default_factory=list,
+        description="Allowed operation patterns (used when mode='deny')",
+    )
+    deny: list[str] = Field(
+        default_factory=list,
+        description="Denied operation patterns (used when mode='allow')",
+    )
+
+    @field_validator("mode")
+    @classmethod
+    def validate_mode(cls, v: str) -> str:
+        """Enforce valid mode values."""
+        if v not in ("allow", "deny"):
+            raise ValueError(f"Permission mode must be 'allow' or 'deny', got: {v!r}")
+        return v
+
+
 class AppConfig(BaseModel):
     """Top-level application configuration persisted to config.json."""
 
@@ -42,6 +77,10 @@ class AppConfig(BaseModel):
         default=10,
         le=100,
         description="Max concurrent threads for multi-project operations (env: KBAGENT_MAX_PARALLEL_WORKERS)",
+    )
+    permissions: PermissionPolicy | None = Field(
+        default=None,
+        description="Firewall-style permission policy (None = no restrictions)",
     )
     projects: dict[str, ProjectConfig] = Field(
         default_factory=dict,

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -65,6 +65,8 @@ OPERATION_REGISTRY: dict[str, str] = {
     "storage.buckets": "read",
     "storage.bucket-detail": "read",
     "storage.tables": "read",
+    "storage.delete-table": "destructive",
+    "storage.delete-bucket": "destructive",
     # Sync / git workflow
     "sync.init": "write",
     "sync.pull": "write",

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -1,0 +1,234 @@
+"""Firewall-style permission engine for CLI commands and MCP tools.
+
+Provides an operation registry mapping every CLI command and MCP tool category
+to a risk level, and a PermissionEngine that evaluates allow/deny policies
+with pattern matching (exact, glob, category).
+"""
+
+import fnmatch
+
+from .errors import PermissionDeniedError
+from .models import PermissionPolicy
+
+# Risk categories for all CLI operations.
+# read = no side effects, write = creates/modifies, destructive = deletes, admin = org-level
+OPERATION_REGISTRY: dict[str, str] = {
+    # Project management
+    "project.add": "admin",
+    "project.list": "read",
+    "project.remove": "admin",
+    "project.edit": "admin",
+    "project.status": "read",
+    # Config browsing & management
+    "config.list": "read",
+    "config.detail": "read",
+    "config.search": "read",
+    "config.update": "write",
+    "config.delete": "destructive",
+    "config.new": "write",
+    # Job history
+    "job.list": "read",
+    "job.detail": "read",
+    # Lineage
+    "lineage.show": "read",
+    # Sharing
+    "sharing.list": "read",
+    "sharing.share": "write",
+    "sharing.unshare": "write",
+    "sharing.link": "write",
+    "sharing.unlink": "write",
+    # Organization
+    "org.setup": "admin",
+    # Branch lifecycle
+    "branch.list": "read",
+    "branch.create": "write",
+    "branch.use": "write",
+    "branch.reset": "write",
+    "branch.delete": "destructive",
+    "branch.merge": "write",
+    # Workspace lifecycle
+    "workspace.create": "write",
+    "workspace.list": "read",
+    "workspace.detail": "read",
+    "workspace.delete": "destructive",
+    "workspace.password": "read",
+    "workspace.load": "write",
+    "workspace.query": "write",
+    "workspace.from-transformation": "write",
+    # MCP tools
+    "tool.list": "read",
+    "tool.call": "write",
+    # Component discovery
+    "component.list": "read",
+    "component.detail": "read",
+    # Storage browsing
+    "storage.buckets": "read",
+    "storage.bucket-detail": "read",
+    "storage.tables": "read",
+    # Sync / git workflow
+    "sync.init": "write",
+    "sync.pull": "write",
+    "sync.status": "read",
+    "sync.diff": "read",
+    "sync.push": "write",
+    "sync.branch-link": "write",
+    "sync.branch-unlink": "write",
+    "sync.branch-status": "read",
+    # Top-level commands
+    "init": "admin",
+    "doctor": "read",
+    "version": "read",
+    "update": "admin",
+    "context": "read",
+    "repl": "read",
+    # Permissions (always allowed -- listed for completeness)
+    "permissions.list": "read",
+    "permissions.show": "read",
+    "permissions.set": "admin",
+    "permissions.reset": "admin",
+    "permissions.check": "read",
+}
+
+# Prefixes for classifying MCP tools (mirrors mcp_service.py WRITE_PREFIXES)
+_MCP_WRITE_PREFIXES = ("create_", "update_", "add_", "set_")
+_MCP_DESTRUCTIVE_PREFIXES = ("delete_", "remove_")
+
+
+def classify_mcp_tool(tool_name: str) -> str:
+    """Classify an MCP tool by its name prefix.
+
+    Returns:
+        Risk category: 'read', 'write', or 'destructive'.
+    """
+    if tool_name.startswith(_MCP_DESTRUCTIVE_PREFIXES):
+        return "destructive"
+    if tool_name.startswith(_MCP_WRITE_PREFIXES):
+        return "write"
+    return "read"
+
+
+def _matches_pattern(operation: str, pattern: str) -> bool:
+    """Check if an operation matches a permission pattern.
+
+    Supports:
+    - Exact: 'branch.delete' matches 'branch.delete'
+    - Glob: 'sync.*' matches 'sync.push', 'tool:create_*' matches 'tool:create_config'
+    - Category 'cli:read' matches all CLI ops with category 'read'
+    - Category 'cli:write' matches all CLI ops with category 'write' or 'destructive' or 'admin'
+    - Category 'tool:read' matches all MCP tools (tool:*) with read classification
+    - Category 'tool:write' matches all MCP tools (tool:*) with write or destructive classification
+    """
+    # Category patterns: cli:read, cli:write, tool:read, tool:write
+    if pattern in ("cli:read", "cli:write", "cli:destructive", "cli:admin"):
+        # cli:* patterns only match CLI operations, never MCP tools
+        if operation.startswith("tool:"):
+            return False
+        target_category = pattern.split(":")[1]
+        # Fail-closed: unknown CLI ops default to 'write' so they are
+        # blocked by cli:write policies. This prevents new commands from
+        # bypassing restrictions if OPERATION_REGISTRY is not updated.
+        op_category = OPERATION_REGISTRY.get(operation, "write")
+        if target_category == "write":
+            # cli:write matches write, destructive, and admin
+            return op_category in ("write", "destructive", "admin")
+        return op_category == target_category
+
+    if pattern in ("tool:read", "tool:write", "tool:destructive"):
+        target_category = pattern.split(":")[1]
+        if not operation.startswith("tool:"):
+            return False
+        tool_name = operation[5:]  # strip 'tool:' prefix
+        tool_category = classify_mcp_tool(tool_name)
+        if target_category == "write":
+            # tool:write matches write and destructive
+            return tool_category in ("write", "destructive")
+        return tool_category == target_category
+
+    # Exact or glob match
+    return fnmatch.fnmatch(operation, pattern)
+
+
+class PermissionEngine:
+    """Evaluates permission policies against operations.
+
+    Thread-safe and stateless per call -- safe to share across contexts.
+    """
+
+    def __init__(self, policy: PermissionPolicy | None) -> None:
+        self._policy = policy
+
+    @property
+    def active(self) -> bool:
+        """Whether a permission policy is configured."""
+        return self._policy is not None
+
+    def is_allowed(self, operation: str) -> bool:
+        """Check if an operation is allowed by the active policy.
+
+        Returns True if no policy is configured (no restrictions).
+
+        Fail-closed: CLI operations not in OPERATION_REGISTRY are treated as
+        'write' for category matching. This ensures new commands added without
+        updating the registry are blocked by policies like 'deny cli:write'.
+        """
+        if self._policy is None:
+            return True
+
+        # permissions.* commands are always allowed (prevent lockout)
+        if operation.startswith("permissions."):
+            return True
+
+        denied = any(_matches_pattern(operation, p) for p in self._policy.deny)
+        allowed = any(_matches_pattern(operation, p) for p in self._policy.allow)
+
+        if self._policy.mode == "allow":
+            # Default-allow: blocked only if deny matches (and allow doesn't override)
+            return not (denied and not allowed)
+        # Default-deny: allowed only if allow matches (and deny doesn't override)
+        return bool(allowed and not denied)
+
+    def check_or_raise(self, operation: str) -> None:
+        """Check if an operation is allowed, raising PermissionDeniedError if not."""
+        if not self.is_allowed(operation):
+            raise PermissionDeniedError(operation)
+
+    def list_operations(self) -> list[dict[str, str]]:
+        """List all known operations with their category and allowed/denied status.
+
+        Returns a list of dicts with keys: name, category, status ('allowed' or 'denied').
+        Includes both CLI operations and MCP tool category summaries.
+        """
+        ops: list[dict[str, str]] = []
+
+        # CLI operations
+        for name, category in sorted(OPERATION_REGISTRY.items()):
+            status = "allowed" if self.is_allowed(name) else "denied"
+            ops.append({"name": name, "type": "cli", "category": category, "status": status})
+
+        # MCP tool categories (virtual entries for reference)
+        mcp_categories = [
+            ("tool:read", "read", "All MCP read tools (get_*, list_*, search, find_*, docs_query)"),
+            ("tool:write", "write", "All MCP write tools (create_*, update_*, add_*, set_*)"),
+            (
+                "tool:destructive",
+                "destructive",
+                "All MCP destructive tools (delete_*, remove_*)",
+            ),
+        ]
+        for name, category, description in mcp_categories:
+            # Check a representative tool for status
+            representative = "tool:get_buckets" if category == "read" else "tool:create_config"
+            if category == "destructive":
+                representative = "tool:delete_config"
+            status = "allowed" if self.is_allowed(representative) else "denied"
+            ops.append(
+                {
+                    "name": name,
+                    "type": "mcp",
+                    "category": category,
+                    "status": status,
+                    "description": description,
+                }
+            )
+
+        return ops

--- a/src/keboola_agent_cli/services/mcp_service.py
+++ b/src/keboola_agent_cli/services/mcp_service.py
@@ -35,6 +35,7 @@ from ..constants import (
 )
 from ..errors import ConfigError
 from ..models import ProjectConfig
+from ..permissions import PermissionEngine
 from .base import BaseService
 
 logger = logging.getLogger(__name__)
@@ -983,6 +984,18 @@ class McpService(BaseService):
 
         return missing, known_tools
 
+    def _check_tool_permission(self, tool_name: str) -> None:
+        """Check if the MCP tool is allowed by the active permission policy.
+
+        Raises:
+            PermissionDeniedError: If the tool is blocked by the policy.
+        """
+        config = self._config_store.load()
+        if config.permissions is None:
+            return
+        engine = PermissionEngine(config.permissions)
+        engine.check_or_raise(f"tool:{tool_name}")
+
     def call_tool(
         self,
         tool_name: str,
@@ -1017,6 +1030,8 @@ class McpService(BaseService):
         Raises:
             ConfigError: If tool_name is not found in the available tool list.
         """
+        self._check_tool_permission(tool_name)
+
         if tool_input is None:
             tool_input = {}
 
@@ -1073,6 +1088,8 @@ class McpService(BaseService):
         Raises:
             ConfigError: If tool_name not found or required params missing.
         """
+        self._check_tool_permission(tool_name)
+
         if tool_input is None:
             tool_input = {}
 

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -191,6 +191,147 @@ class StorageService(BaseService):
         return {"tables": tables, "project_alias": alias}
 
     # ------------------------------------------------------------------
+    # Delete operations
+    # ------------------------------------------------------------------
+
+    def delete_tables(
+        self,
+        alias: str,
+        table_ids: list[str],
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Delete one or more storage tables.
+
+        Batch-tolerant: accumulates errors per table, one failure does not
+        stop other deletes.
+
+        Returns:
+            Dict with 'deleted', 'failed', 'dry_run', 'project_alias',
+            and optionally 'would_delete'.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        if dry_run:
+            return {
+                "deleted": [],
+                "failed": [],
+                "would_delete": list(table_ids),
+                "dry_run": True,
+                "project_alias": alias,
+            }
+
+        deleted: list[str] = []
+        failed: list[dict[str, str]] = []
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            for tid in table_ids:
+                try:
+                    client.delete_table(tid)
+                    deleted.append(tid)
+                except KeboolaApiError as exc:
+                    failed.append({"id": tid, "error": exc.message})
+        finally:
+            client.close()
+
+        return {
+            "deleted": deleted,
+            "failed": failed,
+            "dry_run": False,
+            "project_alias": alias,
+        }
+
+    def delete_buckets(
+        self,
+        alias: str,
+        bucket_ids: list[str],
+        force: bool = False,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Delete one or more storage buckets.
+
+        Protections:
+        - Linked buckets (sourceBucket set) are blocked with a helpful message.
+        - Shared buckets (sharing field set) are blocked unless --force is used.
+        - Without force, non-empty buckets fail at the API level.
+
+        Batch-tolerant: accumulates errors per bucket.
+
+        Returns:
+            Dict with 'deleted', 'failed', 'dry_run', 'project_alias',
+            and optionally 'would_delete'.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        deleted: list[str] = []
+        failed: list[dict[str, str]] = []
+        would_delete: list[str] = []
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            for bid in bucket_ids:
+                # Check bucket metadata for linked/shared protections
+                try:
+                    bucket = client.get_bucket_detail(bid)
+                except KeboolaApiError as exc:
+                    failed.append({"id": bid, "error": exc.message})
+                    continue
+
+                # Linked bucket protection
+                if bucket.get("sourceBucket"):
+                    failed.append(
+                        {
+                            "id": bid,
+                            "error": (
+                                f"Bucket '{bid}' is a linked bucket. "
+                                "Use 'kbagent sharing unlink' to remove it."
+                            ),
+                        }
+                    )
+                    continue
+
+                # Shared bucket protection (unless force)
+                if bucket.get("sharing") and not force:
+                    failed.append(
+                        {
+                            "id": bid,
+                            "error": (
+                                f"Bucket '{bid}' is shared to other projects. "
+                                "Use --force to delete anyway, or 'kbagent sharing unshare' first."
+                            ),
+                        }
+                    )
+                    continue
+
+                if dry_run:
+                    would_delete.append(bid)
+                    continue
+
+                try:
+                    client.delete_bucket(bid, force=force)
+                    deleted.append(bid)
+                except KeboolaApiError as exc:
+                    failed.append({"id": bid, "error": exc.message})
+        finally:
+            client.close()
+
+        result: dict[str, Any] = {
+            "deleted": deleted,
+            "failed": failed,
+            "dry_run": dry_run,
+            "project_alias": alias,
+        }
+        if dry_run:
+            result["would_delete"] = would_delete
+        return result
+
+    # ------------------------------------------------------------------
     # Parallel workers
     # ------------------------------------------------------------------
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,349 @@
+"""Tests for the permission engine (OPERATION_REGISTRY, PermissionEngine, classify_mcp_tool)."""
+
+import pytest
+
+from keboola_agent_cli.errors import PermissionDeniedError
+from keboola_agent_cli.models import PermissionPolicy
+from keboola_agent_cli.permissions import (
+    OPERATION_REGISTRY,
+    PermissionEngine,
+    classify_mcp_tool,
+)
+
+
+class TestClassifyMcpTool:
+    """Tests for classify_mcp_tool()."""
+
+    def test_read_tools(self) -> None:
+        assert classify_mcp_tool("get_buckets") == "read"
+        assert classify_mcp_tool("list_configs") == "read"
+        assert classify_mcp_tool("search") == "read"
+        assert classify_mcp_tool("find_tables") == "read"
+        assert classify_mcp_tool("docs_query") == "read"
+
+    def test_write_tools(self) -> None:
+        assert classify_mcp_tool("create_config") == "write"
+        assert classify_mcp_tool("update_config") == "write"
+        assert classify_mcp_tool("add_tag") == "write"
+        assert classify_mcp_tool("set_metadata") == "write"
+
+    def test_destructive_tools(self) -> None:
+        assert classify_mcp_tool("delete_config") == "destructive"
+        assert classify_mcp_tool("remove_tag") == "destructive"
+
+
+class TestOperationRegistry:
+    """Tests for the OPERATION_REGISTRY."""
+
+    def test_all_operations_have_valid_categories(self) -> None:
+        valid_categories = {"read", "write", "destructive", "admin"}
+        for name, category in OPERATION_REGISTRY.items():
+            assert category in valid_categories, f"{name} has invalid category: {category}"
+
+    def test_known_read_operations(self) -> None:
+        assert OPERATION_REGISTRY["config.list"] == "read"
+        assert OPERATION_REGISTRY["job.detail"] == "read"
+        assert OPERATION_REGISTRY["project.list"] == "read"
+        assert OPERATION_REGISTRY["tool.list"] == "read"
+
+    def test_known_write_operations(self) -> None:
+        assert OPERATION_REGISTRY["branch.create"] == "write"
+        assert OPERATION_REGISTRY["config.update"] == "write"
+        assert OPERATION_REGISTRY["workspace.load"] == "write"
+
+    def test_known_destructive_operations(self) -> None:
+        assert OPERATION_REGISTRY["branch.delete"] == "destructive"
+        assert OPERATION_REGISTRY["workspace.delete"] == "destructive"
+        assert OPERATION_REGISTRY["config.delete"] == "destructive"
+
+    def test_known_admin_operations(self) -> None:
+        assert OPERATION_REGISTRY["org.setup"] == "admin"
+        assert OPERATION_REGISTRY["project.add"] == "admin"
+        assert OPERATION_REGISTRY["project.remove"] == "admin"
+
+
+class TestPermissionEngineNoPolicy:
+    """Tests for PermissionEngine with no policy (None)."""
+
+    def test_no_policy_allows_everything(self) -> None:
+        engine = PermissionEngine(None)
+        assert engine.is_allowed("branch.delete") is True
+        assert engine.is_allowed("tool:create_config") is True
+        assert engine.is_allowed("anything.at.all") is True
+
+    def test_no_policy_active_is_false(self) -> None:
+        engine = PermissionEngine(None)
+        assert engine.active is False
+
+    def test_check_or_raise_passes(self) -> None:
+        engine = PermissionEngine(None)
+        engine.check_or_raise("branch.delete")  # Should not raise
+
+
+class TestPermissionEngineAllowMode:
+    """Tests for mode='allow' (default-allow, deny blocks specific ops)."""
+
+    def test_empty_deny_allows_everything(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=[])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("branch.delete") is True
+        assert engine.is_allowed("tool:create_config") is True
+
+    def test_exact_deny(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("branch.delete") is False
+        assert engine.is_allowed("branch.create") is True
+        assert engine.is_allowed("branch.list") is True
+
+    def test_glob_deny(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["sync.*"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("sync.push") is False
+        assert engine.is_allowed("sync.pull") is False
+        assert engine.is_allowed("sync.status") is False
+        assert engine.is_allowed("branch.create") is True
+
+    def test_category_cli_write_deny(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        engine = PermissionEngine(policy)
+        # Write ops blocked
+        assert engine.is_allowed("branch.create") is False
+        assert engine.is_allowed("config.update") is False
+        # Destructive ops also blocked (cli:write includes destructive and admin)
+        assert engine.is_allowed("branch.delete") is False
+        assert engine.is_allowed("org.setup") is False
+        # Read ops still allowed
+        assert engine.is_allowed("config.list") is True
+        assert engine.is_allowed("job.detail") is True
+
+    def test_category_tool_write_deny(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["tool:write"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("tool:create_config") is False
+        assert engine.is_allowed("tool:delete_bucket") is False
+        assert engine.is_allowed("tool:get_configs") is True
+        assert engine.is_allowed("tool:list_buckets") is True
+
+    def test_tool_glob_deny(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["tool:create_*"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("tool:create_config") is False
+        assert engine.is_allowed("tool:create_bucket") is False
+        assert engine.is_allowed("tool:delete_config") is True
+        assert engine.is_allowed("tool:get_configs") is True
+
+    def test_deny_with_allow_override(self) -> None:
+        """Allow list can override deny for specific operations."""
+        policy = PermissionPolicy(
+            mode="allow",
+            deny=["cli:write"],
+            allow=["branch.create"],
+        )
+        engine = PermissionEngine(policy)
+        # branch.create overridden by allow
+        assert engine.is_allowed("branch.create") is True
+        # Other writes still blocked
+        assert engine.is_allowed("branch.delete") is False
+        assert engine.is_allowed("config.update") is False
+
+    def test_vojta_use_case(self) -> None:
+        """Vojta's use case: block all write tools, allow everything else."""
+        policy = PermissionPolicy(mode="allow", deny=["cli:write", "tool:write"])
+        engine = PermissionEngine(policy)
+        # Reads allowed
+        assert engine.is_allowed("config.list") is True
+        assert engine.is_allowed("tool:get_configs") is True
+        assert engine.is_allowed("tool.list") is True
+        assert engine.is_allowed("project.list") is True
+        # Writes blocked
+        assert engine.is_allowed("branch.create") is False
+        assert engine.is_allowed("tool:create_config") is False
+        assert engine.is_allowed("workspace.delete") is False
+        assert engine.is_allowed("tool:delete_bucket") is False
+
+
+class TestPermissionEngineDenyMode:
+    """Tests for mode='deny' (default-deny, allow enables specific ops)."""
+
+    def test_empty_allow_denies_everything(self) -> None:
+        policy = PermissionPolicy(mode="deny", allow=[])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("config.list") is False
+        assert engine.is_allowed("tool:get_configs") is False
+
+    def test_exact_allow(self) -> None:
+        policy = PermissionPolicy(mode="deny", allow=["config.list", "project.list"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("config.list") is True
+        assert engine.is_allowed("project.list") is True
+        assert engine.is_allowed("branch.create") is False
+
+    def test_category_cli_read_allow(self) -> None:
+        policy = PermissionPolicy(mode="deny", allow=["cli:read"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("config.list") is True
+        assert engine.is_allowed("job.detail") is True
+        assert engine.is_allowed("branch.create") is False
+        assert engine.is_allowed("branch.delete") is False
+
+    def test_category_tool_read_allow(self) -> None:
+        policy = PermissionPolicy(mode="deny", allow=["tool:read"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("tool:get_configs") is True
+        assert engine.is_allowed("tool:list_buckets") is True
+        assert engine.is_allowed("tool:create_config") is False
+
+    def test_deny_overrides_allow(self) -> None:
+        """In deny mode, explicit deny still wins over allow."""
+        policy = PermissionPolicy(
+            mode="deny",
+            allow=["cli:read"],
+            deny=["config.list"],
+        )
+        engine = PermissionEngine(policy)
+        # config.list matches both allow (cli:read) and deny (exact)
+        # deny wins
+        assert engine.is_allowed("config.list") is False
+        # Other reads still allowed
+        assert engine.is_allowed("job.detail") is True
+
+    def test_read_only_mode(self) -> None:
+        """Full read-only: allow only reads."""
+        policy = PermissionPolicy(mode="deny", allow=["cli:read", "tool:read"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("config.list") is True
+        assert engine.is_allowed("tool:get_configs") is True
+        assert engine.is_allowed("branch.create") is False
+        assert engine.is_allowed("tool:create_config") is False
+
+
+class TestPermissionEngineMetaCommands:
+    """permissions.* commands must always be allowed (prevent lockout)."""
+
+    def test_meta_always_allowed_in_allow_mode(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["permissions.*"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("permissions.list") is True
+        assert engine.is_allowed("permissions.show") is True
+        assert engine.is_allowed("permissions.set") is True
+        assert engine.is_allowed("permissions.reset") is True
+        assert engine.is_allowed("permissions.check") is True
+
+    def test_meta_always_allowed_in_deny_mode(self) -> None:
+        policy = PermissionPolicy(mode="deny", allow=[])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("permissions.list") is True
+        assert engine.is_allowed("permissions.reset") is True
+
+
+class TestPermissionEngineCheckOrRaise:
+    """Tests for check_or_raise()."""
+
+    def test_raises_on_denied(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        engine = PermissionEngine(policy)
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            engine.check_or_raise("branch.delete")
+        assert exc_info.value.operation == "branch.delete"
+        assert "branch.delete" in exc_info.value.message
+
+    def test_passes_on_allowed(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        engine = PermissionEngine(policy)
+        engine.check_or_raise("config.list")  # Should not raise
+
+
+class TestPermissionEngineListOperations:
+    """Tests for list_operations()."""
+
+    def test_returns_all_operations(self) -> None:
+        engine = PermissionEngine(None)
+        ops = engine.list_operations()
+        # Should have all CLI ops + 3 MCP categories
+        cli_ops = [op for op in ops if op["type"] == "cli"]
+        mcp_ops = [op for op in ops if op["type"] == "mcp"]
+        assert len(cli_ops) == len(OPERATION_REGISTRY)
+        assert len(mcp_ops) == 3
+
+    def test_status_reflects_policy(self) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        engine = PermissionEngine(policy)
+        ops = engine.list_operations()
+        branch_delete = next(op for op in ops if op["name"] == "branch.delete")
+        config_list = next(op for op in ops if op["name"] == "config.list")
+        assert branch_delete["status"] == "denied"
+        assert config_list["status"] == "allowed"
+
+
+class TestFailClosed:
+    """Unknown CLI operations should be treated as 'write' for category matching."""
+
+    def test_unknown_op_blocked_by_cli_write(self) -> None:
+        """New commands not in OPERATION_REGISTRY are blocked by cli:write."""
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        engine = PermissionEngine(policy)
+        # This operation doesn't exist in OPERATION_REGISTRY
+        assert engine.is_allowed("newfeature.create") is False
+
+    def test_unknown_op_not_matched_by_cli_read(self) -> None:
+        """Unknown operations default to 'write', not 'read'."""
+        policy = PermissionPolicy(mode="deny", allow=["cli:read"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("newfeature.create") is False
+
+    def test_unknown_op_allowed_when_no_category_deny(self) -> None:
+        """Unknown ops allowed in allow-mode when only specific ops are denied."""
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        engine = PermissionEngine(policy)
+        assert engine.is_allowed("newfeature.create") is True
+
+
+class TestOperationRegistryCompleteness:
+    """Verify OPERATION_REGISTRY covers all commands registered in cli.py."""
+
+    def test_all_subapp_commands_registered(self) -> None:
+        """Every command in every sub-app should have a registry entry."""
+
+        # Get the Click command object
+        import typer.main
+
+        from keboola_agent_cli import cli as cli_module
+
+        click_app = typer.main.get_command(cli_module.app)
+
+        missing = []
+        for group_name, group_cmd in click_app.commands.items():
+            if hasattr(group_cmd, "commands"):
+                # It's a sub-app (Click Group)
+                for cmd_name in group_cmd.commands:
+                    op = f"{group_name}.{cmd_name}"
+                    if op not in OPERATION_REGISTRY:
+                        missing.append(op)
+            else:
+                # Top-level command
+                if group_name not in OPERATION_REGISTRY:
+                    missing.append(group_name)
+
+        assert missing == [], (
+            f"Commands missing from OPERATION_REGISTRY: {missing}. "
+            "Add them to permissions.py to ensure they are covered by permission policies."
+        )
+
+
+class TestPermissionPolicyValidation:
+    """Tests for PermissionPolicy model validation."""
+
+    def test_valid_modes(self) -> None:
+        PermissionPolicy(mode="allow")
+        PermissionPolicy(mode="deny")
+
+    def test_invalid_mode(self) -> None:
+        with pytest.raises(ValueError, match="must be 'allow' or 'deny'"):
+            PermissionPolicy(mode="invalid")
+
+    def test_defaults(self) -> None:
+        policy = PermissionPolicy()
+        assert policy.mode == "allow"
+        assert policy.allow == []
+        assert policy.deny == []

--- a/tests/test_permissions_cli.py
+++ b/tests/test_permissions_cli.py
@@ -1,0 +1,471 @@
+"""Tests for permissions CLI commands and enforcement via CliRunner."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.constants import EXIT_PERMISSION_DENIED
+from keboola_agent_cli.models import AppConfig, PermissionPolicy, ProjectConfig
+
+runner = CliRunner()
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+
+def _make_store(tmp_path: Path, policy: PermissionPolicy | None = None) -> ConfigStore:
+    """Create a ConfigStore with optional permission policy."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    store = ConfigStore(config_dir=config_dir)
+    config = AppConfig(
+        projects={
+            "test": ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            )
+        },
+        permissions=policy,
+    )
+    store.save(config)
+    return store
+
+
+class TestPermissionsList:
+    """Tests for `kbagent permissions list`."""
+
+    def test_list_json_no_policy(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "list"])
+        assert result.exit_code == 0
+        resp = json.loads(result.output)
+        data = resp["data"]
+        assert isinstance(data, list)
+        assert len(data) > 0
+        # All should be allowed when no policy
+        for op in data:
+            assert op["status"] == "allowed"
+
+    def test_list_json_with_policy(self, tmp_path: Path) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "list"])
+        assert result.exit_code == 0
+        resp = json.loads(result.output)
+        data = resp["data"]
+        branch_delete = next(op for op in data if op["name"] == "branch.delete")
+        assert branch_delete["status"] == "denied"
+
+    def test_list_filter_by_category(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(
+                app, ["--json", "permissions", "list", "--category", "destructive"]
+            )
+        assert result.exit_code == 0
+        resp = json.loads(result.output)
+        data = resp["data"]
+        for op in data:
+            assert op["category"] == "destructive"
+
+
+class TestPermissionsShow:
+    """Tests for `kbagent permissions show`."""
+
+    def test_show_no_policy(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["active"] is False
+
+    def test_show_with_policy(self, tmp_path: Path) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["cli:write", "tool:write"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["active"] is True
+        assert data["mode"] == "allow"
+        assert "cli:write" in data["deny"]
+        assert "tool:write" in data["deny"]
+
+
+class TestPermissionsSet:
+    """Tests for `kbagent permissions set`."""
+
+    def test_set_deny_mode(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch(
+                "keboola_agent_cli.commands.permissions._require_interactive_confirmation",
+                return_value=True,
+            ),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "permissions",
+                    "set",
+                    "--mode",
+                    "deny",
+                    "--allow",
+                    "cli:read",
+                    "--allow",
+                    "tool:read",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["mode"] == "deny"
+        assert "cli:read" in data["allow"]
+        assert "tool:read" in data["allow"]
+
+        # Verify persisted
+        config = store.load()
+        assert config.permissions is not None
+        assert config.permissions.mode == "deny"
+
+    def test_set_allow_mode_with_deny(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch(
+                "keboola_agent_cli.commands.permissions._require_interactive_confirmation",
+                return_value=True,
+            ),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "permissions",
+                    "set",
+                    "--mode",
+                    "allow",
+                    "--deny",
+                    "cli:write",
+                    "--deny",
+                    "tool:write",
+                ],
+            )
+        assert result.exit_code == 0
+        config = store.load()
+        assert config.permissions is not None
+        assert config.permissions.deny == ["cli:write", "tool:write"]
+
+    def test_set_rejected_without_confirmation(self, tmp_path: Path) -> None:
+        """set should fail when confirmation is not provided (non-interactive)."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch(
+                "keboola_agent_cli.commands.permissions._require_interactive_confirmation",
+                return_value=False,
+            ),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "set", "--mode", "allow"])
+        assert result.exit_code == EXIT_PERMISSION_DENIED
+
+    def test_set_invalid_mode(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "set", "--mode", "invalid"])
+        assert result.exit_code == 2
+
+
+class TestPermissionsReset:
+    """Tests for `kbagent permissions reset`."""
+
+    def test_reset_removes_policy(self, tmp_path: Path) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        store = _make_store(tmp_path, policy)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch(
+                "keboola_agent_cli.commands.permissions._require_interactive_confirmation",
+                return_value=True,
+            ),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "reset"])
+        assert result.exit_code == 0
+        config = store.load()
+        assert config.permissions is None
+
+    def test_reset_rejected_without_confirmation(self, tmp_path: Path) -> None:
+        """reset should fail when confirmation is not provided."""
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        store = _make_store(tmp_path, policy)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch(
+                "keboola_agent_cli.commands.permissions._require_interactive_confirmation",
+                return_value=False,
+            ),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "reset"])
+        assert result.exit_code == EXIT_PERMISSION_DENIED
+        # Policy should remain unchanged
+        config = store.load()
+        assert config.permissions is not None
+
+
+class TestPermissionsCheck:
+    """Tests for `kbagent permissions check`."""
+
+    def test_check_allowed(self, tmp_path: Path) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "check", "config.list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["allowed"] is True
+
+    def test_check_denied(self, tmp_path: Path) -> None:
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "check", "branch.delete"])
+        assert result.exit_code == EXIT_PERMISSION_DENIED
+        data = json.loads(result.output)["data"]
+        assert data["allowed"] is False
+
+    def test_check_no_policy_always_allowed(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "permissions", "check", "branch.delete"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["allowed"] is True
+
+
+class TestPermissionsEnforcement:
+    """Tests for permission enforcement on CLI commands."""
+
+    def test_denied_command_returns_exit_6(self, tmp_path: Path) -> None:
+        """A command blocked by policy should return exit code 6."""
+        policy = PermissionPolicy(mode="allow", deny=["branch.create"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "branch",
+                    "create",
+                    "--project",
+                    "test",
+                    "--name",
+                    "my-branch",
+                ],
+            )
+        assert result.exit_code == EXIT_PERMISSION_DENIED
+
+    def test_allowed_command_proceeds(self, tmp_path: Path) -> None:
+        """A read command should proceed when writes are blocked."""
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        store = _make_store(tmp_path, policy)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockService,
+        ):
+            MockStore.return_value = store
+            service_instance = MockService.return_value
+            service_instance.list_projects.return_value = []
+            result = runner.invoke(app, ["--json", "project", "list"])
+        # Should succeed (exit 0) since project.list is a read operation
+        assert result.exit_code == 0
+
+    def test_denied_workspace_delete(self, tmp_path: Path) -> None:
+        """workspace delete should be blocked by cli:write deny."""
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "workspace",
+                    "delete",
+                    "--project",
+                    "test",
+                    "--workspace-id",
+                    "123",
+                ],
+            )
+        assert result.exit_code == EXIT_PERMISSION_DENIED
+
+    def test_permissions_commands_always_accessible(self, tmp_path: Path) -> None:
+        """permissions commands should work even in deny-all mode."""
+        policy = PermissionPolicy(mode="deny", allow=[])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            # permissions list should always work
+            result = runner.invoke(app, ["--json", "permissions", "list"])
+        assert result.exit_code == 0
+
+    def test_top_level_command_enforcement(self, tmp_path: Path) -> None:
+        """Top-level commands (init, doctor, etc.) should respect policy."""
+        policy = PermissionPolicy(mode="allow", deny=["init"])
+        store = _make_store(tmp_path, policy)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(app, ["--json", "init"])
+        assert result.exit_code == EXIT_PERMISSION_DENIED
+
+    def test_help_allowed_on_denied_command(self, tmp_path: Path) -> None:
+        """--help should work even on commands blocked by policy."""
+        policy = PermissionPolicy(mode="allow", deny=["branch.delete"])
+        store = _make_store(tmp_path, policy)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("sys.argv", ["kbagent", "branch", "delete", "--help"]),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(app, ["branch", "delete", "--help"])
+        # Should show help (exit 0), not permission denied
+        assert result.exit_code == 0
+        assert "delete" in result.output.lower()
+
+    def test_help_allowed_on_denied_subapp(self, tmp_path: Path) -> None:
+        """--help on the group level should work even when all subcommands are blocked."""
+        policy = PermissionPolicy(mode="allow", deny=["cli:write"])
+        store = _make_store(tmp_path, policy)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("sys.argv", ["kbagent", "branch", "--help"]),
+        ):
+            MockStore.return_value = store
+            result = runner.invoke(app, ["branch", "--help"])
+        assert result.exit_code == 0
+
+
+class TestInitReadOnly:
+    """Tests for `kbagent init --read-only`."""
+
+    def test_init_read_only_creates_policy(self, tmp_path: Path) -> None:
+        """init --read-only should create config with read-only permission policy."""
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        with (
+            patch("keboola_agent_cli.commands.init.Path.cwd", return_value=work_dir),
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+        ):
+            # Use a real store for the global config
+            global_dir = tmp_path / "global"
+            global_dir.mkdir()
+            MockStore.return_value = ConfigStore(config_dir=global_dir)
+
+            result = runner.invoke(app, ["--json", "init", "--read-only"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["read_only"] is True
+
+        # Verify the local config has the permission policy
+        local_config_path = work_dir / ".kbagent" / "config.json"
+        assert local_config_path.is_file()
+        config_data = json.loads(local_config_path.read_text())
+        assert config_data["permissions"]["mode"] == "allow"
+        assert "cli:write" in config_data["permissions"]["deny"]
+        assert "tool:write" in config_data["permissions"]["deny"]
+
+    def test_init_read_only_with_from_global(self, tmp_path: Path) -> None:
+        """init --read-only --from-global should copy projects AND set read-only."""
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        global_store = ConfigStore(config_dir=global_dir)
+        global_config = AppConfig(
+            projects={
+                "prod": ProjectConfig(
+                    stack_url="https://connection.keboola.com",
+                    token=TEST_TOKEN,
+                )
+            }
+        )
+        global_store.save(global_config)
+
+        with (
+            patch("keboola_agent_cli.commands.init.Path.cwd", return_value=work_dir),
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+        ):
+            MockStore.return_value = global_store
+
+            result = runner.invoke(app, ["--json", "init", "--from-global", "--read-only"])
+
+        assert result.exit_code == 0
+        local_config_path = work_dir / ".kbagent" / "config.json"
+        config_data = json.loads(local_config_path.read_text())
+        assert "prod" in config_data["projects"]
+        assert config_data["permissions"]["mode"] == "allow"
+        assert "cli:write" in config_data["permissions"]["deny"]
+
+
+class TestMcpToolPermission:
+    """Tests for MCP tool permission enforcement in McpService."""
+
+    def test_blocked_tool_raises(self, tmp_path: Path) -> None:
+        """McpService._check_tool_permission should raise PermissionDeniedError."""
+        from keboola_agent_cli.errors import PermissionDeniedError
+        from keboola_agent_cli.services.mcp_service import McpService
+
+        policy = PermissionPolicy(mode="allow", deny=["tool:write"])
+        store = _make_store(tmp_path, policy)
+        service = McpService(config_store=store)
+
+        import pytest
+
+        with pytest.raises(PermissionDeniedError):
+            service._check_tool_permission("create_config")
+
+    def test_allowed_tool_passes(self, tmp_path: Path) -> None:
+        """Read tools should pass when only writes are blocked."""
+        from keboola_agent_cli.services.mcp_service import McpService
+
+        policy = PermissionPolicy(mode="allow", deny=["tool:write"])
+        store = _make_store(tmp_path, policy)
+        service = McpService(config_store=store)
+
+        # Should not raise
+        service._check_tool_permission("get_configs")
+        service._check_tool_permission("list_buckets")
+
+    def test_no_policy_allows_all_tools(self, tmp_path: Path) -> None:
+        """Without policy, all tools should be allowed."""
+        from keboola_agent_cli.services.mcp_service import McpService
+
+        store = _make_store(tmp_path)
+        service = McpService(config_store=store)
+
+        # Should not raise
+        service._check_tool_permission("create_config")
+        service._check_tool_permission("delete_bucket")

--- a/tests/test_permissions_cli.py
+++ b/tests/test_permissions_cli.py
@@ -397,20 +397,29 @@ class TestInitReadOnly:
         assert "cli:write" in config_data["permissions"]["deny"]
         assert "tool:write" in config_data["permissions"]["deny"]
 
-        # Verify config.json is read-only on filesystem
+        # Verify config.json is owner-read-only (0400)
         import stat
 
         file_mode = local_config_path.stat().st_mode
         assert not (file_mode & stat.S_IWUSR), "config.json should not be user-writable"
+        assert not (file_mode & stat.S_IRGRP), "config.json should not be group-readable"
+        assert file_mode & stat.S_IRUSR, "config.json should be owner-readable"
 
-        # Verify .claude/settings.json was created with deny rules
+        # Verify .claude/settings.json was created with comprehensive deny rules
         claude_settings_path = work_dir / ".claude" / "settings.json"
         assert claude_settings_path.is_file()
         claude_settings = json.loads(claude_settings_path.read_text())
         deny_rules = claude_settings["permissions"]["deny"]
+        # File operation blocks
+        assert "Read(.kbagent/config.json)" in deny_rules
         assert "Edit(.kbagent/config.json)" in deny_rules
         assert "Write(.kbagent/config.json)" in deny_rules
+        # Bash blocks: any command mentioning config, chmod, permissions, config-dir
+        assert "Bash(*.kbagent/config.json*)" in deny_rules
+        assert "Bash(*chmod*.kbagent*)" in deny_rules
         assert "Bash(kbagent permissions set*)" in deny_rules
+        assert "Bash(*--config-dir*)" in deny_rules
+        assert "Bash(*KBAGENT_CONFIG_DIR*)" in deny_rules
         assert "Bash(kbagent permissions reset*)" in deny_rules
 
     def test_init_read_only_with_from_global(self, tmp_path: Path) -> None:

--- a/tests/test_permissions_cli.py
+++ b/tests/test_permissions_cli.py
@@ -397,6 +397,22 @@ class TestInitReadOnly:
         assert "cli:write" in config_data["permissions"]["deny"]
         assert "tool:write" in config_data["permissions"]["deny"]
 
+        # Verify config.json is read-only on filesystem
+        import stat
+
+        file_mode = local_config_path.stat().st_mode
+        assert not (file_mode & stat.S_IWUSR), "config.json should not be user-writable"
+
+        # Verify .claude/settings.json was created with deny rules
+        claude_settings_path = work_dir / ".claude" / "settings.json"
+        assert claude_settings_path.is_file()
+        claude_settings = json.loads(claude_settings_path.read_text())
+        deny_rules = claude_settings["permissions"]["deny"]
+        assert "Edit(.kbagent/config.json)" in deny_rules
+        assert "Write(.kbagent/config.json)" in deny_rules
+        assert "Bash(kbagent permissions set*)" in deny_rules
+        assert "Bash(kbagent permissions reset*)" in deny_rules
+
     def test_init_read_only_with_from_global(self, tmp_path: Path) -> None:
         """init --read-only --from-global should copy projects AND set read-only."""
         work_dir = tmp_path / "project"

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -1,0 +1,392 @@
+"""Tests for storage delete-table and delete-bucket commands and service methods."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import KeboolaApiError
+from keboola_agent_cli.models import AppConfig, ProjectConfig
+from keboola_agent_cli.services.storage_service import StorageService
+
+runner = CliRunner()
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+
+def _make_store(tmp_path: Path) -> ConfigStore:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    store = ConfigStore(config_dir=config_dir)
+    config = AppConfig(
+        projects={
+            "test": ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            )
+        },
+    )
+    store.save(config)
+    return store
+
+
+def _make_service(store: ConfigStore, mock_client: MagicMock) -> StorageService:
+    return StorageService(
+        config_store=store,
+        client_factory=lambda url, token: mock_client,
+    )
+
+
+class TestDeleteTablesService:
+    """Tests for StorageService.delete_tables()."""
+
+    def test_single_table_success(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_table.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(alias="test", table_ids=["in.c-data.users"])
+
+        assert result["deleted"] == ["in.c-data.users"]
+        assert result["failed"] == []
+        assert result["dry_run"] is False
+        mock_client.delete_table.assert_called_once_with("in.c-data.users")
+
+    def test_batch_partial_failure(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_table.side_effect = [
+            {"id": 1, "status": "success"},
+            KeboolaApiError("Table not found", status_code=404, error_code="NOT_FOUND"),
+        ]
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(
+            alias="test", table_ids=["in.c-data.users", "in.c-data.missing"]
+        )
+
+        assert result["deleted"] == ["in.c-data.users"]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["id"] == "in.c-data.missing"
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(alias="test", table_ids=["in.c-data.users"], dry_run=True)
+
+        assert result["dry_run"] is True
+        assert result["would_delete"] == ["in.c-data.users"]
+        mock_client.delete_table.assert_not_called()
+
+    def test_unknown_project(self, tmp_path: Path) -> None:
+        from keboola_agent_cli.errors import ConfigError
+
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        with pytest.raises(ConfigError):
+            service.delete_tables(alias="nonexistent", table_ids=["t"])
+
+
+class TestDeleteBucketsService:
+    """Tests for StorageService.delete_buckets()."""
+
+    def test_single_bucket_success(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {"id": "in.c-data"}
+        mock_client.delete_bucket.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-data"])
+
+        assert result["deleted"] == ["in.c-data"]
+        assert result["failed"] == []
+        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=False)
+
+    def test_force_flag(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {"id": "in.c-data"}
+        mock_client.delete_bucket.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        service.delete_buckets(alias="test", bucket_ids=["in.c-data"], force=True)
+
+        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=True)
+
+    def test_linked_bucket_blocked(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {
+            "id": "in.c-linked",
+            "sourceBucket": {"id": "in.c-original", "project": {"id": 123, "name": "Source"}},
+        }
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-linked"])
+
+        assert result["deleted"] == []
+        assert len(result["failed"]) == 1
+        assert "linked" in result["failed"][0]["error"].lower()
+        mock_client.delete_bucket.assert_not_called()
+
+    def test_shared_bucket_blocked_without_force(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {
+            "id": "in.c-shared",
+            "sharing": "organization",
+        }
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-shared"])
+
+        assert result["deleted"] == []
+        assert len(result["failed"]) == 1
+        assert "shared" in result["failed"][0]["error"].lower()
+
+    def test_shared_bucket_allowed_with_force(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {
+            "id": "in.c-shared",
+            "sharing": "organization",
+        }
+        mock_client.delete_bucket.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-shared"], force=True)
+
+        assert result["deleted"] == ["in.c-shared"]
+        mock_client.delete_bucket.assert_called_once()
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {"id": "in.c-data"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-data"], dry_run=True)
+
+        assert result["dry_run"] is True
+        assert result["would_delete"] == ["in.c-data"]
+        mock_client.delete_bucket.assert_not_called()
+
+    def test_batch_partial_failure(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.side_effect = [
+            {"id": "in.c-ok"},
+            {"id": "in.c-fail"},
+        ]
+        mock_client.delete_bucket.side_effect = [
+            {"id": 1, "status": "success"},
+            KeboolaApiError("Bucket has tables", status_code=400, error_code="VALIDATION_ERROR"),
+        ]
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-ok", "in.c-fail"])
+
+        assert result["deleted"] == ["in.c-ok"]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["id"] == "in.c-fail"
+
+
+class TestDeleteTableCLI:
+    """CLI tests for `kbagent storage delete-table`."""
+
+    def test_delete_table_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_tables.return_value = {
+                "deleted": ["in.c-data.users"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["deleted"] == ["in.c-data.users"]
+
+    def test_delete_table_dry_run(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_tables.return_value = {
+                "deleted": [],
+                "failed": [],
+                "would_delete": ["in.c-data.users"],
+                "dry_run": True,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_delete_table_exit_1_on_failure(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_tables.return_value = {
+                "deleted": [],
+                "failed": [{"id": "in.c-data.x", "error": "not found"}],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.x",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 1
+
+
+class TestDeleteBucketCLI:
+    """CLI tests for `kbagent storage delete-bucket`."""
+
+    def test_delete_bucket_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_buckets.return_value = {
+                "deleted": ["in.c-data"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-bucket",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-data",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["deleted"] == ["in.c-data"]
+
+    def test_delete_bucket_force(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_buckets.return_value = {
+                "deleted": ["in.c-data"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-bucket",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-data",
+                    "--force",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        svc.delete_buckets.assert_called_once_with(
+            alias="test", bucket_ids=["in.c-data"], force=True, dry_run=False
+        )
+
+    def test_delete_bucket_linked_blocked(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_buckets.return_value = {
+                "deleted": [],
+                "failed": [{"id": "in.c-linked", "error": "linked bucket"}],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-bucket",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-linked",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- Adds a complete allow/deny permission engine that restricts which CLI commands and MCP tools an AI agent can use -- like a firewall with include/exclude rules
- Introduces `kbagent permissions list|show|set|reset|check` commands for managing the policy
- `kbagent init --read-only` shortcut creates a workspace where agents can only read
- Changing or removing the policy requires typing a random confirmation code, so agents cannot bypass restrictions programmatically

**Vojta's use case** (block all writes):
```bash
kbagent permissions set --mode allow --deny "cli:write" --deny "tool:write"
```

**Pattern support**: exact (`branch.delete`), glob (`sync.*`, `tool:create_*`), category (`cli:write`, `tool:read`)

**Safety features**:
- `--help` always works on blocked commands
- `permissions` commands always accessible (no lockout)
- Unknown commands treated as write (fail-closed)
- Test validates OPERATION_REGISTRY covers all registered CLI commands
- Exit code 6 for permission denied

## Test plan

- [x] 64 new tests (unit + CLI integration) covering engine logic, enforcement, MCP blocking, init --read-only
- [x] All 1255 tests pass
- [x] Lint clean (ruff check + format)
- [ ] Manual: `kbagent permissions set --mode allow --deny "cli:write"` then try blocked command
- [ ] Manual: `kbagent branch delete --help` shows help even when blocked
- [ ] Manual: `kbagent init --read-only --from-global` creates read-only workspace

Closes #89 (Phase 1)