### PR TITLE
docs: clarify /plugin commands require Claude Code interactive terminal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,27 @@ KBC_MANAGE_API_TOKEN=xxx kbagent org setup --org-id 123 --url https://connection
 
 ## For AI agents (Claude Code, Codex, Gemini)
 
-Install the Claude Code plugin and the agent learns all commands automatically:
+Install the Claude Code plugin and the agent learns all commands automatically.
 
-```bash
+> **Important:** `/plugin` commands are Claude Code **terminal** slash commands.
+> They only work when Claude Code is running as an **interactive CLI in a terminal**
+> (`claude` command in your shell). They do **not** work in:
+> - a regular bash/shell prompt
+> - the VS Code extension chat panel
+> - the Claude desktop app chat window
+>
+> If you are using Claude Code via VS Code or the desktop app, skip to the
+> `kbagent context` fallback below.
+
+Start Claude Code in your terminal (`claude`), then type into its prompt:
+
+```
 /plugin marketplace add padak/keboola_agent_cli
 /plugin install kbagent@keboola-agent-cli
 ```
 
-Or just tell any agent to run `kbagent context` -- it prints a complete reference.
+Or just tell any agent to run `kbagent context` -- it prints a complete reference and
+works regardless of how Claude Code is launched.
 
 ### What you can ask
 


### PR DESCRIPTION
## Problem

The current README presents `/plugin` commands in a `bash` code block, which misleads users into running them in a regular shell. They only work inside Claude Code's **interactive terminal mode** (`claude` in your terminal) -- not in VS Code extension chat, not in the desktop app, and definitely not in bash.

Related to: #102

## Changes

- Moved `/plugin` snippet out of the `bash` fenced block (it's not a shell command)
- Added a clear note explaining where these commands work and where they don't
- Added a note that `kbagent context` is the fallback for users on VS Code / desktop app

## Before / After

**Before:**
```bash
/plugin marketplace add padak/keboola_agent_cli
/plugin install kbagent@keboola-agent-cli
```
(Looked like a bash command -- multiple users tried running it in a terminal and got `bash: /plugin: No such file or directory`)

**After:** Explicit warning listing the three environments where it does NOT work, plus guidance for VS Code/desktop users.