### PR TITLE
chore: bump version to 0.17.1

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.17.0"
+version = "0.17.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump version to 0.17.1

### What's in 0.17.1
- feat: storage write operations -- `create-bucket`, `create-table`, `upload-table` (#100)
- docs: CONTRIBUTING.md -- SKILL.md auto-generation guidance (#106)
- docs: README quick-start restructured for org setup onboarding (#107, closes #102)
- fix: SKILL.md freshness (#105)