### PR TITLE
feat: token refresh, MCP resolution fix, init config warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,8 @@ kbagent project list
 kbagent project remove --project NAME
 kbagent project edit --project NAME [--url URL] [--token TOKEN]
 kbagent project status [--project NAME]
+kbagent project refresh --project ALIAS [--dry-run] [--force] [--yes] [--token-description DESC] [--token-expires-in N]
+kbagent project refresh --all [--dry-run] [--force] [--yes] [--token-description DESC] [--token-expires-in N]
 
 kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]
 kbagent config detail --project NAME --component-id ID --config-id ID [--branch ID]
@@ -245,8 +247,8 @@ kbagent sharing unshare --project ALIAS --bucket-id ID
 kbagent sharing link --project ALIAS --source-project-id ID --bucket-id ID [--name NAME]
 kbagent sharing unlink --project ALIAS --bucket-id ID
 
-kbagent org setup --org-id ID --url URL [--dry-run] [--yes] [--token-description PREFIX]
-kbagent org setup --project-ids 1,2,3 --url URL [--dry-run] [--yes] [--token-description PREFIX]
+kbagent org setup --org-id ID --url URL [--dry-run] [--yes] [--token-description PREFIX] [--refresh]
+kbagent org setup --project-ids 1,2,3 --url URL [--dry-run] [--yes] [--token-description PREFIX] [--refresh]
 
 kbagent tool list [--project NAME] [--branch ID]
 kbagent tool call TOOL_NAME [--project NAME] [--input JSON|@file|-] [--branch ID]

--- a/docs/config-guide.md
+++ b/docs/config-guide.md
@@ -1,0 +1,254 @@
+# kbagent Configuration Guide
+
+kbagent uses a two-tier configuration system: a **global config** shared across
+all directories, and optional **local workspaces** for project-specific
+isolation. This guide explains how they work, when to use each, and how
+resolution works.
+
+## Architecture Overview
+
+| Tier | Location | Created by | Scope |
+|------|----------|------------|-------|
+| Global | `~/.config/keboola-agent-cli/config.json` | `kbagent project add`, `kbagent org setup` | All directories on the machine |
+| Local workspace | `.kbagent/config.json` (relative to project dir) | `kbagent init` | Only the directory tree containing `.kbagent/` |
+
+The config file is a JSON document storing registered projects, the default
+project alias, active branch state, and an optional permission policy. Tokens
+are stored in plain text, so both tiers enforce strict file permissions.
+
+## Resolution Priority
+
+When kbagent starts, it resolves the config directory using this priority chain
+(first match wins):
+
+| Priority | Source | How to set |
+|----------|--------|------------|
+| 1 | `--config-dir` CLI flag | `kbagent --config-dir /path project list` |
+| 2 | `KBAGENT_CONFIG_DIR` env var | `export KBAGENT_CONFIG_DIR=/tmp/ci-config` |
+| 3 | Walk-up from CWD | Automatic -- searches parent directories for `.kbagent/config.json` |
+| 4 | Global default | Automatic -- `~/.config/keboola-agent-cli/` |
+
+The walk-up search (priority 3) works like git searching for `.git/`: kbagent
+starts at your current working directory and checks each parent directory up to
+`$HOME` for a `.kbagent/config.json` file. This means you can `cd` into any
+subdirectory of a workspace and kbagent will still find the local config.
+
+Run `kbagent doctor` to see which config source is active and its path.
+
+## Global Config
+
+The global config is the default. It lives at the platform config directory
+(`~/.config/keboola-agent-cli/` on Linux/macOS) and is shared across all
+directories on the machine.
+
+**Created by:**
+
+```bash
+# Register projects individually
+kbagent project add --project my-project --url https://connection.keboola.com --token <token>
+
+# Or register all projects in an organization at once
+kbagent org setup --org-id 123 --url https://connection.keboola.com
+```
+
+**Good for:**
+
+- General use and exploration
+- Multi-project workflows (lineage, sharing, cross-project queries)
+- Quick one-off commands from any directory
+
+**Security:** the config file is created with `0600` permissions (owner read/write
+only). The config directory itself is created with `0700`. A `.gitignore`
+containing `*` is placed inside the config directory as a defense-in-depth
+measure.
+
+## Local Workspace
+
+A local workspace is an isolated `.kbagent/` directory in your project folder.
+When present, it **shadows the global config** -- projects registered globally
+will not be visible from that directory.
+
+### When to use
+
+- **Project isolation**: keep one project's config separate from others
+- **CI/CD pipelines**: create a temporary config without touching global state
+- **AI agent sandboxing**: restrict what an agent can do with `--read-only`
+- **Team collaboration**: each developer initializes their own workspace in a
+  shared repo (`.kbagent/` is auto-gitignored)
+
+### Creating a local workspace
+
+```bash
+# Create an empty workspace (no projects)
+kbagent init
+
+# Copy all projects from the global config
+kbagent init --from-global
+
+# Create a read-only workspace (blocks write operations)
+kbagent init --from-global --read-only
+```
+
+**What `kbagent init` does:**
+
+1. Creates `.kbagent/config.json` in the current directory
+2. Adds `.kbagent/` to `.gitignore` (creates the file if needed)
+3. If `--from-global`: copies all projects and the default project setting
+4. If `--read-only`: sets a permission policy that blocks `cli:write` and
+   `tool:write` operations, sets the config file to `0400` (read-only), and
+   creates `.claude/settings.json` rules to prevent AI agents from tampering
+   with the config
+
+**Important**: once a local workspace exists, global projects are invisible from
+that directory tree. If you need projects from global, use `--from-global` when
+initializing.
+
+## Common Workflows
+
+### Getting started (simplest path)
+
+```bash
+# Register all projects in your organization
+kbagent org setup --org-id 123 --url https://connection.keboola.com
+
+# Verify
+kbagent project list
+```
+
+This creates the global config and registers every project in the organization.
+Works from any directory.
+
+### Project-specific workspace
+
+```bash
+cd my-project/
+
+# Initialize with projects from global
+kbagent init --from-global
+
+# Local workspace is now active
+kbagent project list  # same projects as global
+```
+
+Useful when you want to set a different default project or active branch without
+affecting your global state.
+
+### AI agent sandbox (read-only)
+
+```bash
+cd agent-workspace/
+
+# Create a locked-down workspace
+kbagent init --from-global --read-only
+
+# Agent can read configs, list tables, browse jobs...
+kbagent config list
+kbagent storage tables --project my-project
+
+# ...but write operations are blocked
+kbagent branch create --project my-project --name "test"  # denied
+```
+
+The `--read-only` flag sets a permission policy that blocks all write CLI
+commands and MCP tools. The config file itself is set to read-only (`0400`), and
+Claude Code settings rules are created to prevent the agent from modifying or
+bypassing the policy.
+
+### CI/CD pipeline
+
+```bash
+# Use a temporary config directory (no local workspace, no global pollution)
+export KBAGENT_CONFIG_DIR=/tmp/kbagent-ci-$$
+
+kbagent project add --project prod \
+  --url "$KBC_URL" \
+  --token "$KBC_TOKEN"
+
+kbagent config list
+kbagent job list --limit 10
+```
+
+The environment variable takes priority over walk-up and global config, so the
+pipeline runs in full isolation.
+
+## Troubleshooting
+
+### "No projects configured" after `kbagent init`
+
+You created a local workspace without copying projects. Options:
+
+- Delete the workspace to fall back to global: `rm -rf .kbagent/`
+- Or re-initialize with projects: `rm -rf .kbagent/ && kbagent init --from-global`
+
+### Which config am I using?
+
+```bash
+kbagent doctor
+```
+
+The first check ("Config source") shows the active config path and whether it is
+`global`, `local`, `env-var`, or `cli-flag`.
+
+### How to switch back to global
+
+Delete the `.kbagent/` directory in the current directory (or any parent directory
+that contains one):
+
+```bash
+rm -rf .kbagent/
+kbagent doctor  # should now show "global"
+```
+
+### Config file has wrong permissions
+
+```bash
+kbagent doctor
+```
+
+If the doctor reports a permission warning, fix it:
+
+```bash
+chmod 600 ~/.config/keboola-agent-cli/config.json
+```
+
+## Config File Security
+
+- **File permissions**: config files are created with `0600` (owner read/write
+  only). The `kbagent doctor` command warns if permissions have drifted.
+- **Tokens in plain text**: API tokens are stored as-is in the JSON file. Protect
+  your config directory accordingly. Do not share or commit config files.
+- **Never committed to git**: `.kbagent/` is auto-added to `.gitignore` by
+  `kbagent init`. The global config directory also contains its own `.gitignore`
+  with a wildcard `*` rule.
+- **Manage tokens are never persisted**: the Manage API token (used by
+  `kbagent org setup`) is only accepted via the `KBC_MANAGE_API_TOKEN` environment
+  variable or an interactive hidden prompt. It is never written to disk.
+- **Token masking in output**: tokens are never displayed in full in CLI output.
+  The `mask_token()` utility shows only the first and last few characters.
+
+## Config File Format
+
+For reference, the config file structure:
+
+```json
+{
+  "version": 1,
+  "default_project": "my-project",
+  "projects": {
+    "my-project": {
+      "stack_url": "https://connection.keboola.com",
+      "token": "<storage-api-token>",
+      "project_name": "My Project",
+      "project_id": 12345,
+      "active_branch_id": null
+    }
+  },
+  "permissions": null
+}
+```
+
+- `version`: config schema version (currently `1`)
+- `default_project`: alias used when `--project` is not specified
+- `projects`: map of alias to project connection details
+- `permissions`: optional permission policy (set by `--read-only` or
+  `kbagent permissions set`)

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -54,6 +54,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Remove a Keboola project connection | `kbagent project remove --project ALIAS` |
 | Edit an existing Keboola project connection | `kbagent project edit --project ALIAS` |
 | Test connectivity to connected Keboola projects | `kbagent project status` |
+| Refresh expired or invalid Storage API tokens | `kbagent project refresh` |
 | Set up projects and register them in the kbagent config | `kbagent org setup --url URL` |
 | List available components from connected projects | `kbagent component list` |
 | Show detailed information about a specific component | `kbagent component detail --component-id COMPONENT-ID` |

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -156,7 +156,7 @@ If kbagent is not yet installed:
 
 ```bash
 uv tool install git+https://github.com/padak/keboola_agent_cli
-uv tool install --prerelease=allow keboola-mcp-server
+uv tool install keboola-mcp-server
 kbagent doctor --fix
 ```
 

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from pathlib import Path
 
 import typer
 
@@ -184,6 +185,28 @@ def main(
     ctx.obj["workspace_service"] = workspace_service
     ctx.obj["doctor_service"] = doctor_service
     ctx.obj["version_service"] = version_service
+
+    # Warn if empty local config shadows global with projects (#104)
+    if source == "local" and not json_output and ctx.invoked_subcommand != "init":
+        try:
+            local_config = config_store.load()
+            if not local_config.projects:
+                import platformdirs as _platformdirs
+
+                _global_dir = Path(_platformdirs.user_config_dir("keboola-agent-cli"))
+                _global_path = _global_dir / "config.json"
+                if _global_path.is_file():
+                    _global_store = ConfigStore(config_dir=_global_dir, source="global")
+                    _global_config = _global_store.load()
+                    if _global_config.projects:
+                        _count = len(_global_config.projects)
+                        formatter.warning(
+                            f"Local workspace has no projects but global config has {_count}. "
+                            f"Run 'kbagent init --from-global' to copy them, "
+                            f"or remove {config_store.config_path.parent}/ to use global config."
+                        )
+        except Exception:
+            pass  # Don't let warning check crash the CLI
 
     # Enforce permissions for top-level commands (sub-app commands use callbacks)
     _top_level_commands = {"init", "doctor", "version", "update", "context", "repl"}

--- a/src/keboola_agent_cli/commands/_helpers.py
+++ b/src/keboola_agent_cli/commands/_helpers.py
@@ -7,14 +7,46 @@ Provides common patterns used by all CLI commands:
 - Branch resolution for --branch flag
 """
 
+import os
+import sys
 from typing import Any
 
 import typer
 
 from ..config_store import ConfigStore
-from ..constants import EXIT_PERMISSION_DENIED
+from ..constants import ENV_KBC_MANAGE_API_TOKEN, EXIT_PERMISSION_DENIED
 from ..errors import KeboolaApiError, PermissionDeniedError
 from ..output import OutputFormatter
+
+
+def resolve_manage_token() -> str:
+    """Resolve the manage token from env var or interactive prompt.
+
+    Token resolution order:
+    1. KBC_MANAGE_API_TOKEN env var (for CI/CD)
+    2. Interactive prompt with hidden input (if TTY)
+    3. Error if neither available
+
+    Returns:
+        The manage API token.
+
+    Raises:
+        typer.Exit: If no token can be resolved.
+    """
+    env_token = os.environ.get(ENV_KBC_MANAGE_API_TOKEN)
+    if env_token:
+        return env_token
+
+    is_tty = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
+    if is_tty:
+        return typer.prompt("Manage API token", hide_input=True)
+
+    typer.echo(
+        f"Error: No manage token available. Set {ENV_KBC_MANAGE_API_TOKEN} env var "
+        "or run interactively.",
+        err=True,
+    )
+    raise typer.Exit(code=2)
 
 
 def get_formatter(ctx: typer.Context) -> OutputFormatter:

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -163,10 +163,11 @@ Use `kbagent <command> --help` for full flag details and examples.
 
 ### Organization Management
 
-  kbagent org setup --org-id ID --url URL [--dry-run] [--yes] [--token-description PREFIX]
+  kbagent org setup --org-id ID --url URL [--dry-run] [--yes] [--token-description PREFIX] [--refresh]
     Bulk-onboard all org projects. Requires org-admin manage token. Idempotent.
+    --refresh also refreshes tokens for already-registered projects with invalid tokens.
 
-  kbagent org setup --project-ids 901,9621,10539 --url URL [--dry-run] [--yes]
+  kbagent org setup --project-ids 901,9621,10539 --url URL [--dry-run] [--yes] [--refresh]
     Non-admin mode: onboard specific projects by ID. Works with Personal Access Token (PAT).
     Use --org-id OR --project-ids (at least one required).
     Token via KBC_MANAGE_API_TOKEN env var or interactive prompt.

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -69,6 +69,10 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent project status [--project NAME]
     Test connectivity. Shows OK/ERROR with response time.
 
+  kbagent project refresh --project ALIAS [--dry-run] [--force] [--yes] [--token-description ...] [--token-expires-in N]
+  kbagent project refresh --all [--dry-run] [--force] [--yes] [--token-description ...] [--token-expires-in N]
+    Refresh project tokens via Manage API. --all refreshes all projects. --force replaces non-expiring tokens.
+
 ### Component Discovery
 
   kbagent component list [--project NAME] [--type TYPE] [--query "search"]

--- a/src/keboola_agent_cli/commands/init.py
+++ b/src/keboola_agent_cli/commands/init.py
@@ -2,6 +2,7 @@
 
 import json
 import stat
+import sys
 from pathlib import Path
 
 import typer
@@ -42,8 +43,31 @@ def init_command(
         return
 
     config = AppConfig()
-    if from_global:
-        global_store: ConfigStore = get_service(ctx, "config_store")
+
+    # Check if global config has projects to offer
+    global_store: ConfigStore = get_service(ctx, "config_store")
+    copy_from_global = from_global
+
+    if not from_global and global_store.source == "global":
+        try:
+            global_config = global_store.load()
+            project_count = len(global_config.projects)
+            if project_count > 0:
+                is_tty = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
+                if not formatter.json_mode and is_tty:
+                    copy_from_global = typer.confirm(
+                        f"Global config has {project_count} project(s). Copy to local workspace?",
+                        default=True,
+                    )
+                else:
+                    formatter.warning(
+                        f"Global config has {project_count} project(s) that won't be "
+                        "available in local workspace. Use --from-global to copy them."
+                    )
+        except Exception:
+            pass  # Global config unreadable, proceed with empty
+
+    if copy_from_global:
         if global_store.source != "global":
             formatter.error(
                 "CONFIG_ERROR",
@@ -73,7 +97,7 @@ def init_command(
 
     project_count = len(config.projects)
     message = f"Initialized local workspace at {local_dir}"
-    if from_global and project_count > 0:
+    if copy_from_global and project_count > 0:
         message += f" (copied {project_count} project(s) from global config)"
     if read_only:
         message += " [read-only mode]"
@@ -83,7 +107,7 @@ def init_command(
             "message": message,
             "path": str(local_dir),
             "created": True,
-            "projects_copied": project_count if from_global else 0,
+            "projects_copied": project_count if copy_from_global else 0,
             "read_only": read_only,
         }
     )

--- a/src/keboola_agent_cli/commands/org.py
+++ b/src/keboola_agent_cli/commands/org.py
@@ -239,11 +239,12 @@ def org_setup(
         _format_setup_result(formatter.console, preview)
 
         would_add = len(preview.get("projects_added", []))
-        if would_add == 0:
+        would_skip = len(preview.get("projects_skipped", []))
+        if would_add == 0 and not (refresh and would_skip > 0):
             formatter.console.print("\nNo new projects to add.")
             return
 
-        if not typer.confirm(f"\nProceed to add {would_add} project(s)?"):
+        if would_add > 0 and not typer.confirm(f"\nProceed to add {would_add} project(s)?"):
             formatter.console.print("Aborted.")
             raise typer.Exit(code=0)
 

--- a/src/keboola_agent_cli/commands/org.py
+++ b/src/keboola_agent_cli/commands/org.py
@@ -4,16 +4,19 @@ Thin CLI layer: parses arguments, calls OrgService, formats output.
 No business logic belongs here.
 """
 
-import os
-import sys
-
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..constants import DEFAULT_TOKEN_DESCRIPTION, ENV_KBC_MANAGE_API_TOKEN, ENV_KBC_STORAGE_API_URL
+from ..constants import DEFAULT_TOKEN_DESCRIPTION, ENV_KBC_STORAGE_API_URL
 from ..errors import KeboolaApiError
-from ._helpers import check_cli_permission, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+    resolve_manage_token,
+)
 
 org_app = typer.Typer(help="Organization management")
 
@@ -21,36 +24,6 @@ org_app = typer.Typer(help="Organization management")
 @org_app.callback(invoke_without_command=True)
 def _org_permission_check(ctx: typer.Context) -> None:
     check_cli_permission(ctx, "org")
-
-
-def _resolve_manage_token() -> str:
-    """Resolve the manage token from env var or interactive prompt.
-
-    Token resolution order:
-    1. KBC_MANAGE_API_TOKEN env var (for CI/CD)
-    2. Interactive prompt with hidden input (if TTY)
-    3. Error if neither available
-
-    Returns:
-        The manage API token.
-
-    Raises:
-        typer.Exit: If no token can be resolved.
-    """
-    env_token = os.environ.get(ENV_KBC_MANAGE_API_TOKEN)
-    if env_token:
-        return env_token
-
-    is_tty = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
-    if is_tty:
-        return typer.prompt("Manage API token", hide_input=True)
-
-    typer.echo(
-        f"Error: No manage token available. Set {ENV_KBC_MANAGE_API_TOKEN} env var "
-        "or run interactively.",
-        err=True,
-    )
-    raise typer.Exit(code=2)
 
 
 def _parse_project_ids(value: str | None) -> list[int] | None:
@@ -71,6 +44,7 @@ def _format_setup_result(console: Console, data: dict) -> None:
     dry_run = data.get("dry_run", False)
     projects_found = data.get("projects_found", 0)
     added = data.get("projects_added", [])
+    refreshed = data.get("projects_refreshed", [])
     skipped = data.get("projects_skipped", [])
     failed = data.get("projects_failed", [])
 
@@ -95,6 +69,27 @@ def _format_setup_result(console: Console, data: dict) -> None:
             table.add_column("Token", style="dim")
 
         for p in added:
+            if dry_run:
+                table.add_row(p["alias"], str(p["project_id"]), p["project_name"])
+            else:
+                table.add_row(
+                    p["alias"], str(p["project_id"]), p["project_name"], p.get("token", "")
+                )
+
+        console.print(table)
+        console.print()
+
+    # Refreshed tokens table
+    if refreshed:
+        action_label = "Tokens to Refresh" if dry_run else "Tokens Refreshed"
+        table = Table(title=action_label)
+        table.add_column("Alias", style="bold cyan")
+        table.add_column("Project ID", justify="right")
+        table.add_column("Project Name")
+        if not dry_run:
+            table.add_column("Token", style="dim")
+
+        for p in refreshed:
             if dry_run:
                 table.add_row(p["alias"], str(p["project_id"]), p["project_name"])
             else:
@@ -136,6 +131,9 @@ def _format_setup_result(console: Console, data: dict) -> None:
     if added:
         verb = "to add" if dry_run else "added"
         summary_parts.append(f"[bold green]{len(added)}[/bold green] {verb}")
+    if refreshed:
+        verb = "to refresh" if dry_run else "refreshed"
+        summary_parts.append(f"[bold cyan]{len(refreshed)}[/bold cyan] {verb}")
     if skipped:
         summary_parts.append(f"[dim]{len(skipped)} skipped[/dim]")
     if failed:
@@ -185,6 +183,11 @@ def org_setup(
         min=1,
         help="Token lifetime in seconds (e.g. 3600 for 1 hour). If not set, tokens never expire.",
     ),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help="Refresh tokens for already-registered projects with invalid tokens",
+    ),
 ) -> None:
     """Set up projects and register them in the kbagent config.
 
@@ -212,7 +215,7 @@ def org_setup(
         )
         raise typer.Exit(code=2)
 
-    manage_token = _resolve_manage_token()
+    manage_token = resolve_manage_token()
 
     # Build kwargs shared by preview and real call
     setup_kwargs: dict = {
@@ -250,6 +253,27 @@ def org_setup(
     except KeboolaApiError as exc:
         _handle_api_error(formatter, exc)
         return
+
+    # Refresh tokens for skipped (already-registered) projects if requested
+    if refresh and result.get("projects_skipped"):
+        config = ctx.obj["config_store"].load()
+        skipped_ids = {p["project_id"] for p in result["projects_skipped"]}
+        skipped_aliases = [
+            alias for alias, proj in config.projects.items() if proj.project_id in skipped_ids
+        ]
+        if skipped_aliases:
+            try:
+                refresh_result = service.refresh_tokens(
+                    manage_token=manage_token,
+                    aliases=skipped_aliases,
+                    token_description=token_description,
+                    token_expires_in=token_expires_in,
+                    dry_run=dry_run,
+                )
+                result["projects_refreshed"] = refresh_result.get("projects_refreshed", [])
+            except KeboolaApiError as exc:
+                _handle_api_error(formatter, exc)
+                return
 
     formatter.output(result, _format_setup_result)
 

--- a/src/keboola_agent_cli/commands/project.py
+++ b/src/keboola_agent_cli/commands/project.py
@@ -11,9 +11,20 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..constants import DEFAULT_STACK_URL, ENV_KBC_STORAGE_API_URL, ENV_KBC_TOKEN
+from ..constants import (
+    DEFAULT_STACK_URL,
+    DEFAULT_TOKEN_DESCRIPTION,
+    ENV_KBC_STORAGE_API_URL,
+    ENV_KBC_TOKEN,
+)
 from ..errors import ConfigError, KeboolaApiError
-from ._helpers import check_cli_permission, get_formatter, get_service, map_error_to_exit_code
+from ._helpers import (
+    check_cli_permission,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+    resolve_manage_token,
+)
 
 project_app = typer.Typer(help="Manage connected Keboola projects")
 
@@ -238,6 +249,89 @@ def project_edit(
         raise typer.Exit(code=5) from None
 
 
+def _format_refresh_result(console: Console, data: dict) -> None:
+    """Render token refresh results as Rich tables with summary."""
+    dry_run = data.get("dry_run", False)
+    mode_label = "[bold yellow]DRY RUN[/bold yellow] " if dry_run else ""
+    console.print(f"\n{mode_label}Token Refresh\n")
+
+    # Refreshed projects
+    refreshed = data.get("projects_refreshed", [])
+    if refreshed:
+        action_label = "Projects to Refresh" if dry_run else "Projects Refreshed"
+        table = Table(title=action_label)
+        table.add_column("Alias", style="bold cyan")
+        table.add_column("Project ID", justify="right")
+        table.add_column("Project Name")
+        if not dry_run:
+            table.add_column("Token", style="dim")
+
+        for p in refreshed:
+            if dry_run:
+                table.add_row(p["alias"], str(p["project_id"]), p["project_name"])
+            else:
+                table.add_row(
+                    p["alias"], str(p["project_id"]), p["project_name"], p.get("token", "")
+                )
+
+        console.print(table)
+        console.print()
+
+    # Valid projects (tokens that were fine)
+    valid = data.get("projects_valid", [])
+    if valid:
+        table = Table(title="Projects Valid")
+        table.add_column("Alias", style="bold cyan")
+        table.add_column("Project ID", justify="right")
+        table.add_column("Project Name")
+
+        for p in valid:
+            table.add_row(p["alias"], str(p["project_id"]), p["project_name"])
+
+        console.print(table)
+        console.print()
+
+    # Skipped projects
+    skipped = data.get("projects_skipped", [])
+    if skipped:
+        table = Table(title="Projects Skipped")
+        table.add_column("Alias", style="bold cyan")
+        table.add_column("Reason", style="dim")
+
+        for p in skipped:
+            table.add_row(p["alias"], p["reason"])
+
+        console.print(table)
+        console.print()
+
+    # Failed projects
+    failed = data.get("projects_failed", [])
+    if failed:
+        table = Table(title="Projects Failed")
+        table.add_column("Alias", style="bold cyan")
+        table.add_column("Error", style="bold red")
+
+        for p in failed:
+            table.add_row(p["alias"], p["error"])
+
+        console.print(table)
+        console.print()
+
+    # Summary line
+    summary_parts = []
+    if refreshed:
+        verb = "to refresh" if dry_run else "refreshed"
+        summary_parts.append(f"[bold green]{len(refreshed)}[/bold green] {verb}")
+    if valid:
+        summary_parts.append(f"[bold green]{len(valid)}[/bold green] valid")
+    if skipped:
+        summary_parts.append(f"[dim]{len(skipped)} skipped[/dim]")
+    if failed:
+        summary_parts.append(f"[bold red]{len(failed)} failed[/bold red]")
+
+    console.print("Summary: " + ", ".join(summary_parts) if summary_parts else "No changes.")
+
+
 @project_app.command("status")
 def project_status(
     ctx: typer.Context,
@@ -265,3 +359,111 @@ def project_status(
             retryable=exc.retryable,
         )
         raise typer.Exit(code=exit_code) from None
+
+
+@project_app.command("refresh")
+def project_refresh(
+    ctx: typer.Context,
+    project: str | None = typer.Option(
+        None, "--project", "-p", help="Refresh token for a specific project"
+    ),
+    all_projects: bool = typer.Option(
+        False, "--all", help="Refresh all projects with invalid tokens"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview what would be refreshed without making changes"
+    ),
+    force: bool = typer.Option(False, "--force", help="Refresh even if token is valid"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    token_description: str = typer.Option(
+        DEFAULT_TOKEN_DESCRIPTION,
+        "--token-description",
+        help="Description prefix for created Storage API tokens",
+    ),
+    token_expires_in: int | None = typer.Option(
+        None,
+        "--token-expires-in",
+        min=1,
+        help="Token lifetime in seconds. If not set, tokens never expire.",
+    ),
+) -> None:
+    """Refresh expired or invalid Storage API tokens.
+
+    Creates new tokens via the Manage API and updates the local config.
+    Requires a Manage API token (via KBC_MANAGE_API_TOKEN env var or interactive prompt).
+
+    \b
+    Examples:
+        kbagent project refresh --project prod
+        kbagent project refresh --all
+        kbagent project refresh --all --dry-run
+        kbagent project refresh --all --force
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "org_service")
+
+    # Validate: must have --project or --all, not both, not neither
+    if project and all_projects:
+        formatter.error(
+            message="Provide --project or --all, not both",
+            error_code="usage_error",
+        )
+        raise typer.Exit(code=2)
+    if not project and not all_projects:
+        formatter.error(
+            message="Provide --project or --all",
+            error_code="usage_error",
+        )
+        raise typer.Exit(code=2)
+
+    manage_token = resolve_manage_token()
+
+    aliases = [project] if project else None
+
+    # Build kwargs shared by preview and real call
+    refresh_kwargs: dict = {
+        "manage_token": manage_token,
+        "aliases": aliases,
+        "token_description": token_description,
+        "token_expires_in": token_expires_in,
+        "force": force,
+    }
+
+    # Interactive safety: show preview first, then confirm
+    interactive = not formatter.json_mode and not yes and not dry_run
+    if interactive:
+        try:
+            preview = service.refresh_tokens(**refresh_kwargs, dry_run=True)
+        except KeboolaApiError as exc:
+            exit_code = map_error_to_exit_code(exc)
+            formatter.error(
+                message=exc.message,
+                error_code=exc.error_code,
+                retryable=exc.retryable,
+            )
+            raise typer.Exit(code=exit_code) from None
+
+        _format_refresh_result(formatter.console, preview)
+
+        would_refresh = len(preview.get("projects_refreshed", []))
+        if would_refresh == 0:
+            formatter.console.print("\nAll tokens are valid.")
+            return
+
+        if not typer.confirm(f"\nProceed to refresh {would_refresh} token(s)?"):
+            formatter.console.print("Aborted.")
+            raise typer.Exit(code=0)
+
+    # Execute the actual refresh
+    try:
+        result = service.refresh_tokens(**refresh_kwargs, dry_run=dry_run)
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(
+            message=exc.message,
+            error_code=exc.error_code,
+            retryable=exc.retryable,
+        )
+        raise typer.Exit(code=exit_code) from None
+
+    formatter.output(result, _format_refresh_result)

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -19,6 +19,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     "project.remove": "admin",
     "project.edit": "admin",
     "project.status": "read",
+    "project.refresh": "admin",
     # Config browsing & management
     "config.list": "read",
     "config.detail": "read",

--- a/src/keboola_agent_cli/services/mcp_service.py
+++ b/src/keboola_agent_cli/services/mcp_service.py
@@ -118,8 +118,10 @@ def detect_mcp_server_command() -> list[str] | None:
         if result.returncode == 0:
             return ["python", "-m", "keboola_mcp_server"]
     # 3. uvx WITHOUT @latest (uses cached version: ~1s cached / ~4.5s uncached)
+    # No --prerelease=allow: pre-releases can pull broken dependency chains
+    # (e.g. FastMCP 2.14.5 with broken fakeredis). Stable releases only.
     if shutil.which("uvx"):
-        return ["uvx", "--prerelease=allow", "keboola_mcp_server"]
+        return ["uvx", "keboola_mcp_server"]
     return None
 
 
@@ -159,7 +161,7 @@ def ensure_mcp_installed() -> dict[str, Any]:
     if shutil.which("uv"):
         try:
             result = subprocess.run(
-                ["uv", "tool", "install", "--prerelease=allow", "keboola-mcp-server"],
+                ["uv", "tool", "install", "keboola-mcp-server"],
                 capture_output=True,
                 text=True,
                 timeout=120,
@@ -186,7 +188,7 @@ def ensure_mcp_installed() -> dict[str, Any]:
         return {
             "method": "uvx_fallback",
             "installed": False,
-            "message": "Using uvx (slower). Run 'uv tool install --prerelease=allow keboola-mcp-server' for faster startup",
+            "message": "Using uvx (slower). Run 'uv tool install keboola-mcp-server' for faster startup",
         }
 
     return {
@@ -1472,9 +1474,7 @@ class McpService(BaseService):
         message = f"MCP server available via: {' '.join(command)} ({transport_info})"
         if is_uvx_fallback:
             status = "warn"
-            message += (
-                ". For faster startup, run: uv tool install --prerelease=allow keboola-mcp-server"
-            )
+            message += ". For faster startup, run: uv tool install keboola-mcp-server"
 
         return {
             "check": "mcp_server",

--- a/src/keboola_agent_cli/services/org_service.py
+++ b/src/keboola_agent_cli/services/org_service.py
@@ -225,6 +225,248 @@ class OrgService:
             "token_expires_in": token_expires_in,
         }
 
+    def refresh_tokens(
+        self,
+        manage_token: str,
+        aliases: list[str] | None = None,
+        token_description: str = DEFAULT_TOKEN_DESCRIPTION,
+        dry_run: bool = False,
+        token_expires_in: int | None = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Refresh storage API tokens for registered projects.
+
+        Checks each project's token validity and creates new tokens for
+        projects with expired or invalid tokens. Already-valid tokens are
+        skipped unless ``force=True``.
+
+        Args:
+            manage_token: Manage API token (for creating new storage tokens).
+            aliases: Optional list of project aliases to refresh. If None, all
+                projects are checked.
+            token_description: Description prefix for newly created tokens.
+            dry_run: If True, only preview what would happen without making changes.
+            token_expires_in: Token lifetime in seconds. None means no expiration.
+            force: If True, refresh all tokens even if they are still valid.
+
+        Returns:
+            Dict with refresh results including refreshed, valid, skipped,
+            and failed projects.
+        """
+        config = self._config_store.load()
+
+        # Determine which projects to check
+        projects_to_check: list[tuple[str, ProjectConfig]] = []
+        failed: list[dict[str, Any]] = []
+
+        if aliases:
+            for alias in aliases:
+                if alias not in config.projects:
+                    failed.append(
+                        {
+                            "alias": alias,
+                            "project_name": "",
+                            "error": f"Project '{alias}' not found in config",
+                        }
+                    )
+                else:
+                    projects_to_check.append((alias, config.projects[alias]))
+        else:
+            projects_to_check = list(config.projects.items())
+
+        if not projects_to_check:
+            return {
+                "dry_run": dry_run,
+                "projects_checked": 0,
+                "projects_refreshed": [],
+                "projects_valid": [],
+                "projects_skipped": [],
+                "projects_failed": failed,
+                "token_expires_in": token_expires_in,
+            }
+
+        # Resolve manage token owner identity for unique token naming
+        owner_name = ""
+        manage_client = self._manage_client_factory(
+            projects_to_check[0][1].stack_url,
+            manage_token,
+        )
+        try:
+            token_info = manage_client.verify_token()
+            user_info = token_info.get("user", {})
+            owner_name = user_info.get("email") or user_info.get("name", "")
+        except Exception:
+            logger.debug("Could not resolve manage token owner identity")
+        finally:
+            manage_client.close()
+
+        projects_refreshed: list[dict[str, Any]] = []
+        projects_valid: list[dict[str, Any]] = []
+        projects_skipped: list[dict[str, Any]] = []
+
+        for alias, project in projects_to_check:
+            # Skip projects without project_id (cannot create tokens via Manage API)
+            if project.project_id is None:
+                projects_skipped.append(
+                    {
+                        "alias": alias,
+                        "project_name": project.project_name,
+                        "reason": "Cannot refresh: project_id is missing",
+                    }
+                )
+                continue
+
+            # Check current token validity
+            token_valid = False
+            try:
+                client = self._storage_client_factory(project.stack_url, project.token)
+                try:
+                    client.verify_token()
+                    token_valid = True
+                except KeboolaApiError as exc:
+                    if exc.error_code == "INVALID_TOKEN":
+                        token_valid = False
+                    else:
+                        raise
+                finally:
+                    client.close()
+            except KeboolaApiError:
+                token_valid = False
+            except Exception as exc:
+                failed.append(
+                    {
+                        "alias": alias,
+                        "project_name": project.project_name,
+                        "error": f"Error checking token: {exc}",
+                    }
+                )
+                continue
+
+            # Valid token and not forcing refresh
+            if token_valid and not force:
+                projects_valid.append(
+                    {
+                        "alias": alias,
+                        "project_id": project.project_id,
+                        "project_name": project.project_name,
+                    }
+                )
+                continue
+
+            # Token needs refresh (or force=True)
+            if dry_run:
+                projects_refreshed.append(
+                    {
+                        "alias": alias,
+                        "project_id": project.project_id,
+                        "project_name": project.project_name,
+                        "token": "***",
+                        "action": "would_refresh",
+                    }
+                )
+                continue
+
+            try:
+                new_token = self._refresh_single_project(
+                    manage_token=manage_token,
+                    alias=alias,
+                    project=project,
+                    token_description=token_description,
+                    owner_name=owner_name,
+                    token_expires_in=token_expires_in,
+                )
+                projects_refreshed.append(
+                    {
+                        "alias": alias,
+                        "project_id": project.project_id,
+                        "project_name": project.project_name,
+                        "token": mask_token(new_token),
+                        "action": "refreshed",
+                    }
+                )
+            except Exception as exc:
+                failed.append(
+                    {
+                        "alias": alias,
+                        "project_name": project.project_name,
+                        "error": str(exc),
+                    }
+                )
+
+        total_count = len(projects_to_check)
+
+        return {
+            "dry_run": dry_run,
+            "projects_checked": total_count,
+            "projects_refreshed": projects_refreshed,
+            "projects_valid": projects_valid,
+            "projects_skipped": projects_skipped,
+            "projects_failed": failed,
+            "token_expires_in": token_expires_in,
+        }
+
+    def _refresh_single_project(
+        self,
+        manage_token: str,
+        alias: str,
+        project: ProjectConfig,
+        token_description: str,
+        owner_name: str = "",
+        token_expires_in: int | None = None,
+    ) -> str:
+        """Create a new token for an existing project and update the config.
+
+        Args:
+            manage_token: Manage API token (for creating the storage token).
+            alias: The project alias in the config store.
+            project: The existing project configuration.
+            token_description: Description prefix for the created token.
+            owner_name: Email/name of the manage token owner (for unique identification).
+            token_expires_in: Token lifetime in seconds. None means no expiration.
+
+        Returns:
+            The new storage API token string.
+        """
+        description = f"{token_description} [{owner_name}]" if owner_name else token_description
+
+        logger.info(
+            "Refreshing token for project %d (%s) alias '%s' with description '%s'",
+            project.project_id,
+            project.project_name,
+            alias,
+            description,
+        )
+
+        # Create a new Storage API token via Manage API
+        manage_client = self._manage_client_factory(project.stack_url, manage_token)
+        try:
+            token_data = manage_client.create_project_token(
+                project_id=project.project_id,
+                description=description,
+                expires_in=token_expires_in,
+            )
+        finally:
+            manage_client.close()
+
+        storage_token = token_data["token"]
+
+        # Verify the new token to get project info
+        storage_client = self._storage_client_factory(project.stack_url, storage_token)
+        try:
+            token_info = storage_client.verify_token()
+        finally:
+            storage_client.close()
+
+        # Update the project in config
+        self._config_store.edit_project(
+            alias,
+            token=storage_token,
+            project_name=token_info.project_name,
+            project_id=token_info.project_id,
+        )
+
+        return storage_token
+
     @staticmethod
     def _fetch_projects_by_ids(
         manage_client: ManageClient,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4026,7 +4026,7 @@ class TestOrgSetupBasic:
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-123456789012345678",
             ),
         ):
@@ -4090,7 +4090,7 @@ class TestOrgSetupBasic:
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-123456789012345678",
             ),
         ):
@@ -4152,7 +4152,7 @@ class TestOrgSetupBasic:
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-123456789012345678",
             ),
         ):
@@ -4196,7 +4196,7 @@ class TestOrgSetupBasic:
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-123456789012345678",
             ),
         ):
@@ -4225,7 +4225,7 @@ class TestOrgSetupBasic:
     def test_missing_org_id_and_project_ids_exit_2(self) -> None:
         """org setup without --org-id and --project-ids exits with code 2."""
         with patch(
-            "keboola_agent_cli.commands.org._resolve_manage_token",
+            "keboola_agent_cli.commands.org.resolve_manage_token",
             return_value="manage-token-123456789012345678",
         ):
             result = runner.invoke(
@@ -4275,7 +4275,7 @@ class TestOrgSetupBasic:
             patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="pat-token-123456789012345678901",
             ),
         ):
@@ -4657,7 +4657,7 @@ class TestOrgSetup:
             patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-abcdef",
             ),
         ):
@@ -4739,7 +4739,7 @@ class TestOrgSetup:
             patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-abcdef",
             ),
         ):
@@ -4780,7 +4780,7 @@ class TestOrgSetup:
             patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-abcdef",
             ),
         ):
@@ -4827,7 +4827,7 @@ class TestOrgSetup:
             patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
             patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
             patch(
-                "keboola_agent_cli.commands.org._resolve_manage_token",
+                "keboola_agent_cli.commands.org.resolve_manage_token",
                 return_value="manage-token-abcdef",
             ),
         ):
@@ -5120,43 +5120,46 @@ class TestBranchRequiresProject:
 
 
 class TestResolveManageToken:
-    """Tests for _resolve_manage_token() in org.py."""
+    """Tests for resolve_manage_token() in _helpers.py."""
 
     def test_token_from_env(self) -> None:
-        """_resolve_manage_token returns token from KBC_MANAGE_API_TOKEN env var."""
-        from keboola_agent_cli.commands.org import _resolve_manage_token
+        """resolve_manage_token returns token from KBC_MANAGE_API_TOKEN env var."""
+        from keboola_agent_cli.commands._helpers import resolve_manage_token
 
         with patch.dict(os.environ, {"KBC_MANAGE_API_TOKEN": "env-manage-token"}):
-            token = _resolve_manage_token()
+            token = resolve_manage_token()
 
         assert token == "env-manage-token"
 
     def test_token_from_prompt(self) -> None:
-        """_resolve_manage_token prompts interactively when env var is not set."""
+        """resolve_manage_token prompts interactively when env var is not set."""
         import sys
 
-        from keboola_agent_cli.commands.org import _resolve_manage_token
+        from keboola_agent_cli.commands._helpers import resolve_manage_token
 
         with (
             patch.dict(os.environ, {}, clear=False),
-            patch("keboola_agent_cli.commands.org.typer.prompt", return_value="prompted-token"),
+            patch(
+                "keboola_agent_cli.commands._helpers.typer.prompt",
+                return_value="prompted-token",
+            ),
             patch.object(sys, "stdin") as mock_stdin,
         ):
             # Ensure KBC_MANAGE_API_TOKEN is not set
             os.environ.pop("KBC_MANAGE_API_TOKEN", None)
             mock_stdin.isatty.return_value = True
 
-            token = _resolve_manage_token()
+            token = resolve_manage_token()
 
         assert token == "prompted-token"
 
     def test_non_tty_error(self) -> None:
-        """_resolve_manage_token raises Exit when not TTY and no env var."""
+        """resolve_manage_token raises Exit when not TTY and no env var."""
         import sys
 
         import typer
 
-        from keboola_agent_cli.commands.org import _resolve_manage_token
+        from keboola_agent_cli.commands._helpers import resolve_manage_token
 
         with (
             patch.dict(os.environ, {}, clear=False),
@@ -5167,7 +5170,7 @@ class TestResolveManageToken:
             os.environ.pop("KBC_MANAGE_API_TOKEN", None)
             mock_stdin.isatty.return_value = False
 
-            _resolve_manage_token()
+            resolve_manage_token()
 
         assert exc_info.value.exit_code == 2
 
@@ -5758,3 +5761,422 @@ class TestInit:
         local_store = ConfigStore(config_dir=tmp_path / ".kbagent")
         local_config = local_store.load()
         assert "prod" in local_config.projects
+
+
+# ---------------------------------------------------------------------------
+# project refresh tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_REFRESH_RESULT = {
+    "projects_refreshed": [
+        {
+            "alias": "prod",
+            "project_id": 258,
+            "project_name": "Production",
+            "token": "258-***refreshed",
+        },
+    ],
+    "projects_valid": [
+        {
+            "alias": "dev",
+            "project_id": 7012,
+            "project_name": "Development",
+        },
+    ],
+    "projects_skipped": [],
+    "projects_failed": [],
+    "dry_run": False,
+}
+
+SAMPLE_REFRESH_DRY_RUN_RESULT = {
+    "projects_refreshed": [
+        {
+            "alias": "prod",
+            "project_id": 258,
+            "project_name": "Production",
+        },
+    ],
+    "projects_valid": [
+        {
+            "alias": "dev",
+            "project_id": 7012,
+            "project_name": "Development",
+        },
+    ],
+    "projects_skipped": [],
+    "projects_failed": [],
+    "dry_run": True,
+}
+
+
+class TestProjectRefresh:
+    """Tests for `kbagent project refresh` command."""
+
+    def test_project_refresh_json_success(self, tmp_path: Path) -> None:
+        """project refresh --all --json --yes returns structured JSON with refreshed projects."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.project.resolve_manage_token",
+                return_value="manage-token-123456789012345678",
+            ),
+        ):
+            MockStore.return_value = store
+
+            mock_service = MagicMock()
+            mock_service.refresh_tokens.return_value = SAMPLE_REFRESH_RESULT
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--all",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert len(output["data"]["projects_refreshed"]) == 1
+        assert output["data"]["projects_refreshed"][0]["alias"] == "prod"
+        assert output["data"]["projects_refreshed"][0]["project_id"] == 258
+        assert output["data"]["dry_run"] is False
+
+    def test_project_refresh_requires_project_or_all(self, tmp_path: Path) -> None:
+        """project refresh without --project or --all returns usage error."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService"),
+        ):
+            MockStore.return_value = store
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 2, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert "--project" in output["error"]["message"] or "--all" in output["error"]["message"]
+
+    def test_project_refresh_both_project_and_all(self, tmp_path: Path) -> None:
+        """project refresh with both --project and --all returns usage error."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService"),
+        ):
+            MockStore.return_value = store
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--project",
+                    "prod",
+                    "--all",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 2, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert "not both" in output["error"]["message"]
+
+    def test_project_refresh_dry_run(self, tmp_path: Path) -> None:
+        """project refresh --all --dry-run --json shows preview without changes."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.project.resolve_manage_token",
+                return_value="manage-token-123456789012345678",
+            ),
+        ):
+            MockStore.return_value = store
+
+            mock_service = MagicMock()
+            mock_service.refresh_tokens.return_value = SAMPLE_REFRESH_DRY_RUN_RESULT
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--all",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["dry_run"] is True
+        assert len(output["data"]["projects_refreshed"]) == 1
+        assert output["data"]["projects_refreshed"][0]["alias"] == "prod"
+
+    def test_project_refresh_single_project(self, tmp_path: Path) -> None:
+        """project refresh --project prod --json --yes refreshes a specific project."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        single_result = {
+            "projects_refreshed": [
+                {
+                    "alias": "prod",
+                    "project_id": 258,
+                    "project_name": "Production",
+                    "token": "258-***refreshed",
+                },
+            ],
+            "projects_valid": [],
+            "projects_skipped": [],
+            "projects_failed": [],
+            "dry_run": False,
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.project.resolve_manage_token",
+                return_value="manage-token-123456789012345678",
+            ),
+        ):
+            MockStore.return_value = store
+
+            mock_service = MagicMock()
+            mock_service.refresh_tokens.return_value = single_result
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--project",
+                    "prod",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert len(output["data"]["projects_refreshed"]) == 1
+        assert output["data"]["projects_refreshed"][0]["alias"] == "prod"
+
+        # Verify service was called with aliases=["prod"]
+        mock_service.refresh_tokens.assert_called_once()
+        call_kwargs = mock_service.refresh_tokens.call_args[1]
+        assert call_kwargs["aliases"] == ["prod"]
+
+    def test_project_refresh_api_error(self, tmp_path: Path) -> None:
+        """project refresh with API error returns appropriate exit code."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.project.resolve_manage_token",
+                return_value="manage-token-123456789012345678",
+            ),
+        ):
+            MockStore.return_value = store
+
+            mock_service = MagicMock()
+            mock_service.refresh_tokens.side_effect = KeboolaApiError(
+                message="Invalid manage token",
+                status_code=401,
+                error_code="INVALID_TOKEN",
+                retryable=False,
+            )
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--all",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 3
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "INVALID_TOKEN"
+
+    def test_project_refresh_force_flag(self, tmp_path: Path) -> None:
+        """project refresh --all --force passes force=True to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.project.resolve_manage_token",
+                return_value="manage-token-123456789012345678",
+            ),
+        ):
+            MockStore.return_value = store
+
+            mock_service = MagicMock()
+            mock_service.refresh_tokens.return_value = SAMPLE_REFRESH_RESULT
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "project",
+                    "refresh",
+                    "--all",
+                    "--force",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+
+        # Verify force=True was passed to service
+        mock_service.refresh_tokens.assert_called_once()
+        call_kwargs = mock_service.refresh_tokens.call_args[1]
+        assert call_kwargs["force"] is True
+
+    def test_org_setup_refresh_flag(self, tmp_path: Path) -> None:
+        """org setup --refresh calls refresh_tokens for skipped projects after setup."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "existing-project": {
+                    "token": "200-oldtoken",
+                    "project_id": 200,
+                    "project_name": "Existing Project",
+                },
+            },
+        )
+
+        setup_result = {
+            "organization_id": 42,
+            "stack_url": "https://connection.keboola.com",
+            "projects_found": 2,
+            "projects_added": [
+                {
+                    "project_id": 100,
+                    "project_name": "New Project",
+                    "alias": "new-project",
+                    "token": "100-***",
+                    "action": "added",
+                },
+            ],
+            "projects_skipped": [
+                {
+                    "project_id": 200,
+                    "project_name": "Existing Project",
+                    "reason": "Already registered in config",
+                },
+            ],
+            "projects_failed": [],
+            "dry_run": False,
+        }
+
+        refresh_result = {
+            "projects_refreshed": [
+                {
+                    "alias": "existing-project",
+                    "project_id": 200,
+                    "project_name": "Existing Project",
+                    "token": "200-***refreshed",
+                },
+            ],
+            "projects_valid": [],
+            "projects_skipped": [],
+            "projects_failed": [],
+            "dry_run": False,
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.OrgService") as MockOrgService,
+            patch(
+                "keboola_agent_cli.commands.org.resolve_manage_token",
+                return_value="manage-token-123456789012345678",
+            ),
+        ):
+            MockStore.return_value = store
+
+            mock_service = MagicMock()
+            mock_service.setup_organization.return_value = setup_result
+            mock_service.refresh_tokens.return_value = refresh_result
+            MockOrgService.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "org",
+                    "setup",
+                    "--org-id",
+                    "42",
+                    "--url",
+                    "https://connection.keboola.com",
+                    "--refresh",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+
+        # Both setup and refresh should have been called
+        mock_service.setup_organization.assert_called_once()
+        mock_service.refresh_tokens.assert_called_once()
+
+        # The final result should contain projects_refreshed from the refresh call
+        assert len(output["data"]["projects_refreshed"]) == 1
+        assert output["data"]["projects_refreshed"][0]["alias"] == "existing-project"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from helpers import make_mock_client
 from keboola_agent_cli.cli import app
 from keboola_agent_cli.config_store import ConfigStore
 from keboola_agent_cli.errors import ConfigError, KeboolaApiError
-from keboola_agent_cli.models import ProjectConfig
+from keboola_agent_cli.models import AppConfig, ProjectConfig
 from keboola_agent_cli.services.config_service import ConfigService
 from keboola_agent_cli.services.job_service import JobService
 from keboola_agent_cli.services.lineage_service import LineageService
@@ -5761,6 +5761,157 @@ class TestInit:
         local_store = ConfigStore(config_dir=tmp_path / ".kbagent")
         local_config = local_store.load()
         assert "prod" in local_config.projects
+
+    def test_init_prompts_to_copy_global_projects(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """init prompts to copy projects when global config has projects (#104)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        global_dir = tmp_path / "global-config"
+        global_dir.mkdir()
+
+        with (
+            patch("keboola_agent_cli.cli.resolve_config_dir") as mock_resolve,
+            patch(
+                "keboola_agent_cli.commands.init.typer.confirm", return_value=True
+            ) as mock_confirm,
+            patch("keboola_agent_cli.commands.init.sys") as mock_sys,
+        ):
+            mock_resolve.return_value = (global_dir, "global")
+            mock_sys.stdin.isatty.return_value = True
+
+            global_store = ConfigStore(config_dir=global_dir, source="global")
+            global_store.add_project(
+                "prod",
+                ProjectConfig(
+                    stack_url="https://connection.keboola.com",
+                    token="901-xxx-testtoken1234",
+                    project_name="Production",
+                    project_id=1234,
+                ),
+            )
+
+            result = runner.invoke(app, ["init"])
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        mock_confirm.assert_called_once()
+        assert "Copy to local workspace?" in mock_confirm.call_args[0][0]
+
+        # Verify local config got the project
+        local_store = ConfigStore(config_dir=tmp_path / ".kbagent")
+        local_config = local_store.load()
+        assert "prod" in local_config.projects
+
+    def test_init_prompt_decline_creates_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Declining the prompt creates empty local config (#104)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        global_dir = tmp_path / "global-config"
+        global_dir.mkdir()
+
+        with (
+            patch("keboola_agent_cli.cli.resolve_config_dir") as mock_resolve,
+            patch("keboola_agent_cli.commands.init.typer.confirm", return_value=False),
+            patch("keboola_agent_cli.commands.init.sys") as mock_sys,
+        ):
+            mock_resolve.return_value = (global_dir, "global")
+            mock_sys.stdin.isatty.return_value = True
+
+            global_store = ConfigStore(config_dir=global_dir, source="global")
+            global_store.add_project(
+                "prod",
+                ProjectConfig(
+                    stack_url="https://connection.keboola.com",
+                    token="901-xxx-testtoken1234",
+                    project_name="Production",
+                    project_id=1234,
+                ),
+            )
+
+            result = runner.invoke(app, ["init"])
+
+        assert result.exit_code == 0
+        # Local config should have zero projects
+        local_store = ConfigStore(config_dir=tmp_path / ".kbagent")
+        local_config = local_store.load()
+        assert len(local_config.projects) == 0
+
+    def test_init_json_mode_warns_about_global_projects(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In JSON mode, init warns about global projects instead of prompting (#104)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        global_dir = tmp_path / "global-config"
+        global_dir.mkdir()
+
+        with patch("keboola_agent_cli.cli.resolve_config_dir") as mock_resolve:
+            mock_resolve.return_value = (global_dir, "global")
+
+            global_store = ConfigStore(config_dir=global_dir, source="global")
+            global_store.add_project(
+                "prod",
+                ProjectConfig(
+                    stack_url="https://connection.keboola.com",
+                    token="901-xxx-testtoken1234",
+                    project_name="Production",
+                    project_id=1234,
+                ),
+            )
+
+            result = runner.invoke(app, ["--json", "init"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["data"]["projects_copied"] == 0
+
+    def test_empty_local_config_warns_about_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Commands warn when empty local config shadows global with projects (#104)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KBAGENT_CONFIG_DIR", raising=False)
+
+        # Create an empty local config
+        local_dir = tmp_path / ".kbagent"
+        local_dir.mkdir()
+        local_store = ConfigStore(config_dir=local_dir, source="local")
+        local_store.save(AppConfig())
+
+        # Create a global config with projects
+        global_dir = tmp_path / "global-config"
+        global_dir.mkdir()
+        global_store = ConfigStore(config_dir=global_dir, source="global")
+        global_store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-xxx-testtoken1234",
+                project_name="Production",
+                project_id=1234,
+            ),
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.resolve_config_dir") as mock_resolve,
+            patch("platformdirs.user_config_dir", return_value=str(global_dir)),
+            patch("keboola_agent_cli.output.OutputFormatter.warning") as mock_warning,
+        ):
+            mock_resolve.return_value = (local_dir, "local")
+
+            # Run a non-init command (project list) in human mode
+            runner.invoke(app, ["project", "list"])
+
+        # Warning should have been called with message about shadowing
+        mock_warning.assert_called_once()
+        warning_msg = mock_warning.call_args[0][0]
+        assert "Local workspace has no projects but global config has 1" in warning_msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_service.py
+++ b/tests/test_mcp_service.py
@@ -186,14 +186,14 @@ class TestDetectMcpServerCommand:
         mock_which.side_effect = which_side_effect
         mock_run.return_value = MagicMock(returncode=1)
         result = detect_mcp_server_command()
-        assert result == ["uvx", "--prerelease=allow", "keboola_mcp_server"]
+        assert result == ["uvx", "keboola_mcp_server"]
 
     @patch("keboola_agent_cli.services.mcp_service.shutil.which")
     def test_uvx_fallback(self, mock_which: MagicMock) -> None:
         """When only uvx is available, returns uvx WITHOUT @latest."""
         mock_which.side_effect = lambda cmd: "/usr/local/bin/uvx" if cmd == "uvx" else None
         result = detect_mcp_server_command()
-        assert result == ["uvx", "--prerelease=allow", "keboola_mcp_server"]
+        assert result == ["uvx", "keboola_mcp_server"]
 
     @patch("keboola_agent_cli.services.mcp_service.shutil.which")
     def test_nothing_available(self, mock_which: MagicMock) -> None:

--- a/tests/test_org_service.py
+++ b/tests/test_org_service.py
@@ -675,3 +675,525 @@ class TestUniqueAlias:
 
     def test_gap_in_sequence(self) -> None:
         assert OrgService._unique_alias("prod", {"prod", "prod-2", "prod-3"}) == "prod-4"
+
+
+class TestRefreshTokens:
+    """Tests for OrgService.refresh_tokens()."""
+
+    @staticmethod
+    def _setup_store(tmp_path: Path, projects: dict[str, dict]) -> ConfigStore:
+        """Create a ConfigStore with the given projects pre-registered.
+
+        Args:
+            tmp_path: Temporary directory for config files.
+            projects: Mapping of alias -> project kwargs for ProjectConfig.
+
+        Returns:
+            ConfigStore with all projects added.
+        """
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = ConfigStore(config_dir=config_dir)
+        for alias, kwargs in projects.items():
+            store.add_project(alias, ProjectConfig(**kwargs))
+        return store
+
+    @staticmethod
+    def _make_manage_mock(
+        token_response: dict | None = None,
+        verify_response: dict | None = None,
+    ) -> MagicMock:
+        """Create a mock ManageClient for refresh operations.
+
+        Args:
+            token_response: Response from create_project_token.
+            verify_response: Response from verify_token (manage token identity).
+
+        Returns:
+            MagicMock configured as ManageClient.
+        """
+        mock = MagicMock()
+        mock.create_project_token.return_value = token_response or {
+            "id": "tok-new",
+            "token": "901-99999-newGeneratedTokenValue12345",
+            "description": "kbagent-cli",
+        }
+        mock.verify_token.return_value = verify_response or {
+            "user": {"email": "admin@test.com", "name": "Admin"},
+        }
+        return mock
+
+    def test_refresh_single_invalid_token(self, tmp_path: Path) -> None:
+        """An invalid token is detected and refreshed with a new one."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "prod": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-old-expiredTokenValue123456789",
+                    "project_name": "Prod",
+                    "project_id": 100,
+                },
+            },
+        )
+
+        # Storage client: first call (old token check) fails, second call (new token verify) succeeds
+        mock_storage = MagicMock()
+        mock_storage.verify_token.side_effect = [
+            KeboolaApiError(
+                message="Invalid token",
+                status_code=401,
+                error_code="INVALID_TOKEN",
+            ),
+            TokenVerifyResponse(
+                token_id="new-123",
+                token_description="kbagent-cli",
+                project_id=100,
+                project_name="Prod",
+                owner_name="Prod",
+            ),
+        ]
+
+        def storage_factory(url: str, token: str) -> MagicMock:
+            return mock_storage
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+        )
+
+        assert result["projects_checked"] == 1
+        assert len(result["projects_refreshed"]) == 1
+        assert result["projects_refreshed"][0]["alias"] == "prod"
+        assert result["projects_refreshed"][0]["action"] == "refreshed"
+        assert result["projects_refreshed"][0]["project_id"] == 100
+        assert len(result["projects_valid"]) == 0
+        assert len(result["projects_failed"]) == 0
+
+        # Config should be updated with the new token
+        config = store.load()
+        assert config.projects["prod"].token == "901-99999-newGeneratedTokenValue12345"
+
+    def test_refresh_all_only_invalid(self, tmp_path: Path) -> None:
+        """With two projects, only the one with an invalid token is refreshed."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "prod": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-prod-validTokenValue1234567890",
+                    "project_name": "Prod",
+                    "project_id": 100,
+                },
+                "dev": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-dev-expiredTokenValue123456789",
+                    "project_name": "Dev",
+                    "project_id": 200,
+                },
+            },
+        )
+
+        # We need per-project storage mocks since each project gets its own client
+        call_count = {"n": 0}
+
+        def storage_factory(url, token):
+            call_count["n"] += 1
+            mock = MagicMock()
+            if "prod-valid" in token:
+                # Prod: valid token
+                mock.verify_token.return_value = TokenVerifyResponse(
+                    token_id="prod-tok",
+                    token_description="kbagent-cli",
+                    project_id=100,
+                    project_name="Prod",
+                    owner_name="Prod",
+                )
+            elif "dev-expired" in token:
+                # Dev: invalid old token
+                mock.verify_token.side_effect = KeboolaApiError(
+                    message="Invalid token",
+                    status_code=401,
+                    error_code="INVALID_TOKEN",
+                )
+            else:
+                # New token verification (after refresh)
+                mock.verify_token.return_value = TokenVerifyResponse(
+                    token_id="new-dev-tok",
+                    token_description="kbagent-cli",
+                    project_id=200,
+                    project_name="Dev",
+                    owner_name="Dev",
+                )
+            return mock
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+        )
+
+        assert result["projects_checked"] == 2
+        assert len(result["projects_valid"]) == 1
+        assert result["projects_valid"][0]["alias"] == "prod"
+        assert len(result["projects_refreshed"]) == 1
+        assert result["projects_refreshed"][0]["alias"] == "dev"
+        assert result["projects_refreshed"][0]["action"] == "refreshed"
+        assert len(result["projects_failed"]) == 0
+
+    def test_refresh_dry_run(self, tmp_path: Path) -> None:
+        """Dry run reports what would be refreshed without making changes."""
+        old_token = "901-old-expiredTokenValue123456789"
+        store = self._setup_store(
+            tmp_path,
+            {
+                "prod": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": old_token,
+                    "project_name": "Prod",
+                    "project_id": 100,
+                },
+            },
+        )
+
+        mock_storage = MagicMock()
+        mock_storage.verify_token.side_effect = KeboolaApiError(
+            message="Invalid token",
+            status_code=401,
+            error_code="INVALID_TOKEN",
+        )
+
+        def storage_factory(url: str, token: str) -> MagicMock:
+            return mock_storage
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+            dry_run=True,
+        )
+
+        assert result["dry_run"] is True
+        assert len(result["projects_refreshed"]) == 1
+        assert result["projects_refreshed"][0]["action"] == "would_refresh"
+        assert result["projects_refreshed"][0]["token"] == "***"
+
+        # Config should NOT be updated
+        config = store.load()
+        assert config.projects["prod"].token == old_token
+
+        # create_project_token should NOT have been called
+        manage_mock.create_project_token.assert_not_called()
+
+    def test_refresh_force_valid_token(self, tmp_path: Path) -> None:
+        """force=True refreshes even valid tokens."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "prod": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-prod-validTokenValue1234567890",
+                    "project_name": "Prod",
+                    "project_id": 100,
+                },
+            },
+        )
+
+        # Storage: first call (check) succeeds, second call (verify new) also succeeds
+        call_count = {"n": 0}
+
+        def storage_factory(url, token):
+            call_count["n"] += 1
+            mock = MagicMock()
+            mock.verify_token.return_value = TokenVerifyResponse(
+                token_id=f"tok-{call_count['n']}",
+                token_description="kbagent-cli",
+                project_id=100,
+                project_name="Prod",
+                owner_name="Prod",
+            )
+            return mock
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+            force=True,
+        )
+
+        assert result["projects_checked"] == 1
+        assert len(result["projects_refreshed"]) == 1
+        assert result["projects_refreshed"][0]["alias"] == "prod"
+        assert result["projects_refreshed"][0]["action"] == "refreshed"
+        assert len(result["projects_valid"]) == 0
+
+        # create_project_token should have been called despite valid token
+        manage_mock.create_project_token.assert_called_once()
+
+        # Config should be updated with the new token
+        config = store.load()
+        assert config.projects["prod"].token == "901-99999-newGeneratedTokenValue12345"
+
+    def test_refresh_skip_no_project_id(self, tmp_path: Path) -> None:
+        """Projects without project_id are skipped with explanation."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "legacy": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-legacy-tokenValue12345678901",
+                    "project_name": "Legacy",
+                    # project_id defaults to None
+                },
+            },
+        )
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        mock_storage = MagicMock()
+
+        def storage_factory(url: str, token: str) -> MagicMock:
+            return mock_storage
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+        )
+
+        assert result["projects_checked"] == 1
+        assert len(result["projects_skipped"]) == 1
+        assert result["projects_skipped"][0]["alias"] == "legacy"
+        assert "project_id is missing" in result["projects_skipped"][0]["reason"]
+        assert len(result["projects_refreshed"]) == 0
+        assert len(result["projects_valid"]) == 0
+
+        # Storage verify_token should NOT have been called (skipped before check)
+        mock_storage.verify_token.assert_not_called()
+
+    def test_refresh_partial_failure(self, tmp_path: Path) -> None:
+        """One project refreshing successfully while another fails."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "alpha": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-alpha-expiredTokenValue12345",
+                    "project_name": "Alpha",
+                    "project_id": 100,
+                },
+                "beta": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-beta-expiredTokenValue123456",
+                    "project_name": "Beta",
+                    "project_id": 200,
+                },
+            },
+        )
+
+        # Storage: all old tokens are invalid, new token verification succeeds
+        def storage_factory(url, token):
+            mock = MagicMock()
+            if "expired" in token:
+                mock.verify_token.side_effect = KeboolaApiError(
+                    message="Invalid token",
+                    status_code=401,
+                    error_code="INVALID_TOKEN",
+                )
+            else:
+                mock.verify_token.return_value = TokenVerifyResponse(
+                    token_id="new-tok",
+                    token_description="kbagent-cli",
+                    project_id=100,
+                    project_name="Alpha",
+                    owner_name="Alpha",
+                )
+            return mock
+
+        # Manage: first create_project_token succeeds, second fails
+        create_call_count = {"n": 0}
+
+        def manage_factory(url, token):
+            mock = MagicMock()
+            mock.verify_token.return_value = {
+                "user": {"email": "admin@test.com", "name": "Admin"},
+            }
+
+            def create_token(project_id, description, **kwargs):
+                create_call_count["n"] += 1
+                if project_id == 200:
+                    raise KeboolaApiError(
+                        message="Access denied to project 200",
+                        status_code=403,
+                        error_code="ACCESS_DENIED",
+                    )
+                return {
+                    "id": "tok-new",
+                    "token": "901-99999-newGeneratedTokenValue12345",
+                    "description": description,
+                }
+
+            mock.create_project_token.side_effect = create_token
+            return mock
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+        )
+
+        assert result["projects_checked"] == 2
+        assert len(result["projects_refreshed"]) == 1
+        assert result["projects_refreshed"][0]["alias"] == "alpha"
+        assert len(result["projects_failed"]) == 1
+        assert result["projects_failed"][0]["alias"] == "beta"
+        assert "Access denied" in result["projects_failed"][0]["error"]
+
+    def test_refresh_all_valid_no_action(self, tmp_path: Path) -> None:
+        """All valid tokens result in no refreshes."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "prod": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-prod-validTokenValue1234567890",
+                    "project_name": "Prod",
+                    "project_id": 100,
+                },
+                "dev": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-dev-validTokenValue12345678901",
+                    "project_name": "Dev",
+                    "project_id": 200,
+                },
+            },
+        )
+
+        def storage_factory(url, token):
+            mock = MagicMock()
+            if "prod-valid" in token:
+                pid, name = 100, "Prod"
+            else:
+                pid, name = 200, "Dev"
+            mock.verify_token.return_value = TokenVerifyResponse(
+                token_id=f"tok-{pid}",
+                token_description="kbagent-cli",
+                project_id=pid,
+                project_name=name,
+                owner_name=name,
+            )
+            return mock
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+        )
+
+        assert result["projects_checked"] == 2
+        assert len(result["projects_valid"]) == 2
+        assert len(result["projects_refreshed"]) == 0
+        assert len(result["projects_failed"]) == 0
+        assert len(result["projects_skipped"]) == 0
+
+        # create_project_token should NOT have been called
+        manage_mock.create_project_token.assert_not_called()
+
+    def test_refresh_unknown_alias(self, tmp_path: Path) -> None:
+        """Requesting an unknown alias reports it as failed."""
+        store = self._setup_store(
+            tmp_path,
+            {
+                "prod": {
+                    "stack_url": "https://connection.keboola.com",
+                    "token": "901-prod-validTokenValue1234567890",
+                    "project_name": "Prod",
+                    "project_id": 100,
+                },
+            },
+        )
+
+        manage_mock = self._make_manage_mock()
+
+        def manage_factory(url: str, token: str) -> MagicMock:
+            return manage_mock
+
+        mock_storage = MagicMock()
+
+        def storage_factory(url: str, token: str) -> MagicMock:
+            return mock_storage
+
+        service = OrgService(
+            config_store=store,
+            manage_client_factory=manage_factory,
+            storage_client_factory=storage_factory,
+        )
+
+        result = service.refresh_tokens(
+            manage_token="manage-token-123456789012345678",
+            aliases=["nonexistent"],
+        )
+
+        assert len(result["projects_failed"]) == 1
+        assert result["projects_failed"][0]["alias"] == "nonexistent"
+        assert "not found in config" in result["projects_failed"][0]["error"]
+        assert result["projects_checked"] == 0
+        assert len(result["projects_refreshed"]) == 0
+        assert len(result["projects_valid"]) == 0


### PR DESCRIPTION
## Summary

Addresses three related issues around project token management, MCP server stability, and config UX:

- **#110** -- Add `kbagent project refresh` command to refresh expired/invalid Storage API tokens via Manage API, plus `org setup --refresh` flag
- **#109** -- Remove `--prerelease=allow` from MCP server resolution to prevent pulling broken pre-release dependency chains (FastMCP 2.14.5 / fakeredis)
- **#104** -- `kbagent init` now prompts to copy projects from global config; all commands warn when empty local config shadows global with projects

Also adds `docs/config-guide.md` explaining global vs local config architecture.

## Changes

### Token refresh (#110)
- New `kbagent project refresh --project ALIAS | --all` command
- `org setup --refresh` flag to refresh skipped (already-registered) projects
- `OrgService.refresh_tokens()` + `_refresh_single_project()` in service layer
- `resolve_manage_token()` moved to shared `_helpers.py`
- Permission registered as `project.refresh: admin`
- 16 new tests (8 service + 8 CLI)

### MCP resolution (#109)
- Removed `--prerelease=allow` from `detect_mcp_server_command()` uvx fallback
- Removed `--prerelease=allow` from `ensure_mcp_installed()` uv tool install
- Updated hint messages and SKILL.md setup instructions

### Init config warning (#104)
- `kbagent init` prompts "Copy N projects from global?" (default: yes) in TTY mode
- JSON/non-TTY mode shows warning instead of prompt
- All commands warn when local workspace has 0 projects but global has N
- New `docs/config-guide.md` covering config architecture and workflows

## Test plan

- [ ] `make check` passes (lint + format + 1339 tests)
- [ ] `kbagent project refresh --all --dry-run` shows invalid tokens
- [ ] `kbagent project refresh --project ALIAS` refreshes a specific project
- [ ] `kbagent org setup --refresh --dry-run` previews refresh during org setup
- [ ] `kbagent init` in directory with global projects prompts to copy
- [ ] Running command in empty local workspace shows global config warning
- [ ] MCP tools work without `--prerelease=allow` (stable resolution)