### PR TITLE
feat: add --branch support to all storage commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,11 +233,14 @@ kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID
 
-kbagent storage buckets [--project NAME]
-kbagent storage bucket-detail --project NAME --bucket-id ID
-kbagent storage tables --project NAME [--bucket-id ID]
-kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes]
-kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes]
+kbagent storage buckets [--project NAME] [--branch ID]
+kbagent storage bucket-detail --project NAME --bucket-id ID [--branch ID]
+kbagent storage tables --project NAME [--bucket-id ID] [--branch ID]
+kbagent storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]
+kbagent storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]
+kbagent storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]
+kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
+kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
 
 kbagent lineage show [--project NAME]   # also works as just: kbagent lineage
 

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -30,9 +30,14 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `job detail --project NAME --job-id ID` -- full job detail with timing and result message
 
 ## Storage
-- `storage buckets [--project NAME]` -- list buckets with sharing/linked info
-- `storage bucket-detail --project NAME --bucket-id ID` -- bucket detail with Snowflake paths
-- `storage tables --project NAME [--bucket-id ID]` -- list tables, optionally by bucket
+- `storage buckets [--project NAME] [--branch ID]` -- list buckets with sharing/linked info (branch-aware)
+- `storage bucket-detail --project NAME --bucket-id ID [--branch ID]` -- bucket detail with Snowflake paths (branch-aware)
+- `storage tables --project NAME [--bucket-id ID] [--branch ID]` -- list tables, optionally by bucket (branch-aware)
+- `storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]` -- create bucket (branch-aware)
+- `storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]` -- create typed table (branch-aware)
+- `storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]` -- upload CSV (branch-aware)
+- `storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]` -- delete tables (branch-aware)
+- `storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete buckets (branch-aware)
 
 ## Data Lineage
 - `lineage [--project NAME]` -- cross-project data flow via bucket sharing

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -572,19 +572,23 @@ class KeboolaClient(BaseHttpClient):
         response = self._request("GET", "/v2/storage/dev-branches")
         return response.json()
 
-    def list_buckets(self, include: str | None = None) -> list[dict[str, Any]]:
+    def list_buckets(
+        self, include: str | None = None, branch_id: int | None = None
+    ) -> list[dict[str, Any]]:
         """List storage buckets with optional extended information.
 
         Args:
             include: Optional include parameter (e.g. "linkedBuckets" for sharing info).
+            branch_id: If set, list buckets from a specific dev branch.
 
         Returns:
             List of bucket dicts from the API.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         params: dict[str, str] = {}
         if include:
             params["include"] = include
-        response = self._request("GET", "/v2/storage/buckets", params=params)
+        response = self._request("GET", f"{prefix}/buckets", params=params)
         return response.json()
 
     def list_buckets_with_metadata(self) -> list[dict[str, Any]]:
@@ -792,7 +796,9 @@ class KeboolaClient(BaseHttpClient):
         )
         return self._wait_for_storage_job(response.json())
 
-    def delete_bucket(self, bucket_id: str, force: bool = False) -> dict[str, Any]:
+    def delete_bucket(
+        self, bucket_id: str, force: bool = False, branch_id: int | None = None
+    ) -> dict[str, Any]:
         """Delete a bucket (async, waits for completion).
 
         Used for unlinking shared buckets or deleting regular buckets.
@@ -800,15 +806,17 @@ class KeboolaClient(BaseHttpClient):
         Args:
             bucket_id: Bucket ID to delete.
             force: If True, delete even if bucket contains tables.
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Completed storage job dict.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_id = quote(bucket_id, safe="")
         params: dict[str, str] = {"async": "true"}
         if force:
             params["force"] = "true"
-        response = self._request("DELETE", f"/v2/storage/buckets/{safe_id}", params=params)
+        response = self._request("DELETE", f"{prefix}/buckets/{safe_id}", params=params)
         return self._wait_for_storage_job(response.json())
 
     def create_bucket(
@@ -817,6 +825,7 @@ class KeboolaClient(BaseHttpClient):
         name: str,
         description: str | None = None,
         backend: str | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create a new storage bucket (sync).
 
@@ -825,16 +834,18 @@ class KeboolaClient(BaseHttpClient):
             name: Bucket name slug (e.g. "my-bucket").
             description: Optional description.
             backend: Optional backend type (e.g. "snowflake", "bigquery").
+            branch_id: If set, create bucket in a specific dev branch.
 
         Returns:
             New bucket dict from the API.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         body: dict[str, str] = {"stage": stage, "name": name}
         if description is not None:
             body["description"] = description
         if backend is not None:
             body["backend"] = backend
-        response = self._request("POST", "/v2/storage/buckets", json=body)
+        response = self._request("POST", f"{prefix}/buckets", json=body)
         return response.json()
 
     def create_table(
@@ -843,6 +854,7 @@ class KeboolaClient(BaseHttpClient):
         name: str,
         columns: list[dict[str, Any]],
         primary_key: list[str] | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create a new table with typed columns (async, waits for completion).
 
@@ -852,19 +864,19 @@ class KeboolaClient(BaseHttpClient):
             columns: List of column dicts with "name" and "definition.type" keys,
                      e.g. [{"name": "id", "definition": {"type": "INTEGER"}}].
             primary_key: Optional list of column names for the primary key.
+            branch_id: If set, create table in a specific dev branch.
 
         Returns:
             Completed storage job results dict.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_id = quote(bucket_id, safe="")
         body: dict[str, Any] = {
             "name": name,
             "primaryKeysNames": primary_key or [],
             "columns": columns,
         }
-        response = self._request(
-            "POST", f"/v2/storage/buckets/{safe_id}/tables-definition", json=body
-        )
+        response = self._request("POST", f"{prefix}/buckets/{safe_id}/tables-definition", json=body)
         job = self._wait_for_storage_job(response.json())
         return job.get("results", {})
 
@@ -970,6 +982,7 @@ class KeboolaClient(BaseHttpClient):
         incremental: bool = False,
         delimiter: str = ",",
         enclosure: str = '"',
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Trigger async import of a pre-uploaded file into a table (step 3).
 
@@ -981,10 +994,12 @@ class KeboolaClient(BaseHttpClient):
             incremental: If True, append rows; if False, full load.
             delimiter: CSV column delimiter.
             enclosure: CSV value enclosure character.
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Completed import job dict.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_id = quote(table_id, safe="")
         body: dict[str, str] = {
             "dataFileId": str(file_id),
@@ -992,7 +1007,7 @@ class KeboolaClient(BaseHttpClient):
             "delimiter": delimiter,
             "enclosure": enclosure,
         }
-        response = self._request("POST", f"/v2/storage/tables/{safe_id}/import-async", data=body)
+        response = self._request("POST", f"{prefix}/tables/{safe_id}/import-async", data=body)
         return self._wait_for_storage_job(response.json(), max_wait=IMPORT_JOB_MAX_WAIT)
 
     def upload_table(
@@ -1002,6 +1017,7 @@ class KeboolaClient(BaseHttpClient):
         incremental: bool = False,
         delimiter: str = ",",
         enclosure: str = '"',
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Upload a CSV file into an existing table (async, waits for completion).
 
@@ -1016,6 +1032,7 @@ class KeboolaClient(BaseHttpClient):
             incremental: If True, append rows; if False (default), full load.
             delimiter: CSV column delimiter (default ",").
             enclosure: CSV value enclosure character (default '"').
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Import results dict with importedRowsCount, warnings, etc.
@@ -1031,22 +1048,23 @@ class KeboolaClient(BaseHttpClient):
             incremental=incremental,
             delimiter=delimiter,
             enclosure=enclosure,
+            branch_id=branch_id,
         )
         return job.get("results", {})
 
-    def delete_table(self, table_id: str) -> dict[str, Any]:
+    def delete_table(self, table_id: str, branch_id: int | None = None) -> dict[str, Any]:
         """Delete a storage table (async, waits for completion).
 
         Args:
             table_id: Full table ID (e.g. "in.c-bucket.table").
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Completed storage job dict.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_id = quote(table_id, safe="")
-        response = self._request(
-            "DELETE", f"/v2/storage/tables/{safe_id}", params={"async": "true"}
-        )
+        response = self._request("DELETE", f"{prefix}/tables/{safe_id}", params={"async": "true"})
         return self._wait_for_storage_job(response.json())
 
     def list_tables_with_metadata(self) -> list[dict[str, Any]]:

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -111,32 +111,32 @@ Use `kbagent <command> --help` for full flag details and examples.
 
 ### Storage
 
-  kbagent storage buckets [--project NAME]
-    List buckets with sharing/linked info. Shows source project for linked buckets.
+  kbagent storage buckets [--project NAME] [--branch ID]
+    List buckets with sharing/linked info. Shows source project for linked buckets. Branch-aware.
 
-  kbagent storage bucket-detail --project NAME --bucket-id BUCKET_ID
-    Bucket detail with Snowflake direct access paths. Resolves linked bucket source DB.
+  kbagent storage bucket-detail --project NAME --bucket-id BUCKET_ID [--branch ID]
+    Bucket detail with Snowflake direct access paths. Resolves linked bucket source DB. Branch-aware.
 
-  kbagent storage tables --project NAME [--bucket-id BUCKET_ID]
-    List storage tables, optionally filtered by bucket.
+  kbagent storage tables --project NAME [--bucket-id BUCKET_ID] [--branch ID]
+    List storage tables, optionally filtered by bucket. Branch-aware.
 
-  kbagent storage create-bucket --project NAME --stage STAGE --name BUCKET_NAME [--description D] [--backend B]
-    Create a new storage bucket. Stage must be "in" or "out".
+  kbagent storage create-bucket --project NAME --stage STAGE --name BUCKET_NAME [--description D] [--backend B] [--branch ID]
+    Create a new storage bucket. Stage must be "in" or "out". Branch-aware.
 
-  kbagent storage create-table --project NAME --bucket-id BUCKET_ID --name TABLE_NAME --column col:TYPE [...] [--primary-key COL]
+  kbagent storage create-table --project NAME --bucket-id BUCKET_ID --name TABLE_NAME --column col:TYPE [...] [--primary-key COL] [--branch ID]
     Create a typed table. --column repeatable. Types: STRING, INTEGER, NUMERIC, FLOAT, BOOLEAN, DATE, TIMESTAMP.
-    Column type defaults to STRING if omitted (e.g. --column name is equivalent to --column name:STRING).
+    Column type defaults to STRING if omitted (e.g. --column name is equivalent to --column name:STRING). Branch-aware.
 
-  kbagent storage upload-table --project NAME --table-id TABLE_ID --file PATH [--incremental] [--delimiter D] [--enclosure E] [--no-auto-create]
+  kbagent storage upload-table --project NAME --table-id TABLE_ID --file PATH [--incremental] [--delimiter D] [--enclosure E] [--no-auto-create] [--branch ID]
     Upload CSV into a table. Auto-creates bucket and table if missing (columns inferred as STRING from CSV header).
     Use --no-auto-create to require the table to already exist.
-    Full load by default; --incremental to append rows. Supports files up to 5 GB via async file-first upload flow.
+    Full load by default; --incremental to append rows. Supports files up to 5 GB via async file-first upload flow. Branch-aware.
 
-  kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes]
-    Delete one or more tables. Batch: repeat --table-id. --dry-run to preview.
+  kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
+    Delete one or more tables. Batch: repeat --table-id. --dry-run to preview. Branch-aware.
 
-  kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes]
-    Delete one or more buckets. --force cascade-deletes tables. Linked/shared buckets protected.
+  kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
+    Delete one or more buckets. --force cascade-deletes tables. Linked/shared buckets protected. Branch-aware.
 
 ### Sharing (Cross-Project)
 

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import typer
 
+from ..config_store import ConfigStore
 from ..errors import ConfigError, KeboolaApiError
 from ._helpers import (
     check_cli_permission,
@@ -15,6 +16,7 @@ from ._helpers import (
     get_formatter,
     get_service,
     map_error_to_exit_code,
+    resolve_branch,
 )
 
 storage_app = typer.Typer(help="Browse and manage storage buckets and tables")
@@ -33,6 +35,11 @@ def storage_buckets(
         "--project",
         help="Project alias (can be repeated for multiple projects)",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """List storage buckets with sharing/linked bucket information.
 
@@ -42,9 +49,23 @@ def storage_buckets(
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+
+    # --branch requires exactly one --project
+    if branch is not None and (not project or len(project) != 1):
+        formatter.error(
+            message="--branch requires exactly one --project (branch ID is per-project)",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    # Resolve active branch for single-project queries
+    effective_branch: int | None = branch
+    if branch is None and project and len(project) == 1:
+        _, effective_branch = resolve_branch(config_store, formatter, project[0], None)
 
     try:
-        result = service.list_buckets(aliases=project)
+        result = service.list_buckets(aliases=project, branch_id=effective_branch)
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
@@ -102,6 +123,11 @@ def storage_bucket_detail(
         "--bucket-id",
         help="Bucket ID (e.g. in.c-db)",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """Show detailed bucket info including Snowflake direct access paths.
 
@@ -111,9 +137,15 @@ def storage_bucket_detail(
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     try:
-        result = service.get_bucket_detail(alias=project, bucket_id=bucket_id)
+        result = service.get_bucket_detail(
+            alias=project,
+            bucket_id=bucket_id,
+            branch_id=effective_branch,
+        )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
@@ -191,14 +223,26 @@ def storage_create_bucket(
         "--backend",
         help="Optional backend type (e.g. 'snowflake', 'bigquery')",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """Create a new storage bucket."""
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     try:
         result = service.create_bucket(
-            alias=project, stage=stage, name=name, description=description, backend=backend
+            alias=project,
+            stage=stage,
+            name=name,
+            description=description,
+            backend=backend,
+            branch_id=effective_branch,
         )
     except ValueError as exc:
         formatter.error(message=str(exc), error_code="INVALID_ARGUMENT")
@@ -248,6 +292,11 @@ def storage_create_table(
         "--primary-key",
         help="Primary key column name. Can be repeated.",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """Create a new storage table with typed columns.
 
@@ -255,6 +304,8 @@ def storage_create_table(
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     try:
         result = service.create_table(
@@ -263,6 +314,7 @@ def storage_create_table(
             name=name,
             columns=column,
             primary_key=primary_key,
+            branch_id=effective_branch,
         )
     except ValueError as exc:
         formatter.error(message=str(exc), error_code="INVALID_ARGUMENT")
@@ -322,6 +374,11 @@ def storage_upload_table(
         help="Auto-create bucket and table if they don't exist (default: on). "
         "Columns are inferred as STRING from the CSV header row.",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """Upload a CSV file into a storage table.
 
@@ -331,6 +388,8 @@ def storage_upload_table(
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     p = Path(file)
     if not p.is_file():
@@ -352,6 +411,7 @@ def storage_upload_table(
             delimiter=delimiter,
             enclosure=enclosure,
             auto_create=auto_create,
+            branch_id=effective_branch,
         )
     except ValueError as exc:
         formatter.error(message=str(exc), error_code="INVALID_ARGUMENT")
@@ -398,13 +458,24 @@ def storage_tables(
         "--bucket-id",
         help="Filter tables by bucket ID",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """List storage tables from a project."""
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     try:
-        result = service.list_tables(alias=project, bucket_id=bucket_id)
+        result = service.list_tables(
+            alias=project,
+            bucket_id=bucket_id,
+            branch_id=effective_branch,
+        )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
@@ -467,6 +538,11 @@ def storage_delete_table(
         "-y",
         help="Skip confirmation prompt",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """Delete one or more storage tables.
 
@@ -475,10 +551,17 @@ def storage_delete_table(
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     if dry_run:
         try:
-            result = service.delete_tables(alias=project, table_ids=table_id, dry_run=True)
+            result = service.delete_tables(
+                alias=project,
+                table_ids=table_id,
+                dry_run=True,
+                branch_id=effective_branch,
+            )
         except ConfigError as exc:
             formatter.error(message=exc.message, error_code="CONFIG_ERROR")
             raise typer.Exit(code=5) from None
@@ -499,7 +582,11 @@ def storage_delete_table(
         raise typer.Exit(code=0)
 
     try:
-        result = service.delete_tables(alias=project, table_ids=table_id)
+        result = service.delete_tables(
+            alias=project,
+            table_ids=table_id,
+            branch_id=effective_branch,
+        )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None
@@ -545,6 +632,11 @@ def storage_delete_bucket(
         "-y",
         help="Skip confirmation prompt",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
 ) -> None:
     """Delete one or more storage buckets.
 
@@ -554,10 +646,16 @@ def storage_delete_bucket(
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     try:
         result = service.delete_buckets(
-            alias=project, bucket_ids=bucket_id, force=force, dry_run=dry_run
+            alias=project,
+            bucket_ids=bucket_id,
+            force=force,
+            dry_run=dry_run,
+            branch_id=effective_branch,
         )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -43,17 +43,26 @@ class StorageService(BaseService):
     def list_buckets(
         self,
         aliases: list[str] | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """List storage buckets from one or more projects.
 
         Includes sharing/linked bucket metadata (sourceBucket, sourceProject)
         that is not available via MCP tools.
 
+        Args:
+            aliases: Project aliases to query. If None, queries all.
+            branch_id: If set, list buckets from a specific dev branch.
+
         Returns:
             Dict with 'buckets' list and 'errors' list.
         """
         projects = self.resolve_projects(aliases)
-        successes, errors = self._run_parallel(projects, self._fetch_buckets)
+
+        def _worker(alias: str, project: ProjectConfig) -> tuple[str, list[dict[str, Any]], bool]:
+            return self._fetch_buckets(alias, project, branch_id=branch_id)
+
+        successes, errors = self._run_parallel(projects, _worker)
 
         buckets: list[dict[str, Any]] = []
         for result in successes:
@@ -91,10 +100,16 @@ class StorageService(BaseService):
         self,
         alias: str,
         bucket_id: str,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Get detailed bucket info including tables and sharing metadata.
 
         For linked buckets, includes the Snowflake direct access path.
+
+        Args:
+            alias: Project alias.
+            bucket_id: Bucket ID (e.g. 'in.c-db').
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Dict with bucket detail, tables, and resolved Snowflake paths.
@@ -105,7 +120,7 @@ class StorageService(BaseService):
         client = self._client_factory(project.stack_url, project.token)
         try:
             token_info = client.verify_token()
-            bucket = client.get_bucket_detail(bucket_id)
+            bucket = client.get_bucket_detail(bucket_id, branch_id=branch_id)
         finally:
             client.close()
 
@@ -177,8 +192,14 @@ class StorageService(BaseService):
         self,
         alias: str,
         bucket_id: str | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """List tables from a project, optionally filtered by bucket.
+
+        Args:
+            alias: Project alias.
+            bucket_id: Optional bucket ID filter.
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Dict with 'tables' list.
@@ -188,7 +209,7 @@ class StorageService(BaseService):
 
         client = self._client_factory(project.stack_url, project.token)
         try:
-            raw_tables = client.list_tables(bucket_id=bucket_id)
+            raw_tables = client.list_tables(bucket_id=bucket_id, branch_id=branch_id)
         finally:
             client.close()
 
@@ -222,11 +243,16 @@ class StorageService(BaseService):
         name: str,
         description: str | None = None,
         backend: str | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create a new storage bucket.
 
         Args:
+            alias: Project alias.
             stage: Bucket stage — must be "in" or "out".
+            description: Optional bucket description.
+            backend: Optional backend type.
+            branch_id: If set, create bucket in a specific dev branch.
 
         Returns:
             Dict with created bucket details.
@@ -244,7 +270,11 @@ class StorageService(BaseService):
         client = self._client_factory(project.stack_url, project.token)
         try:
             bucket = client.create_bucket(
-                stage=stage, name=name, description=description, backend=backend
+                stage=stage,
+                name=name,
+                description=description,
+                backend=backend,
+                branch_id=branch_id,
             )
         finally:
             client.close()
@@ -265,11 +295,17 @@ class StorageService(BaseService):
         name: str,
         columns: list[str],
         primary_key: list[str] | None = None,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create a new table with typed columns.
 
         Args:
+            alias: Project alias.
+            bucket_id: Target bucket ID.
+            name: Table name.
             columns: List of "name:TYPE" strings (e.g. ["id:INTEGER", "name:STRING"]).
+            primary_key: Optional list of primary key column names.
+            branch_id: If set, create table in a specific dev branch.
 
         Returns:
             Dict with created table details.
@@ -298,6 +334,7 @@ class StorageService(BaseService):
                 name=name,
                 columns=parsed_columns,
                 primary_key=primary_key,
+                branch_id=branch_id,
             )
         finally:
             client.close()
@@ -320,12 +357,23 @@ class StorageService(BaseService):
         delimiter: str = ",",
         enclosure: str = '"',
         auto_create: bool = True,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Upload a CSV file into a storage table.
 
         When auto_create is True (default), auto-creates the bucket and/or
         table if they don't exist. Columns are inferred as STRING from the CSV
         header row. Pass auto_create=False to require the table to exist.
+
+        Args:
+            alias: Project alias.
+            table_id: Target table ID.
+            file_path: Local path to the CSV file.
+            incremental: Append rows (True) or full load (False).
+            delimiter: CSV column delimiter.
+            enclosure: CSV value enclosure character.
+            auto_create: Auto-create bucket and table if missing.
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Dict with import results plus auto_created_bucket / auto_created_table flags.
@@ -351,17 +399,24 @@ class StorageService(BaseService):
 
                     # Ensure bucket exists
                     try:
-                        client.get_bucket_detail(bucket_id)
+                        client.get_bucket_detail(bucket_id, branch_id=branch_id)
                     except KeboolaApiError as exc:
                         if exc.status_code == 404:
-                            client.create_bucket(stage=stage, name=bucket_name)
+                            client.create_bucket(
+                                stage=stage,
+                                name=bucket_name,
+                                branch_id=branch_id,
+                            )
                             auto_created_bucket = True
                             logger.info("Auto-created bucket %s", bucket_id)
                         else:
                             raise
 
                     # Ensure table exists
-                    existing = client.list_tables(bucket_id=bucket_id)
+                    existing = client.list_tables(
+                        bucket_id=bucket_id,
+                        branch_id=branch_id,
+                    )
                     if not any(t.get("name") == table_name for t in existing):
                         columns = _read_csv_header(file_path, delimiter=delimiter)
                         client.create_table(
@@ -371,6 +426,7 @@ class StorageService(BaseService):
                                 {"name": col, "definition": {"type": "STRING"}} for col in columns
                             ],
                             primary_key=None,
+                            branch_id=branch_id,
                         )
                         auto_created_table = True
                         logger.info("Auto-created table %s (%d columns)", table_id, len(columns))
@@ -381,6 +437,7 @@ class StorageService(BaseService):
                 incremental=incremental,
                 delimiter=delimiter,
                 enclosure=enclosure,
+                branch_id=branch_id,
             )
         finally:
             client.close()
@@ -405,11 +462,18 @@ class StorageService(BaseService):
         alias: str,
         table_ids: list[str],
         dry_run: bool = False,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Delete one or more storage tables.
 
         Batch-tolerant: accumulates errors per table, one failure does not
         stop other deletes.
+
+        Args:
+            alias: Project alias.
+            table_ids: List of table IDs to delete.
+            dry_run: If True, only report what would be deleted.
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Dict with 'deleted', 'failed', 'dry_run', 'project_alias',
@@ -436,7 +500,7 @@ class StorageService(BaseService):
         try:
             for tid in table_ids:
                 try:
-                    client.delete_table(tid)
+                    client.delete_table(tid, branch_id=branch_id)
                     deleted.append(tid)
                 except KeboolaApiError as exc:
                     failed.append({"id": tid, "error": exc.message})
@@ -456,6 +520,7 @@ class StorageService(BaseService):
         bucket_ids: list[str],
         force: bool = False,
         dry_run: bool = False,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Delete one or more storage buckets.
 
@@ -465,6 +530,13 @@ class StorageService(BaseService):
         - Without force, non-empty buckets fail at the API level.
 
         Batch-tolerant: accumulates errors per bucket.
+
+        Args:
+            alias: Project alias.
+            bucket_ids: List of bucket IDs to delete.
+            force: Force delete even if bucket has tables or is shared.
+            dry_run: If True, only report what would be deleted.
+            branch_id: If set, target a specific dev branch.
 
         Returns:
             Dict with 'deleted', 'failed', 'dry_run', 'project_alias',
@@ -484,7 +556,7 @@ class StorageService(BaseService):
             for bid in bucket_ids:
                 # Check bucket metadata for linked/shared protections
                 try:
-                    bucket = client.get_bucket_detail(bid)
+                    bucket = client.get_bucket_detail(bid, branch_id=branch_id)
                 except KeboolaApiError as exc:
                     failed.append({"id": bid, "error": exc.message})
                     continue
@@ -520,7 +592,7 @@ class StorageService(BaseService):
                     continue
 
                 try:
-                    client.delete_bucket(bid, force=force)
+                    client.delete_bucket(bid, force=force, branch_id=branch_id)
                     deleted.append(bid)
                 except KeboolaApiError as exc:
                     failed.append({"id": bid, "error": exc.message})
@@ -542,14 +614,17 @@ class StorageService(BaseService):
     # ------------------------------------------------------------------
 
     def _fetch_buckets(
-        self, alias: str, project: ProjectConfig
+        self,
+        alias: str,
+        project: ProjectConfig,
+        branch_id: int | None = None,
     ) -> tuple[str, list[dict[str, Any]], bool]:
         """Fetch buckets for a single project (worker for _run_parallel)."""
         from ..errors import KeboolaApiError
 
         client = self._client_factory(project.stack_url, project.token)
         try:
-            buckets = client.list_buckets(include="linkedBuckets")
+            buckets = client.list_buckets(include="linkedBuckets", branch_id=branch_id)
             return (alias, buckets, True)
         except KeboolaApiError as exc:
             return (

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1100,6 +1100,37 @@ class TestListBuckets:
             result = client.list_buckets()
             assert result == []
 
+    def test_list_buckets_with_branch_id(self, httpx_mock) -> None:
+        """list_buckets(branch_id=123) uses branch-prefixed URL."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/123/buckets",
+            json=SAMPLE_BUCKETS,
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.list_buckets(branch_id=123)
+            assert len(result) == 2
+            assert result[0]["id"] == "in.c-data"
+
+    def test_list_buckets_with_branch_id_and_include(self, httpx_mock) -> None:
+        """list_buckets(branch_id=123, include=) combines branch prefix with params."""
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/branch/123/buckets?include=linkedBuckets",
+            json=SAMPLE_BUCKETS_WITH_SHARING,
+            status_code=200,
+        )
+
+        with KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k",
+        ) as client:
+            result = client.list_buckets(include="linkedBuckets", branch_id=123)
+            assert len(result) == 1
+
 
 class TestApiErrorMessageTruncation:
     """Tests for S4: API error message truncation to 500 characters."""

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -55,7 +55,7 @@ class TestDeleteTablesService:
         assert result["deleted"] == ["in.c-data.users"]
         assert result["failed"] == []
         assert result["dry_run"] is False
-        mock_client.delete_table.assert_called_once_with("in.c-data.users")
+        mock_client.delete_table.assert_called_once_with("in.c-data.users", branch_id=None)
 
     def test_batch_partial_failure(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -110,7 +110,7 @@ class TestDeleteBucketsService:
 
         assert result["deleted"] == ["in.c-data"]
         assert result["failed"] == []
-        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=False)
+        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=False, branch_id=None)
 
     def test_force_flag(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -121,7 +121,7 @@ class TestDeleteBucketsService:
 
         service.delete_buckets(alias="test", bucket_ids=["in.c-data"], force=True)
 
-        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=True)
+        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=True, branch_id=None)
 
     def test_linked_bucket_blocked(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -359,7 +359,11 @@ class TestDeleteBucketCLI:
             )
         assert result.exit_code == 0
         svc.delete_buckets.assert_called_once_with(
-            alias="test", bucket_ids=["in.c-data"], force=True, dry_run=False
+            alias="test",
+            bucket_ids=["in.c-data"],
+            force=True,
+            dry_run=False,
+            branch_id=None,
         )
 
     def test_delete_bucket_linked_blocked(self, tmp_path: Path) -> None:
@@ -390,3 +394,228 @@ class TestDeleteBucketCLI:
                 ],
             )
         assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Branch support tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteTableBranch:
+    """Tests for --branch support in delete-table."""
+
+    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
+        """delete_tables passes branch_id to client.delete_table."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_table.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(alias="test", table_ids=["in.c-data.users"], branch_id=42)
+
+        assert result["deleted"] == ["in.c-data.users"]
+        mock_client.delete_table.assert_called_once_with("in.c-data.users", branch_id=42)
+
+    def test_cli_branch_flag_json(self, tmp_path: Path) -> None:
+        """storage delete-table --branch 42 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_tables.return_value = {
+                "deleted": ["in.c-data.users"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--branch",
+                    "42",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.delete_tables.call_args.kwargs
+        assert call_kwargs["branch_id"] == 42
+
+
+class TestDeleteBucketBranch:
+    """Tests for --branch support in delete-bucket."""
+
+    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
+        """delete_buckets passes branch_id to client calls."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {"id": "in.c-data"}
+        mock_client.delete_bucket.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-data"], branch_id=99)
+
+        assert result["deleted"] == ["in.c-data"]
+        mock_client.get_bucket_detail.assert_called_once_with("in.c-data", branch_id=99)
+        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=False, branch_id=99)
+
+    def test_cli_branch_flag_json(self, tmp_path: Path) -> None:
+        """storage delete-bucket --branch 99 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_buckets.return_value = {
+                "deleted": ["in.c-data"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-bucket",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-data",
+                    "--branch",
+                    "99",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.delete_buckets.call_args.kwargs
+        assert call_kwargs["branch_id"] == 99
+
+
+class TestStorageBucketsBranch:
+    """Tests for --branch support in storage buckets (list) command."""
+
+    def test_cli_branch_flag(self, tmp_path: Path) -> None:
+        """storage buckets --branch 10 --project test passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_buckets.return_value = {"buckets": [], "errors": []}
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "buckets", "--project", "test", "--branch", "10"],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.list_buckets.call_args.kwargs
+        assert call_kwargs["branch_id"] == 10
+
+    def test_cli_branch_requires_single_project(self, tmp_path: Path) -> None:
+        """storage buckets --branch without --project returns exit code 2."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_buckets.return_value = {"buckets": [], "errors": []}
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "buckets", "--branch", "10"],
+            )
+        assert result.exit_code == 2
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert "INVALID_ARGUMENT" in output["error"]["code"]
+
+
+class TestStorageBucketDetailBranch:
+    """Tests for --branch support in storage bucket-detail command."""
+
+    def test_cli_branch_flag(self, tmp_path: Path) -> None:
+        """storage bucket-detail --branch 20 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.get_bucket_detail.return_value = {
+                "project_alias": "test",
+                "project_id": 1234,
+                "bucket_id": "in.c-data",
+                "display_name": "data",
+                "stage": "in",
+                "description": "",
+                "backend": "snowflake",
+                "is_linked": False,
+                "source_project_id": None,
+                "source_project_name": "",
+                "source_bucket_id": "",
+                "snowflake_database": "SAPI_1234",
+                "snowflake_schema": "in.c-data",
+                "tables": [],
+                "table_count": 0,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "bucket-detail",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-data",
+                    "--branch",
+                    "20",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.get_bucket_detail.call_args.kwargs
+        assert call_kwargs["branch_id"] == 20
+
+
+class TestStorageTablesBranch:
+    """Tests for --branch support in storage tables command."""
+
+    def test_cli_branch_flag(self, tmp_path: Path) -> None:
+        """storage tables --branch 30 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {"tables": [], "project_alias": "test"}
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "tables",
+                    "--project",
+                    "test",
+                    "--branch",
+                    "30",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.list_tables.call_args.kwargs
+        assert call_kwargs["branch_id"] == 30

--- a/tests/test_storage_write.py
+++ b/tests/test_storage_write.py
@@ -69,7 +69,11 @@ class TestCreateBucketService:
         assert result["stage"] == "in"
         assert result["project_alias"] == "test"
         mock_client.create_bucket.assert_called_once_with(
-            stage="in", name="my-bucket", description="Test bucket", backend=None
+            stage="in",
+            name="my-bucket",
+            description="Test bucket",
+            backend=None,
+            branch_id=None,
         )
         mock_client.close.assert_called_once()
 
@@ -87,7 +91,11 @@ class TestCreateBucketService:
         service.create_bucket(alias="test", stage="out", name="result", backend="bigquery")
 
         mock_client.create_bucket.assert_called_once_with(
-            stage="out", name="result", description=None, backend="bigquery"
+            stage="out",
+            name="result",
+            description=None,
+            backend="bigquery",
+            branch_id=None,
         )
 
     def test_api_error_propagates(self, tmp_path: Path) -> None:
@@ -154,6 +162,7 @@ class TestCreateTableService:
                 {"name": "name", "definition": {"type": "STRING"}},
             ],
             primary_key=["id"],
+            branch_id=None,
         )
         mock_client.close.assert_called_once()
 
@@ -195,6 +204,7 @@ class TestCreateTableService:
             name="t",
             columns=[{"name": "x", "definition": {"type": "STRING"}}],
             primary_key=None,
+            branch_id=None,
         )
 
     def test_invalid_column_type_raises(self, tmp_path: Path) -> None:
@@ -253,6 +263,7 @@ class TestUploadTableService:
             incremental=False,
             delimiter=",",
             enclosure='"',
+            branch_id=None,
         )
         mock_client.close.assert_called_once()
 
@@ -279,6 +290,7 @@ class TestUploadTableService:
             incremental=True,
             delimiter=",",
             enclosure='"',
+            branch_id=None,
         )
 
     def test_custom_delimiter_and_enclosure(self, tmp_path: Path) -> None:
@@ -304,6 +316,7 @@ class TestUploadTableService:
             incremental=False,
             delimiter=";",
             enclosure="'",
+            branch_id=None,
         )
 
     def test_warnings_passed_through(self, tmp_path: Path) -> None:
@@ -369,7 +382,11 @@ class TestUploadTableAutoCreate:
             file_path=str(csv_file),
         )
 
-        mock_client.create_bucket.assert_called_once_with(stage="in", name="users")
+        mock_client.create_bucket.assert_called_once_with(
+            stage="in",
+            name="users",
+            branch_id=None,
+        )
         mock_client.create_table.assert_called_once_with(
             bucket_id="in.c-users",
             name="users",
@@ -379,6 +396,7 @@ class TestUploadTableAutoCreate:
                 {"name": "email", "definition": {"type": "STRING"}},
             ],
             primary_key=None,
+            branch_id=None,
         )
         assert result["auto_created_bucket"] is True
         assert result["auto_created_table"] is True
@@ -409,6 +427,7 @@ class TestUploadTableAutoCreate:
                 {"name": "payload", "definition": {"type": "STRING"}},
             ],
             primary_key=None,
+            branch_id=None,
         )
         assert result["auto_created_bucket"] is False
         assert result["auto_created_table"] is True
@@ -575,6 +594,7 @@ class TestCreateBucketCLI:
             name="result",
             description="My output",
             backend="bigquery",
+            branch_id=None,
         )
 
     def test_create_bucket_invalid_stage(self, tmp_path: Path) -> None:
@@ -682,6 +702,7 @@ class TestCreateTableCLI:
             name="users",
             columns=["id:INTEGER", "name:STRING"],
             primary_key=["id"],
+            branch_id=None,
         )
 
     def test_create_table_no_primary_key(self, tmp_path: Path) -> None:
@@ -831,6 +852,7 @@ class TestUploadTableCLI:
             delimiter=",",
             enclosure='"',
             auto_create=True,
+            branch_id=None,
         )
 
     def test_upload_table_incremental(self, tmp_path: Path) -> None:
@@ -874,6 +896,7 @@ class TestUploadTableCLI:
             delimiter=",",
             enclosure='"',
             auto_create=True,
+            branch_id=None,
         )
 
     def test_upload_table_file_not_found(self, tmp_path: Path) -> None:
@@ -972,4 +995,211 @@ class TestUploadTableCLI:
             delimiter=",",
             enclosure='"',
             auto_create=False,
+            branch_id=None,
         )
+
+
+# ---------------------------------------------------------------------------
+# Branch support tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBucketBranch:
+    """Tests for --branch support in create-bucket."""
+
+    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
+        """create_bucket passes branch_id to client."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.create_bucket.return_value = {
+            "id": "in.c-my-bucket",
+            "displayName": "my-bucket",
+            "stage": "in",
+            "backend": "snowflake",
+            "description": "",
+        }
+        service = _make_service(store, mock_client)
+
+        service.create_bucket(alias="test", stage="in", name="my-bucket", branch_id=55)
+
+        mock_client.create_bucket.assert_called_once_with(
+            stage="in",
+            name="my-bucket",
+            description=None,
+            backend=None,
+            branch_id=55,
+        )
+
+    def test_cli_branch_flag(self, tmp_path: Path) -> None:
+        """storage create-bucket --branch 55 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.create_bucket.return_value = {
+                "project_alias": "test",
+                "id": "in.c-my-bucket",
+                "display_name": "my-bucket",
+                "stage": "in",
+                "backend": "snowflake",
+                "description": "",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "create-bucket",
+                    "--project",
+                    "test",
+                    "--stage",
+                    "in",
+                    "--name",
+                    "my-bucket",
+                    "--branch",
+                    "55",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.create_bucket.call_args.kwargs
+        assert call_kwargs["branch_id"] == 55
+
+
+class TestCreateTableBranch:
+    """Tests for --branch support in create-table."""
+
+    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
+        """create_table passes branch_id to client."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.create_table.return_value = {"id": "in.c-b.users"}
+        service = _make_service(store, mock_client)
+
+        service.create_table(
+            alias="test",
+            bucket_id="in.c-b",
+            name="users",
+            columns=["id:INTEGER"],
+            branch_id=77,
+        )
+
+        mock_client.create_table.assert_called_once_with(
+            bucket_id="in.c-b",
+            name="users",
+            columns=[{"name": "id", "definition": {"type": "INTEGER"}}],
+            primary_key=None,
+            branch_id=77,
+        )
+
+    def test_cli_branch_flag(self, tmp_path: Path) -> None:
+        """storage create-table --branch 77 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.create_table.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-b.users",
+                "name": "users",
+                "bucket_id": "in.c-b",
+                "primary_key": [],
+                "columns": ["id"],
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "create-table",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-b",
+                    "--name",
+                    "users",
+                    "--column",
+                    "id:INTEGER",
+                    "--branch",
+                    "77",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.create_table.call_args.kwargs
+        assert call_kwargs["branch_id"] == 77
+
+
+class TestUploadTableBranch:
+    """Tests for --branch support in upload-table."""
+
+    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
+        """upload_table passes branch_id to client."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n")
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.upload_table.return_value = {"importedRowsCount": 1, "warnings": []}
+        service = _make_service(store, mock_client)
+
+        service.upload_table(
+            alias="test",
+            table_id="in.c-b.data",
+            file_path=str(csv_file),
+            auto_create=False,
+            branch_id=33,
+        )
+
+        mock_client.upload_table.assert_called_once_with(
+            table_id="in.c-b.data",
+            file_path=str(csv_file),
+            incremental=False,
+            delimiter=",",
+            enclosure='"',
+            branch_id=33,
+        )
+
+    def test_cli_branch_flag(self, tmp_path: Path) -> None:
+        """storage upload-table --branch 33 passes branch_id to service."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n")
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.upload_table.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-b.data",
+                "incremental": False,
+                "imported_rows": 1,
+                "file_size_bytes": 5,
+                "warnings": [],
+                "auto_created_bucket": False,
+                "auto_created_table": False,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "upload-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-b.data",
+                    "--file",
+                    str(csv_file),
+                    "--branch",
+                    "33",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.upload_table.call_args.kwargs
+        assert call_kwargs["branch_id"] == 33


### PR DESCRIPTION
## Summary

- Added `--branch` option to all 8 storage commands: `buckets`, `bucket-detail`, `tables`, `create-bucket`, `create-table`, `upload-table`, `delete-table`, `delete-bucket`
- All commands use `resolve_branch()` to auto-detect active branch (consistent with config commands)
- Updated client, service, and command layers to pass `branch_id` through the full call chain

## Motivation

Storage commands were the only command group without `--branch` support, even though the underlying Storage API supports branch-scoped requests via `/v2/storage/branch/{id}/` prefix. This gives agents a reliable REST-based path to storage data on dev branches, independent of MCP tools.

Related: keboola/mcp-server#464 (fixes MCP-side ID normalization bug on dev branches)

## Changes

| Layer | File | Change |
|---|---|---|
| Client | `client.py` | `branch_id` param added to 7 methods |
| Service | `storage_service.py` | `branch_id` param added to 8 public methods + worker |
| Commands | `storage.py` | `--branch` option on all 8 commands with `resolve_branch()` |
| Tests | 3 test files | 16 new tests, ~15 existing updated |

## Test plan

- [x] All 1355 tests pass (`make check`)
- [x] Lint + format clean
- [ ] Manual test: `kbagent storage tables --project X --branch Y`
- [ ] Manual test: `kbagent storage buckets --project X --branch Y`