### PR TITLE
feat: kbagent encrypt command + sync push plaintext fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,8 @@ kbagent component list [--project NAME] [--type TYPE] [--query QUERY]
 kbagent component detail --component-id ID [--project NAME]
 kbagent config new --component-id ID [--name NAME] [--project NAME] [--output-dir DIR]
 
+kbagent encrypt values --project ALIAS --component-id ID --input JSON|@file|- [--output-file PATH]
+
 kbagent context
 kbagent init [--from-global]
 kbagent doctor [--fix]

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -104,6 +104,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Link the current git branch to a Keboola development branch | `kbagent sync branch-link --project PROJECT` |
 | Remove the branch mapping for the current git branch | `kbagent sync branch-unlink` |
 | Show the branch mapping status for the current git branch | `kbagent sync branch-status` |
+| Encrypt #-prefixed secret values for a Keboola component | `kbagent encrypt values --project PROJECT --component-id COMPONENT-ID --input INPUT-DATA` |
 <!-- END AUTO-GENERATED COMMANDS -->
 
 ### Sync pull notable flags

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -8,6 +8,7 @@ description: >
   temporary workspaces, bulk-onboarding organizations, syncing project configs
   as local files (GitOps), git-branching with Keboola dev branch isolation,
   sharing buckets across projects, linking shared data,
+  encrypting secrets for MCP tool call workflows,
   and syncing storage metadata and job history. Triggers: kbagent, Keboola project,
   keboola configs, keboola jobs, keboola lineage, keboola transformations,
   keboola MCP tools, keboola workspace, SQL debugging, keboola branches,
@@ -16,7 +17,9 @@ description: >
   keboola gitops, sync pull, sync push, sync diff, branch-link,
   search configs, find in configurations, audit configurations,
   input mapping migration, remove input mapping, Snowflake paths,
-  MULTI_STATEMENT_COUNT, statement count error, SQL transformation migration.
+  MULTI_STATEMENT_COUNT, statement count error, SQL transformation migration,
+  keboola encrypt, encrypt secrets, encrypt credentials, encrypt password,
+  keboola encryption API, #password, #api_token, KBC::ProjectSecure.
 ---
 
 # kbagent -- Keboola Agent CLI
@@ -146,6 +149,7 @@ For detailed response parsing rules and common pitfalls, see [gotchas](reference
 | Workspace SQL debugging | [workspace-workflow](references/workspace-workflow.md) |
 | Bucket sharing & linking | [sharing-workflow](references/sharing-workflow.md) |
 | Dev branches | [branch-workflow](references/branch-workflow.md) |
+| Encrypting secrets for MCP tools | [encrypt-workflow](references/encrypt-workflow.md) |
 | Sync & Git-branching (GitOps) | [sync-workflow](references/sync-workflow.md) |
 | Reading synced data | [reading-synced-data](references/reading-synced-data.md) |
 | SQL migration (input mapping removal) | [sql-migration-workflow](references/sql-migration-workflow.md) |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -67,12 +67,15 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 ## Sync (GitOps)
 - `sync init --project ALIAS [--directory DIR] [--git-branching]` -- initialize sync working directory
 - `sync pull --project ALIAS [--all-projects] [--force] [--dry-run] [--with-samples] [--no-storage] [--no-jobs] [--job-limit N]` -- download configs to local files. For large projects (>100 configs), automatically fetches jobs per-config when the grouped API limit is insufficient
-- `sync push --project ALIAS [--all-projects] [--dry-run] [--force]` -- push local changes (auto-encrypts secrets)
+- `sync push --project ALIAS [--all-projects] [--dry-run] [--force] [--allow-plaintext-on-encrypt-failure]` -- push local changes (auto-encrypts secrets, fails if encryption fails)
 - `sync diff --project ALIAS [--all-projects]` -- 3-way diff (local vs base vs remote), detects conflicts
 - `sync status [--directory DIR]` -- show locally modified/added/deleted configs
 - `sync branch-link --project ALIAS [--branch-id ID] [--branch-name NAME]` -- link git branch to Keboola dev branch
 - `sync branch-unlink [--directory DIR]` -- remove git-to-Keboola branch mapping
 - `sync branch-status [--directory DIR]` -- show current branch mapping
+
+## Encryption
+- `encrypt values --project ALIAS --component-id ID --input JSON|@file|- [--output-file PATH]` -- encrypt #-prefixed secrets via Keboola Encryption API (one-way, no decrypt). Scope: ComponentSecure (project + component). Use for MCP tool call workflows.
 
 ## Utility
 - `init [--from-global]` -- create local `.kbagent/` workspace (per-directory isolation)

--- a/plugins/kbagent/skills/kbagent/references/encrypt-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/encrypt-workflow.md
@@ -1,0 +1,99 @@
+# Encryption Workflow
+
+Encrypt secret values before passing them to Keboola configs via MCP tools or API.
+
+## Why you need this
+
+MCP write tools (`update_config`, `create_config`) accept a complete config JSON
+and forward it to the Storage API. They do NOT encrypt anything. If your payload
+contains `#`-prefixed credentials, the ciphertext must be ready BEFORE the tool call.
+
+`kbagent encrypt values` calls the Keboola Encryption API and returns ciphertext
+that Keboola components can decrypt at runtime. The API is **one-way** -- there is
+no decrypt endpoint.
+
+## Encryption scope
+
+All encryption uses **ComponentSecure** scope (project + component). This means:
+- Encrypted values work in ANY config of that component within the project
+- You can clone configs freely -- secrets still decrypt
+- You can merge dev branches to main -- secrets still decrypt
+
+Do NOT try to narrow the scope (e.g. per-config or per-branch) -- it breaks
+config cloning and branch merging.
+
+## Basic usage
+
+```bash
+# Encrypt a single secret
+kbagent --json encrypt values \
+  --project my-proj \
+  --component-id keboola.ex-db-snowflake \
+  --input '{"#password": "my-secret-password"}'
+
+# Output: {"#password": "KBC::ProjectSecure::...encrypted..."}
+```
+
+## Pipe workflow (MCP tool calls)
+
+The primary use case -- encrypt, then pass to a write tool:
+
+```bash
+# Step 1: Encrypt the secret
+CIPHER=$(kbagent --json encrypt values \
+  --project my-proj \
+  --component-id keboola.python-transformation-v2 \
+  --input '{"#api_token": "rotated-value"}' \
+  | jq -r '.data["#api_token"]')
+
+# Step 2: Use in a tool call
+kbagent --json tool call update_config --project my-proj \
+  --input "{\"component_id\": \"keboola.python-transformation-v2\", \"configuration_id\": \"123\", \"parameters\": {\"#api_token\": \"$CIPHER\"}}"
+```
+
+Or encrypt from a file:
+
+```bash
+# secrets.json: {"#db_password": "new-pass", "#api_key": "new-key"}
+kbagent --json encrypt values \
+  --project prod \
+  --component-id keboola.ex-db-snowflake \
+  --input @secrets.json \
+  --output-file encrypted.json
+```
+
+## Input formats
+
+| Format | Example | When to use |
+|--------|---------|-------------|
+| Inline JSON | `--input '{"#key": "val"}'` | Quick single-value encryption |
+| File | `--input @secrets.json` | Multiple values, avoid shell escaping |
+| Stdin | `--input -` | Pipe from another command, scripting |
+| Output file | `--output-file enc.json` | Save encrypted values (0600 permissions) |
+
+## Rules
+
+1. **All keys must start with `#`** -- the Encryption API requires this
+2. **All values must be strings** -- no nested objects, no numbers
+3. **Already-encrypted values pass through** -- values starting with `KBC::` are returned unchanged (idempotent)
+4. **One project at a time** -- each project has its own encryption key, no `--all-projects`
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Key 'password' must start with '#' | Missing `#` prefix | Use `#password` not `password` |
+| Value for '#key' must be a string | Non-string value (int, dict, etc.) | Convert to string first |
+| 403 / auth error | Token lacks encryption permissions | Check token scopes |
+| Connection error to encryption API | Network issue or wrong stack URL | Run `kbagent doctor` |
+
+## Sync push and encryption
+
+`sync push` auto-encrypts `#`-prefixed plaintext values before pushing to Keboola.
+If the Encryption API fails, push is **refused** (plaintext secrets are never sent).
+
+Use `--allow-plaintext-on-encrypt-failure` only if you understand the risk:
+```bash
+# DANGEROUS: secrets may be stored as plaintext in Keboola
+kbagent sync push --project my-proj --allow-plaintext-on-encrypt-failure
+```

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -11,6 +11,7 @@ from .commands.component import component_app
 from .commands.config import config_app
 from .commands.context import context_command
 from .commands.doctor import doctor_command
+from .commands.encrypt import encrypt_app
 from .commands.init import init_command
 from .commands.job import job_app
 from .commands.lineage import lineage_app
@@ -33,6 +34,7 @@ from .services.branch_service import BranchService
 from .services.component_service import ComponentService
 from .services.config_service import ConfigService
 from .services.doctor_service import DoctorService
+from .services.encrypt_service import EncryptService
 from .services.job_service import JobService
 from .services.lineage_service import LineageService
 from .services.mcp_service import McpService
@@ -80,6 +82,7 @@ app.add_typer(branch_app, name="branch", rich_help_panel=_DEV)
 app.add_typer(workspace_app, name="workspace", rich_help_panel=_DEV)
 app.add_typer(tool_app, name="tool", rich_help_panel=_DEV)
 app.add_typer(sync_app, name="sync", rich_help_panel=_DEV)
+app.add_typer(encrypt_app, name="encrypt", rich_help_panel=_DEV)
 
 
 @app.callback()
@@ -153,6 +156,7 @@ def main(
     sharing_service = SharingService(config_store=config_store)
     storage_service = StorageService(config_store=config_store)
     sync_service = SyncService(config_store=config_store)
+    encrypt_service = EncryptService(config_store=config_store)
     workspace_service = WorkspaceService(config_store=config_store)
     doctor_service = DoctorService(config_store=config_store, mcp_service=mcp_service)
     version_service = VersionService()
@@ -182,6 +186,7 @@ def main(
     ctx.obj["sharing_service"] = sharing_service
     ctx.obj["storage_service"] = storage_service
     ctx.obj["sync_service"] = sync_service
+    ctx.obj["encrypt_service"] = encrypt_service
     ctx.obj["workspace_service"] = workspace_service
     ctx.obj["doctor_service"] = doctor_service
     ctx.obj["version_service"] = version_service

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -234,8 +234,9 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent sync diff --project ALIAS [--all-projects] [--directory DIR]
     3-way diff: local vs pull-time snapshot vs remote. Detects conflicts.
 
-  kbagent sync push --project ALIAS [--all-projects] [--dry-run] [--force]
+  kbagent sync push --project ALIAS [--all-projects] [--dry-run] [--force] [--allow-plaintext-on-encrypt-failure]
     Push local changes. Auto-encrypts secrets. Skips conflicts (pull first).
+    Fails if encryption fails (plaintext secrets never pushed). Use escape hatch flag only if you know what you are doing.
 
   kbagent sync branch-link --project ALIAS [--branch-id ID] [--branch-name NAME]
     Link git branch to Keboola dev branch. Auto-creates if needed.
@@ -245,6 +246,15 @@ Use `kbagent <command> --help` for full flag details and examples.
 
   kbagent sync branch-status [--directory DIR]
     Show current branch mapping status.
+
+### Encryption
+
+  kbagent encrypt values --project ALIAS --component-id ID --input JSON|@file|-  [--output-file PATH]
+    Encrypt #-prefixed secret values via Keboola Encryption API (one-way, no decrypt).
+    Scope: ComponentSecure (project + component). Use for MCP tool call workflows
+    where ciphertext must exist before calling update_config / create_config.
+    --input accepts: inline JSON, @file.json (from file), or - (from stdin).
+    Already-encrypted values (KBC:: prefix) pass through unchanged.
 
 ### MCP Tools (Multi-Project)
 

--- a/src/keboola_agent_cli/commands/encrypt.py
+++ b/src/keboola_agent_cli/commands/encrypt.py
@@ -1,0 +1,131 @@
+"""Encrypt command -- encrypt secret values via Keboola Encryption API.
+
+Thin CLI layer: parses arguments, calls EncryptService, formats output.
+No business logic belongs here.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import typer
+
+from ..errors import ConfigError, KeboolaApiError
+from ._helpers import (
+    check_cli_permission,
+    get_formatter,
+    get_service,
+    map_error_to_exit_code,
+)
+
+encrypt_app = typer.Typer(
+    help="Encrypt secret values via Keboola Encryption API (one-way, no decrypt)"
+)
+
+
+@encrypt_app.callback(invoke_without_command=True)
+def _encrypt_permission_check(ctx: typer.Context) -> None:
+    check_cli_permission(ctx, "encrypt")
+
+
+@encrypt_app.command("values")
+def encrypt_values(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    component_id: str = typer.Option(
+        ...,
+        "--component-id",
+        help="Keboola component ID (e.g. keboola.python-transformation-v2)",
+    ),
+    input_data: str = typer.Option(
+        ...,
+        "--input",
+        help="JSON to encrypt: inline JSON, @file.json, or - for stdin",
+    ),
+    output_file: Path | None = typer.Option(
+        None,
+        "--output-file",
+        help="Write result to file (0600 permissions) instead of stdout",
+    ),
+) -> None:
+    """Encrypt #-prefixed secret values for a Keboola component.
+
+    Input must be a JSON object with #-prefixed keys and string values.
+    Already-encrypted values (KBC:: prefix) pass through unchanged.
+
+    The Keboola Encryption API is one-way -- there is no decrypt endpoint.
+    Encrypted values can only be used by Keboola components at runtime.
+
+    Examples:
+        kbagent encrypt values --project my-proj --component-id keboola.ex-db-snowflake --input '{"#password": "secret"}'
+        echo '{"#token": "abc"}' | kbagent encrypt values --project my-proj --component-id keboola.ex-db-snowflake --input -
+        kbagent encrypt values --project my-proj --component-id keboola.ex-db-snowflake --input @secrets.json --output-file encrypted.json
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "encrypt_service")
+
+    # Parse input
+    try:
+        parsed = _parse_input(input_data)
+    except (json.JSONDecodeError, FileNotFoundError, ValueError) as exc:
+        formatter.error(message=str(exc), error_code="INPUT_ERROR")
+        raise typer.Exit(code=2) from None
+
+    if not isinstance(parsed, dict):
+        formatter.error(
+            message="Input must be a JSON object (dict), not " + type(parsed).__name__,
+            error_code="INPUT_ERROR",
+        )
+        raise typer.Exit(code=2) from None
+
+    try:
+        result = service.encrypt(alias=project, component_id=component_id, input_data=parsed)
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(
+            message=exc.message,
+            error_code=exc.error_code,
+            retryable=exc.retryable,
+        )
+        raise typer.Exit(code=exit_code) from None
+
+    if output_file:
+        output_file.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        output_file.chmod(0o600)
+        if not formatter.json_mode:
+            formatter.console.print(f"Encrypted values written to {output_file}")
+
+    formatter.output(result, lambda c, d: c.print_json(json.dumps(d, indent=2)))
+
+
+def _parse_input(raw: str) -> dict:
+    """Parse input from inline JSON, @file, or stdin.
+
+    Args:
+        raw: One of:
+            - "-" to read from stdin
+            - "@path/to/file.json" to read from a file
+            - Inline JSON string
+
+    Returns:
+        Parsed JSON as a dict.
+
+    Raises:
+        json.JSONDecodeError: If JSON parsing fails.
+        FileNotFoundError: If @file does not exist.
+    """
+    if raw == "-":
+        return json.loads(sys.stdin.read())
+    if raw.startswith("@"):
+        file_path = Path(raw[1:])
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Input file not found: {file_path}")
+        return json.loads(file_path.read_text(encoding="utf-8"))
+    return json.loads(raw)

--- a/src/keboola_agent_cli/commands/sync.py
+++ b/src/keboola_agent_cli/commands/sync.py
@@ -744,6 +744,11 @@ def sync_push(
         "--force",
         help="Allow deletion of remote configs that were removed locally",
     ),
+    allow_plaintext: bool = typer.Option(
+        False,
+        "--allow-plaintext-on-encrypt-failure",
+        help="Allow push even if secret encryption fails (DANGEROUS: secrets stored as plaintext)",
+    ),
 ) -> None:
     """Push local configuration changes to a Keboola project.
 
@@ -769,7 +774,12 @@ def sync_push(
     if all_projects:
         base_dir = _safe_resolve_dir(directory)
         try:
-            data = service.push_all(base_dir, dry_run=dry_run, force=force)
+            data = service.push_all(
+                base_dir,
+                dry_run=dry_run,
+                force=force,
+                allow_plaintext_fallback=allow_plaintext,
+            )
         except ConfigError as exc:
             formatter.error(message=exc.message, error_code="CONFIG_ERROR")
             raise typer.Exit(code=5) from None
@@ -788,6 +798,7 @@ def sync_push(
             project_root=project_root,
             dry_run=dry_run,
             force=force,
+            allow_plaintext_fallback=allow_plaintext,
         )
     except FileNotFoundError as exc:
         formatter.error(message=str(exc), error_code="NOT_INITIALIZED")

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -73,6 +73,8 @@ OPERATION_REGISTRY: dict[str, str] = {
     # Storage destructive
     "storage.delete-table": "destructive",
     "storage.delete-bucket": "destructive",
+    # Encryption
+    "encrypt.values": "write",
     # Sync / git workflow
     "sync.init": "write",
     "sync.pull": "write",

--- a/src/keboola_agent_cli/services/encrypt_service.py
+++ b/src/keboola_agent_cli/services/encrypt_service.py
@@ -1,0 +1,87 @@
+"""Encryption service -- encrypt secret values via Keboola Encryption API."""
+
+import logging
+from typing import Any
+
+from ..errors import ConfigError
+from .base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class EncryptService(BaseService):
+    """Encrypt #-prefixed secret values using Keboola Encryption API.
+
+    The Keboola Encryption API is one-way -- there is no decrypt endpoint.
+    Encrypted values (KBC:: prefix) can only be used by Keboola components.
+    """
+
+    def encrypt(
+        self,
+        alias: str,
+        component_id: str,
+        input_data: dict[str, Any],
+    ) -> dict[str, str]:
+        """Encrypt secret values for a given project and component.
+
+        Args:
+            alias: Project alias.
+            component_id: Keboola component ID (e.g. 'keboola.ex-db-snowflake').
+            input_data: Dict with #-prefixed keys and plaintext string values.
+
+        Returns:
+            Dict with same keys, values replaced by ciphertext.
+
+        Raises:
+            ConfigError: If input validation fails (missing # prefix, non-string values).
+            KeboolaApiError: If the encryption API call fails.
+        """
+        # Validate input
+        errors: list[str] = []
+        for key, value in input_data.items():
+            if not key.startswith("#"):
+                errors.append(f"Key '{key}' must start with '#'")
+            if not isinstance(value, str):
+                errors.append(f"Value for '{key}' must be a string, got {type(value).__name__}")
+        if errors:
+            raise ConfigError("; ".join(errors))
+
+        # Filter out already-encrypted values (KBC:: prefix) -- pass through unchanged
+        to_encrypt: dict[str, str] = {}
+        already_encrypted: dict[str, str] = {}
+        for key, value in input_data.items():
+            if isinstance(value, str) and value.startswith("KBC::"):
+                already_encrypted[key] = value
+            else:
+                to_encrypt[key] = value
+
+        if not to_encrypt:
+            return already_encrypted
+
+        # Resolve project and call API
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            project_id = project.project_id
+            if not project_id:
+                token_info = client.verify_token()
+                project_id = token_info.project_id
+
+            if not project_id:
+                raise ConfigError(
+                    f"Cannot determine project ID for '{alias}'. "
+                    "Try running 'kbagent project status' to refresh project info."
+                )
+
+            encrypted = client.encrypt_values(
+                project_id=project_id,
+                component_id=component_id,
+                data=to_encrypt,
+            )
+            # Merge back already-encrypted values
+            encrypted.update(already_encrypted)
+            return encrypted
+        finally:
+            client.close()

--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -32,7 +32,7 @@ from ..constants import (
     STORAGE_DIR_NAME,
     STORAGE_SAMPLES_DIR_NAME,
 )
-from ..errors import ConfigError
+from ..errors import ConfigError, KeboolaApiError
 from ..sync.code_extraction import extract_code_files, merge_code_files
 from ..sync.config_format import (
     api_config_to_local,
@@ -805,6 +805,7 @@ class SyncService(BaseService):
         project_root: Path,
         dry_run: bool = False,
         force: bool = False,
+        allow_plaintext_fallback: bool = False,
     ) -> dict[str, Any]:
         """Push local changes to Keboola.
 
@@ -882,6 +883,7 @@ class SyncService(BaseService):
                             project_root,
                             manifest,
                             branch_id,
+                            allow_plaintext_fallback=allow_plaintext_fallback,
                         )
                         if result:
                             new_id = str(result.get("id", ""))
@@ -920,6 +922,7 @@ class SyncService(BaseService):
                             project_root,
                             manifest,
                             branch_id,
+                            allow_plaintext_fallback=allow_plaintext_fallback,
                         )
                         # Update both hashes so pull knows local == remote
                         config_dir = project_root / branch_path / config_path_str
@@ -993,12 +996,23 @@ class SyncService(BaseService):
         project_id: int | None,
         component_id: str,
         configuration: dict[str, Any],
+        *,
+        allow_plaintext_fallback: bool = False,
     ) -> dict[str, Any]:
         """Encrypt #-prefixed secret values in configuration before push.
 
         Walks the configuration dict recursively, collects all #-prefixed keys
         with unencrypted string values, sends them to the Encryption API,
         and replaces plaintext values with encrypted ones.
+
+        Args:
+            client: HTTP client with encrypt_values method.
+            project_id: Keboola project ID (encryption skipped if None).
+            component_id: Component ID for encryption context.
+            configuration: Config dict to encrypt in-place.
+            allow_plaintext_fallback: When False (default), encryption failure
+                raises KeboolaApiError. When True, logs a warning and continues
+                with plaintext values (escape hatch).
         """
         if not project_id:
             return configuration
@@ -1020,7 +1034,22 @@ class SyncService(BaseService):
             _apply_encrypted(configuration, "", encrypted)
             logger.info("Encrypted %d secret value(s) for %s", len(encrypted), component_id)
         except Exception as exc:
-            logger.warning("Failed to encrypt secrets for %s: %s", component_id, exc)
+            if allow_plaintext_fallback:
+                logger.warning(
+                    "Failed to encrypt secrets for %s: %s (plaintext fallback allowed)",
+                    component_id,
+                    exc,
+                )
+            else:
+                raise KeboolaApiError(
+                    message=(
+                        f"Encryption failed for {component_id}: {exc}. "
+                        f"Refusing to push plaintext secrets. "
+                        f"Use --allow-plaintext-on-encrypt-failure to override."
+                    ),
+                    status_code=0,
+                    error_code="ENCRYPTION_FAILED",
+                ) from exc
 
         return configuration
 
@@ -1032,6 +1061,8 @@ class SyncService(BaseService):
         project_root: Path,
         manifest: Manifest,
         branch_id: int | None,
+        *,
+        allow_plaintext_fallback: bool = False,
     ) -> dict[str, Any] | None:
         """Create a new config from a local _config.yml file."""
         branch_path = self._find_branch_path(manifest, branch_id)
@@ -1053,7 +1084,11 @@ class SyncService(BaseService):
         # Encrypt #-prefixed secrets before sending to API
         project_id = manifest.project.id if manifest.project else None
         configuration = self._encrypt_secrets_in_config(
-            client, project_id, component_id, configuration
+            client,
+            project_id,
+            component_id,
+            configuration,
+            allow_plaintext_fallback=allow_plaintext_fallback,
         )
 
         result = client.create_config(
@@ -1086,6 +1121,8 @@ class SyncService(BaseService):
         project_root: Path,
         manifest: Manifest,
         branch_id: int | None,
+        *,
+        allow_plaintext_fallback: bool = False,
     ) -> None:
         """Update an existing config from a local _config.yml file."""
         branch_path = self._find_branch_path(manifest, branch_id)
@@ -1107,7 +1144,11 @@ class SyncService(BaseService):
         # Encrypt #-prefixed secrets before sending to API
         project_id = manifest.project.id if manifest.project else None
         configuration = self._encrypt_secrets_in_config(
-            client, project_id, component_id, configuration
+            client,
+            project_id,
+            component_id,
+            configuration,
+            allow_plaintext_fallback=allow_plaintext_fallback,
         )
 
         client.update_config(
@@ -1305,6 +1346,7 @@ class SyncService(BaseService):
         base_dir: Path,
         dry_run: bool = False,
         force: bool = False,
+        allow_plaintext_fallback: bool = False,
     ) -> dict[str, Any]:
         """Push all registered projects that have a local manifest.
 
@@ -1314,6 +1356,8 @@ class SyncService(BaseService):
             base_dir: Parent directory containing per-project subdirectories.
             dry_run: Compute changes but don't execute them.
             force: Allow deletions without extra confirmation.
+            allow_plaintext_fallback: Allow push with plaintext secrets on
+                encryption failure.
 
         Returns:
             Dict with per-project push results, a summary, and skipped list.
@@ -1337,7 +1381,13 @@ class SyncService(BaseService):
             nonlocal success_count, failed_count
             project_root = base_dir / alias
             try:
-                result = self.push(alias, project_root, dry_run=dry_run, force=force)
+                result = self.push(
+                    alias,
+                    project_root,
+                    dry_run=dry_run,
+                    force=force,
+                    allow_plaintext_fallback=allow_plaintext_fallback,
+                )
                 results[alias] = result
                 success_count += 1
             except Exception as exc:

--- a/tests/test_encrypt_cli.py
+++ b/tests/test_encrypt_cli.py
@@ -1,0 +1,449 @@
+"""Tests for encrypt CLI commands via CliRunner.
+
+Tests the `kbagent encrypt values` subcommand: inline JSON, @file, stdin,
+output file, validation errors, and API errors. Follows the existing CLI
+test pattern from test_workspace_cli.py / test_component_cli.py with
+patched services in ctx.obj.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.models import ProjectConfig
+from keboola_agent_cli.services.project_service import ProjectService
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+runner = CliRunner()
+
+
+def _setup_config(config_dir: Path, projects: dict[str, dict] | None = None) -> ConfigStore:
+    """Set up a ConfigStore with given projects for CLI encrypt tests."""
+    store = ConfigStore(config_dir=config_dir)
+    if projects:
+        for alias, info in projects.items():
+            store.add_project(
+                alias,
+                ProjectConfig(
+                    stack_url=info.get("stack_url", "https://connection.keboola.com"),
+                    token=info["token"],
+                    project_name=info.get("project_name", alias),
+                    project_id=info.get("project_id", 1234),
+                ),
+            )
+    return store
+
+
+def _make_encrypt_mock() -> MagicMock:
+    """Create a fresh MagicMock for EncryptService."""
+    return MagicMock()
+
+
+class TestEncryptValuesJson:
+    """Tests for `kbagent encrypt values` command with JSON output."""
+
+    def test_encrypt_values_json_output(self, tmp_path: Path) -> None:
+        """encrypt values --json returns structured JSON with encrypted data."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.return_value = {
+            "#password": "KBC::ProjectSecure::enc-abc123",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    '{"#password": "secret123"}',
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["#password"] == "KBC::ProjectSecure::enc-abc123"
+        mock_enc.encrypt.assert_called_once_with(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            input_data={"#password": "secret123"},
+        )
+
+    def test_encrypt_values_inline_json(self, tmp_path: Path) -> None:
+        """Inline JSON input string is parsed and passed to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.return_value = {
+            "#key1": "KBC::ProjectSecure::enc-1",
+            "#key2": "KBC::ProjectSecure::enc-2",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    '{"#key1": "val1", "#key2": "val2"}',
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["#key1"] == "KBC::ProjectSecure::enc-1"
+        assert output["data"]["#key2"] == "KBC::ProjectSecure::enc-2"
+
+
+class TestEncryptValuesFileInput:
+    """Tests for @file and stdin input modes."""
+
+    def test_encrypt_values_file_input(self, tmp_path: Path) -> None:
+        """@file.json input reads from file and passes parsed JSON to service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        # Write a temp JSON file
+        input_file = tmp_path / "secrets.json"
+        input_file.write_text('{"#db_pass": "s3cret"}', encoding="utf-8")
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.return_value = {
+            "#db_pass": "KBC::ProjectSecure::enc-file",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    f"@{input_file}",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["#db_pass"] == "KBC::ProjectSecure::enc-file"
+        mock_enc.encrypt.assert_called_once_with(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            input_data={"#db_pass": "s3cret"},
+        )
+
+    def test_encrypt_values_stdin_input(self, tmp_path: Path) -> None:
+        """- (stdin) input reads JSON from stdin."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.return_value = {
+            "#token": "KBC::ProjectSecure::enc-stdin",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+            patch("keboola_agent_cli.commands.encrypt.sys") as mock_sys,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+            mock_sys.stdin.read.return_value = '{"#token": "abc"}'
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    "-",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["#token"] == "KBC::ProjectSecure::enc-stdin"
+
+
+class TestEncryptValuesOutputFile:
+    """Tests for --output-file option."""
+
+    def test_encrypt_values_output_file(self, tmp_path: Path) -> None:
+        """--output-file writes encrypted JSON with 0600 permissions."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        output_file = tmp_path / "encrypted.json"
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.return_value = {
+            "#password": "KBC::ProjectSecure::enc-output",
+        }
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    '{"#password": "secret"}',
+                    "--output-file",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+
+        # Verify file was written with correct content
+        assert output_file.exists()
+        file_data = json.loads(output_file.read_text(encoding="utf-8"))
+        assert file_data["#password"] == "KBC::ProjectSecure::enc-output"
+
+        # Verify file permissions are 0600
+        mode = output_file.stat().st_mode & 0o777
+        assert mode == 0o600
+
+
+class TestEncryptValuesErrors:
+    """Tests for error handling in encrypt values command."""
+
+    def test_encrypt_values_invalid_json(self, tmp_path: Path) -> None:
+        """Bad JSON input gives exit code 2 with INPUT_ERROR."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    "not-valid-json{",
+                ],
+            )
+
+        assert result.exit_code == 2
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "INPUT_ERROR"
+        mock_enc.encrypt.assert_not_called()
+
+    def test_encrypt_values_missing_project(self, tmp_path: Path) -> None:
+        """Missing --project gives exit code 2 (Typer required option)."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = _make_encrypt_mock()
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    '{"#x": "y"}',
+                ],
+            )
+
+        assert result.exit_code == 2
+
+    def test_encrypt_values_validation_error(self, tmp_path: Path) -> None:
+        """ConfigError from service gives exit code 5 with CONFIG_ERROR."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.side_effect = ConfigError("Key 'password' must start with '#'")
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    '{"password": "secret"}',
+                ],
+            )
+
+        assert result.exit_code == 5
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "CONFIG_ERROR"
+        assert "must start with '#'" in output["error"]["message"]
+
+    def test_encrypt_values_api_error(self, tmp_path: Path) -> None:
+        """KeboolaApiError gives appropriate exit code based on error code."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        mock_enc = _make_encrypt_mock()
+        mock_enc.encrypt.side_effect = KeboolaApiError(
+            message="Invalid token",
+            status_code=401,
+            error_code="INVALID_TOKEN",
+            retryable=False,
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.EncryptService") as MockEncService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockEncService.return_value = mock_enc
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "encrypt",
+                    "values",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--input",
+                    '{"#password": "secret"}',
+                ],
+            )
+
+        # INVALID_TOKEN -> exit code 3
+        assert result.exit_code == 3
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "INVALID_TOKEN"

--- a/tests/test_encrypt_service.py
+++ b/tests/test_encrypt_service.py
@@ -1,0 +1,193 @@
+"""Tests for EncryptService - encrypt secret values via Keboola Encryption API."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from helpers import setup_single_project
+from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.models import TokenVerifyResponse
+from keboola_agent_cli.services.encrypt_service import EncryptService
+
+
+def _make_encrypt_client(
+    encrypted_response: dict[str, str] | None = None,
+    project_id: int = 258,
+) -> MagicMock:
+    """Create a mock KeboolaClient with encrypt_values and verify_token."""
+    mock_client = MagicMock()
+    mock_client.verify_token.return_value = TokenVerifyResponse(
+        token_id="12345",
+        token_description="Test Token",
+        project_id=project_id,
+        project_name="Production",
+        owner_name="Production",
+    )
+    if encrypted_response is not None:
+        mock_client.encrypt_values.return_value = encrypted_response
+    return mock_client
+
+
+class TestEncryptSuccess:
+    """Tests for successful encryption scenarios."""
+
+    def test_encrypt_success(self, tmp_config_dir: Path) -> None:
+        """Valid input with #-prefixed keys returns encrypted values from API."""
+        encrypted = {
+            "#password": "KBC::ProjectSecure::enc-abc123",
+            "#token": "KBC::ProjectSecure::enc-def456",
+        }
+        mock_client = _make_encrypt_client(encrypted_response=encrypted)
+
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.encrypt(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            input_data={"#password": "secret123", "#token": "my-api-key"},
+        )
+
+        assert result == encrypted
+        mock_client.encrypt_values.assert_called_once_with(
+            project_id=258,
+            component_id="keboola.ex-db-snowflake",
+            data={"#password": "secret123", "#token": "my-api-key"},
+        )
+
+    def test_encrypt_passthrough_already_encrypted(self, tmp_config_dir: Path) -> None:
+        """Input with KBC:: values passes through unchanged, no API call made."""
+        mock_client = _make_encrypt_client()
+
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.encrypt(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            input_data={
+                "#password": "KBC::ProjectSecure::already-encrypted",
+                "#token": "KBC::ProjectSecure::also-encrypted",
+            },
+        )
+
+        assert result == {
+            "#password": "KBC::ProjectSecure::already-encrypted",
+            "#token": "KBC::ProjectSecure::also-encrypted",
+        }
+        mock_client.encrypt_values.assert_not_called()
+
+    def test_encrypt_mixed_new_and_encrypted(self, tmp_config_dir: Path) -> None:
+        """Mix of plaintext and already-encrypted values: only plaintext sent to API."""
+        api_response = {"#password": "KBC::ProjectSecure::enc-new"}
+        mock_client = _make_encrypt_client(encrypted_response=api_response)
+
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.encrypt(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            input_data={
+                "#password": "secret123",
+                "#token": "KBC::ProjectSecure::already-encrypted",
+            },
+        )
+
+        # Result merges API response with already-encrypted values
+        assert result == {
+            "#password": "KBC::ProjectSecure::enc-new",
+            "#token": "KBC::ProjectSecure::already-encrypted",
+        }
+        # Only the plaintext value was sent to the API
+        mock_client.encrypt_values.assert_called_once_with(
+            project_id=258,
+            component_id="keboola.ex-db-snowflake",
+            data={"#password": "secret123"},
+        )
+
+
+class TestEncryptValidation:
+    """Tests for input validation in EncryptService.encrypt()."""
+
+    def test_encrypt_validation_missing_hash(self, tmp_config_dir: Path) -> None:
+        """Key without # prefix raises ConfigError."""
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(config_store=store)
+
+        with pytest.raises(ConfigError, match="Key 'password' must start with '#'"):
+            svc.encrypt(
+                alias="prod",
+                component_id="keboola.ex-db-snowflake",
+                input_data={"password": "secret123"},
+            )
+
+    def test_encrypt_validation_non_string_value(self, tmp_config_dir: Path) -> None:
+        """Non-string value raises ConfigError."""
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(config_store=store)
+
+        with pytest.raises(ConfigError, match="Value for '#count' must be a string, got int"):
+            svc.encrypt(
+                alias="prod",
+                component_id="keboola.ex-db-snowflake",
+                input_data={"#count": 42},
+            )
+
+
+class TestEncryptEdgeCases:
+    """Tests for edge cases and error propagation."""
+
+    def test_encrypt_empty_after_filter(self, tmp_config_dir: Path) -> None:
+        """All values already encrypted means no API call, returns passthrough."""
+        mock_client = _make_encrypt_client()
+
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.encrypt(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            input_data={"#secret": "KBC::ProjectSecure::already"},
+        )
+
+        assert result == {"#secret": "KBC::ProjectSecure::already"}
+        mock_client.encrypt_values.assert_not_called()
+        # verify_token should also NOT be called since we never reach API
+        mock_client.verify_token.assert_not_called()
+
+    def test_encrypt_api_error_propagates(self, tmp_config_dir: Path) -> None:
+        """KeboolaApiError from client.encrypt_values propagates to caller."""
+        mock_client = _make_encrypt_client()
+        mock_client.encrypt_values.side_effect = KeboolaApiError(
+            message="Encryption service unavailable",
+            error_code="SERVICE_UNAVAILABLE",
+            status_code=503,
+            retryable=True,
+        )
+
+        store = setup_single_project(tmp_config_dir)
+        svc = EncryptService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        with pytest.raises(KeboolaApiError, match="Encryption service unavailable"):
+            svc.encrypt(
+                alias="prod",
+                component_id="keboola.ex-db-snowflake",
+                input_data={"#password": "secret"},
+            )

--- a/tests/test_sync_encrypt.py
+++ b/tests/test_sync_encrypt.py
@@ -1,0 +1,185 @@
+"""Tests for SyncService._encrypt_secrets_in_config security fix.
+
+Validates that encryption failures raise KeboolaApiError by default
+(preventing plaintext secrets from being pushed), and that the
+allow_plaintext_fallback flag preserves the old warning behavior.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from keboola_agent_cli.errors import KeboolaApiError
+from keboola_agent_cli.services.sync_service import SyncService
+
+
+def _make_config_with_secrets() -> dict:
+    """Return a configuration dict containing unencrypted #-prefixed secrets."""
+    return {
+        "parameters": {
+            "#apiToken": "my-secret-token",
+            "baseUrl": "https://api.example.com",
+            "nested": {
+                "#password": "super-secret",
+            },
+        },
+    }
+
+
+def _make_config_without_secrets() -> dict:
+    """Return a configuration dict with no secret values."""
+    return {
+        "parameters": {
+            "baseUrl": "https://api.example.com",
+            "limit": 100,
+        },
+    }
+
+
+class TestEncryptSecretsRaisesOnFailure:
+    """When allow_plaintext_fallback=False (default), encryption failure must raise."""
+
+    def test_encrypt_secrets_raises_on_failure(self) -> None:
+        """Encryption API error raises KeboolaApiError with ENCRYPTION_FAILED code."""
+        client = MagicMock()
+        client.encrypt_values.side_effect = RuntimeError("API unavailable")
+
+        config = _make_config_with_secrets()
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            SyncService._encrypt_secrets_in_config(
+                client=client,
+                project_id=258,
+                component_id="keboola.ex-http",
+                configuration=config,
+            )
+
+        assert exc_info.value.error_code == "ENCRYPTION_FAILED"
+        assert "keboola.ex-http" in str(exc_info.value)
+        assert "API unavailable" in str(exc_info.value)
+
+    def test_encrypt_secrets_raises_preserves_cause(self) -> None:
+        """The raised KeboolaApiError chains the original exception via __cause__."""
+        client = MagicMock()
+        original = ConnectionError("timeout")
+        client.encrypt_values.side_effect = original
+
+        config = _make_config_with_secrets()
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            SyncService._encrypt_secrets_in_config(
+                client=client,
+                project_id=258,
+                component_id="keboola.ex-http",
+                configuration=config,
+            )
+
+        assert exc_info.value.__cause__ is original
+
+
+class TestEncryptSecretsWarnsWithFallback:
+    """When allow_plaintext_fallback=True, encryption failure logs warning only."""
+
+    def test_encrypt_secrets_warns_on_failure_with_fallback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Fallback mode logs a warning and returns config with plaintext intact."""
+        client = MagicMock()
+        client.encrypt_values.side_effect = RuntimeError("API unavailable")
+
+        config = _make_config_with_secrets()
+        original_token = config["parameters"]["#apiToken"]
+
+        with caplog.at_level(logging.WARNING):
+            result = SyncService._encrypt_secrets_in_config(
+                client=client,
+                project_id=258,
+                component_id="keboola.ex-http",
+                configuration=config,
+                allow_plaintext_fallback=True,
+            )
+
+        # Config returned unchanged with plaintext values
+        assert result["parameters"]["#apiToken"] == original_token
+        assert result["parameters"]["nested"]["#password"] == "super-secret"
+
+        # Warning was logged
+        assert any("Failed to encrypt secrets" in record.message for record in caplog.records)
+        assert any("plaintext fallback allowed" in record.message for record in caplog.records)
+
+
+class TestEncryptSecretsSuccess:
+    """When encryption succeeds, behavior is identical regardless of fallback flag."""
+
+    def test_encrypt_secrets_success_default(self) -> None:
+        """Successful encryption applies encrypted values (default mode)."""
+        client = MagicMock()
+        # Keys match the format produced by _collect_secrets: #prefix.key
+        client.encrypt_values.return_value = {
+            "#parameters.#apiToken": "KBC::ProjectSecure::enc-aaa",
+            "#parameters.nested.#password": "KBC::ProjectSecure::enc-bbb",
+        }
+
+        config = _make_config_with_secrets()
+
+        result = SyncService._encrypt_secrets_in_config(
+            client=client,
+            project_id=258,
+            component_id="keboola.ex-http",
+            configuration=config,
+        )
+
+        assert result["parameters"]["#apiToken"] == "KBC::ProjectSecure::enc-aaa"
+        client.encrypt_values.assert_called_once()
+
+    def test_encrypt_secrets_success_with_fallback_flag(self) -> None:
+        """Successful encryption applies encrypted values (fallback mode)."""
+        client = MagicMock()
+        client.encrypt_values.return_value = {
+            "#parameters.#apiToken": "KBC::ProjectSecure::enc-aaa",
+            "#parameters.nested.#password": "KBC::ProjectSecure::enc-bbb",
+        }
+
+        config = _make_config_with_secrets()
+
+        result = SyncService._encrypt_secrets_in_config(
+            client=client,
+            project_id=258,
+            component_id="keboola.ex-http",
+            configuration=config,
+            allow_plaintext_fallback=True,
+        )
+
+        assert result["parameters"]["#apiToken"] == "KBC::ProjectSecure::enc-aaa"
+        client.encrypt_values.assert_called_once()
+
+    def test_encrypt_secrets_skips_when_no_project_id(self) -> None:
+        """When project_id is None, encryption is skipped entirely."""
+        client = MagicMock()
+        config = _make_config_with_secrets()
+
+        result = SyncService._encrypt_secrets_in_config(
+            client=client,
+            project_id=None,
+            component_id="keboola.ex-http",
+            configuration=config,
+        )
+
+        client.encrypt_values.assert_not_called()
+        assert result["parameters"]["#apiToken"] == "my-secret-token"
+
+    def test_encrypt_secrets_skips_when_no_secrets(self) -> None:
+        """When config has no #-prefixed keys, encrypt_values is never called."""
+        client = MagicMock()
+        config = _make_config_without_secrets()
+
+        result = SyncService._encrypt_secrets_in_config(
+            client=client,
+            project_id=258,
+            component_id="keboola.ex-http",
+            configuration=config,
+        )
+
+        client.encrypt_values.assert_not_called()
+        assert result["parameters"]["baseUrl"] == "https://api.example.com"


### PR DESCRIPTION
## Summary

Implements #116 (Parts A + B, skipping Part C per discussion).

- **New `kbagent encrypt values` command** -- exposes Keboola Encryption API as a standalone CLI primitive for MCP tool call workflows where ciphertext must exist before `update_config`/`create_config`
- **Security fix in `sync push`** -- `_encrypt_secrets_in_config()` now fails hard on Encryption API errors instead of silently pushing plaintext secrets

## Changes

### Part A -- `kbagent encrypt values`

| File | Change |
|---|---|
| `services/encrypt_service.py` | New service: validation, KBC:: passthrough, API call |
| `commands/encrypt.py` | New command: `--input` (JSON/`@file`/stdin), `--output-file` (0600) |
| `cli.py` | Wiring: encrypt_app + EncryptService |
| `permissions.py` | `"encrypt.values": "write"` |

### Part B -- Sync push fail-closed

| File | Change |
|---|---|
| `services/sync_service.py` | `_encrypt_secrets_in_config()` raises `KeboolaApiError` by default |
| `commands/sync.py` | New `--allow-plaintext-on-encrypt-failure` escape hatch flag |

### Documentation

- `context.py` -- encrypt section + sync push flag docs
- `CLAUDE.md` -- All CLI Commands updated
- `SKILL.md` -- regenerated via `make skill-gen`

### Part C -- Skipped

`encrypt_values()` signature stays as-is (project + component scope = `ComponentSecure`). Adding `config_id`/`branch_type` would break config cloning and branch merging.

## Test plan

- [x] 7 service tests (validation, passthrough, API errors)
- [x] 9 CLI tests (JSON/file/stdin input, output file, error codes)
- [x] 7 sync encrypt tests (fail-hard default, fallback flag, success paths)
- [x] `make check` passes (1378 tests, lint, format, SKILL.md freshness)

Closes #116