### PR TITLE
chore: bump version to 0.17.4

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.17.3"
+version = "0.17.4"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Version bump for release 0.17.4.

## What's in 0.17.4

- **feat: `kbagent encrypt values` command** (#116) -- encrypt secrets for MCP tool call workflows
- **fix: sync push fails on encryption error** (#116) -- no more silent plaintext fallback
- Full encryption workflow documentation and plugin SKILL updates

Huge thanks to @FrantisekVasa for the incredibly thorough issue writeup and extensive testing of the encryption workflow!