### PR TITLE
feat: auto-update on startup with version cache and re-exec

### DIFF
--- a/src/keboola_agent_cli/auto_update.py
+++ b/src/keboola_agent_cli/auto_update.py
@@ -1,0 +1,256 @@
+"""Auto-update module for kbagent CLI.
+
+Checks for updates on startup, downloads the new version, and re-execs
+the same command in the updated version (similar to Claude Code).
+
+All output goes to sys.stderr.write() since OutputFormatter is not yet
+initialized when this runs. The entire flow is wrapped in a blanket
+try/except so it NEVER crashes the CLI.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from importlib.metadata import distribution
+from pathlib import Path
+
+import platformdirs
+
+from . import __version__
+from .constants import (
+    AUTO_UPDATE_CHECK_INTERVAL,
+    ENV_AUTO_UPDATE,
+    ENV_SKIP_UPDATE,
+    KBAGENT_INSTALL_SOURCE,
+    VERSION_CACHE_FILENAME,
+    VERSION_CHECK_TIMEOUT,
+)
+from .services.version_service import _fetch_kbagent_latest_version, _is_up_to_date
+
+logger = logging.getLogger(__name__)
+
+
+def _get_cache_path() -> Path:
+    """Return path to the version cache file.
+
+    Uses the global config directory (~/.config/keboola-agent-cli/).
+    """
+    config_dir = Path(platformdirs.user_config_dir("keboola-agent-cli"))
+    return config_dir / VERSION_CACHE_FILENAME
+
+
+def _read_cache() -> dict | None:
+    """Read the version cache file.
+
+    Returns:
+        Parsed dict with 'last_check' and 'latest_version', or None
+        if the file is missing, unreadable, or corrupt.
+    """
+    cache_path = _get_cache_path()
+    try:
+        if not cache_path.is_file():
+            return None
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and "last_check" in data and "latest_version" in data:
+            return data
+        return None
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _write_cache(latest_version: str) -> None:
+    """Write the version cache file.
+
+    Args:
+        latest_version: The latest version string to cache.
+    """
+    cache_path = _get_cache_path()
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "last_check": time.time(),
+            "latest_version": latest_version,
+        }
+        cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass  # Non-critical; next run will re-fetch
+
+
+def _is_cache_fresh(cache: dict, ttl: int) -> bool:
+    """Check whether the cache is still within its TTL.
+
+    Args:
+        cache: Parsed cache dict with 'last_check' timestamp.
+        ttl: Maximum age in seconds.
+
+    Returns:
+        True if the cache is fresh, False if stale.
+    """
+    try:
+        return (time.time() - float(cache["last_check"])) < ttl
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def _is_dev_install() -> bool:
+    """Detect development (editable) installs.
+
+    Returns True if:
+    - __version__ is '0.0.0-dev' (PackageNotFoundError fallback), or
+    - The package was installed in editable mode (PEP 660 direct_url.json).
+    """
+    if __version__ == "0.0.0-dev":
+        return True
+
+    try:
+        dist = distribution("keboola-agent-cli")
+        direct_url = dist.read_text("direct_url.json")
+        if direct_url:
+            data = json.loads(direct_url)
+            # Editable installs have dir_info.editable = true
+            if data.get("dir_info", {}).get("editable", False):
+                return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _should_skip() -> bool:
+    """Determine whether the auto-update check should be skipped.
+
+    Skip conditions:
+    - KBAGENT_SKIP_UPDATE=1 (set by re-exec to prevent loops)
+    - KBAGENT_AUTO_UPDATE in {false, 0, no} (user opt-out)
+    - Development/editable install
+    - Current command is 'update' or 'version' (handled separately)
+    """
+    # Re-exec guard
+    if os.environ.get(ENV_SKIP_UPDATE) == "1":
+        return True
+
+    # User opt-out
+    auto_update_val = os.environ.get(ENV_AUTO_UPDATE, "").lower().strip()
+    if auto_update_val in ("false", "0", "no"):
+        return True
+
+    # Dev install
+    if _is_dev_install():
+        return True
+
+    # Skip for update/version commands (they handle versioning themselves)
+    argv = sys.argv
+    if len(argv) >= 2:
+        cmd = argv[1].lower()
+        if cmd in ("update", "version"):
+            return True
+
+    return False
+
+
+def _perform_update(latest_version: str) -> bool:
+    """Download and install the latest version.
+
+    Tries uv first, falls back to pip.
+
+    Args:
+        latest_version: The version being updated to (for logging).
+
+    Returns:
+        True if the update succeeded, False otherwise.
+    """
+    uv_path = shutil.which("uv")
+    if uv_path:
+        cmd = [uv_path, "tool", "install", "--upgrade", KBAGENT_INSTALL_SOURCE]
+    else:
+        pip_path = shutil.which("pip")
+        if pip_path is None:
+            return False
+        cmd = [pip_path, "install", "--upgrade", KBAGENT_INSTALL_SOURCE]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+    except OSError:
+        return False
+
+
+def _re_exec() -> None:
+    """Replace the current process with the updated kbagent binary.
+
+    Sets KBAGENT_SKIP_UPDATE=1 to prevent infinite re-exec loops.
+    Falls back to `python -m keboola_agent_cli` if the kbagent binary
+    is not found on PATH.
+    """
+    env = os.environ.copy()
+    env[ENV_SKIP_UPDATE] = "1"
+
+    kbagent_path = shutil.which("kbagent")
+    if kbagent_path:
+        os.execvpe("kbagent", sys.argv, env)
+    else:
+        # Fallback: run as python module
+        new_argv = [sys.executable, "-m", "keboola_agent_cli", *sys.argv[1:]]
+        os.execvpe(sys.executable, new_argv, env)
+
+
+def maybe_auto_update() -> None:
+    """Main entry point for the auto-update flow.
+
+    Called from cli.py at the very top of main(). Orchestrates:
+    1. Skip-condition checks
+    2. Cache lookup (avoid network call if TTL is fresh)
+    3. Fetch latest version from GitHub if cache is stale
+    4. Compare versions
+    5. Download update
+    6. Re-exec the same command with the new binary
+
+    This function NEVER raises. Any exception is caught and silently
+    logged so the CLI always proceeds normally.
+    """
+    try:
+        if _should_skip():
+            return
+
+        cache = _read_cache()
+        latest_version: str | None = None
+
+        if cache and _is_cache_fresh(cache, AUTO_UPDATE_CHECK_INTERVAL):
+            latest_version = cache.get("latest_version")
+        else:
+            latest_version = _fetch_kbagent_latest_version(timeout=VERSION_CHECK_TIMEOUT)
+            if latest_version:
+                _write_cache(latest_version)
+
+        if latest_version is None:
+            return
+
+        up_to_date = _is_up_to_date(__version__, latest_version)
+        if up_to_date is True or up_to_date is None:
+            return
+
+        # Update available
+        sys.stderr.write(f"Updating kbagent v{__version__} -> v{latest_version}...\n")
+
+        if not _perform_update(latest_version):
+            sys.stderr.write("Auto-update failed; continuing with current version.\n")
+            return
+
+        sys.stderr.write(f"Updated to v{latest_version}. Re-launching...\n")
+        _re_exec()
+
+        # If re-exec fails (shouldn't happen), continue with old version
+    except Exception:
+        # Blanket catch: auto-update must NEVER crash the CLI
+        logger.debug("Auto-update check failed", exc_info=True)

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -112,6 +112,10 @@ def main(
     ),
 ) -> None:
     """Global options applied to all commands."""
+    from .auto_update import maybe_auto_update
+
+    maybe_auto_update()
+
     # If no subcommand given, launch REPL on TTY or show help otherwise
     if ctx.invoked_subcommand is None:
         is_interactive = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -90,6 +90,12 @@ MCP_PYPI_URL: str = "https://pypi.org/pypi/keboola-mcp-server/json"
 KBAGENT_GITHUB_REPO: str = "padak/keboola_agent_cli"
 KBAGENT_INSTALL_SOURCE: str = "git+https://github.com/padak/keboola_agent_cli"
 
+# --- Auto-Update ---
+ENV_AUTO_UPDATE: str = "KBAGENT_AUTO_UPDATE"
+ENV_SKIP_UPDATE: str = "KBAGENT_SKIP_UPDATE"
+AUTO_UPDATE_CHECK_INTERVAL: int = 3600  # 1 hour TTL for version cache
+VERSION_CACHE_FILENAME: str = "version_cache.json"
+
 # --- AI Service ---
 AI_SERVICE_TIMEOUT: httpx.Timeout = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
 SECRET_PLACEHOLDER: str = "<YOUR_SECRET>"

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,0 +1,409 @@
+"""Tests for the auto-update module."""
+
+import json
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+from keboola_agent_cli.auto_update import (
+    _get_cache_path,
+    _is_cache_fresh,
+    _is_dev_install,
+    _perform_update,
+    _re_exec,
+    _read_cache,
+    _should_skip,
+    _write_cache,
+    maybe_auto_update,
+)
+from keboola_agent_cli.constants import ENV_AUTO_UPDATE, ENV_SKIP_UPDATE
+
+
+# ---------------------------------------------------------------------------
+# _should_skip
+# ---------------------------------------------------------------------------
+class TestShouldSkip:
+    """Tests for the _should_skip() function."""
+
+    def test_skip_when_skip_update_env_set(self):
+        with patch.dict(os.environ, {ENV_SKIP_UPDATE: "1"}):
+            assert _should_skip() is True
+
+    def test_skip_when_auto_update_false(self):
+        with patch.dict(os.environ, {ENV_AUTO_UPDATE: "false"}, clear=False):
+            assert _should_skip() is True
+
+    def test_skip_when_auto_update_zero(self):
+        with patch.dict(os.environ, {ENV_AUTO_UPDATE: "0"}, clear=False):
+            assert _should_skip() is True
+
+    def test_skip_when_auto_update_no(self):
+        with patch.dict(os.environ, {ENV_AUTO_UPDATE: "no"}, clear=False):
+            assert _should_skip() is True
+
+    def test_skip_when_auto_update_no_case_insensitive(self):
+        with patch.dict(os.environ, {ENV_AUTO_UPDATE: "NO"}, clear=False):
+            assert _should_skip() is True
+
+    @patch("keboola_agent_cli.auto_update._is_dev_install", return_value=True)
+    def test_skip_when_dev_install(self, _mock):
+        # Clear any conflicting env vars
+        env = {k: v for k, v in os.environ.items() if k not in (ENV_SKIP_UPDATE, ENV_AUTO_UPDATE)}
+        with patch.dict(os.environ, env, clear=True):
+            assert _should_skip() is True
+
+    @patch("keboola_agent_cli.auto_update._is_dev_install", return_value=False)
+    def test_skip_for_update_command(self, _mock):
+        env = {k: v for k, v in os.environ.items() if k not in (ENV_SKIP_UPDATE, ENV_AUTO_UPDATE)}
+        with patch.dict(os.environ, env, clear=True), patch("sys.argv", ["kbagent", "update"]):
+            assert _should_skip() is True
+
+    @patch("keboola_agent_cli.auto_update._is_dev_install", return_value=False)
+    def test_skip_for_version_command(self, _mock):
+        env = {k: v for k, v in os.environ.items() if k not in (ENV_SKIP_UPDATE, ENV_AUTO_UPDATE)}
+        with patch.dict(os.environ, env, clear=True), patch("sys.argv", ["kbagent", "version"]):
+            assert _should_skip() is True
+
+    @patch("keboola_agent_cli.auto_update._is_dev_install", return_value=False)
+    def test_no_skip_for_normal_command(self, _mock):
+        env = {k: v for k, v in os.environ.items() if k not in (ENV_SKIP_UPDATE, ENV_AUTO_UPDATE)}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.argv", ["kbagent", "config", "list"]),
+        ):
+            assert _should_skip() is False
+
+    @patch("keboola_agent_cli.auto_update._is_dev_install", return_value=False)
+    def test_no_skip_when_argv_empty(self, _mock):
+        """Edge case: sys.argv has no elements."""
+        env = {k: v for k, v in os.environ.items() if k not in (ENV_SKIP_UPDATE, ENV_AUTO_UPDATE)}
+        with patch.dict(os.environ, env, clear=True), patch("sys.argv", []):
+            assert _should_skip() is False
+
+
+# ---------------------------------------------------------------------------
+# _is_dev_install
+# ---------------------------------------------------------------------------
+class TestIsDevInstall:
+    """Tests for the _is_dev_install() function."""
+
+    def test_dev_version(self):
+        with patch("keboola_agent_cli.auto_update.__version__", "0.0.0-dev"):
+            assert _is_dev_install() is True
+
+    def test_editable_install(self):
+        """Simulate PEP 660 editable install via direct_url.json."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = json.dumps(
+            {"url": "file:///some/path", "dir_info": {"editable": True}}
+        )
+        with (
+            patch("keboola_agent_cli.auto_update.__version__", "1.0.0"),
+            patch("keboola_agent_cli.auto_update.distribution", return_value=mock_dist),
+        ):
+            assert _is_dev_install() is True
+
+    def test_normal_install(self):
+        """Non-editable, non-dev version should return False."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = json.dumps(
+            {"url": "https://github.com/padak/keboola_agent_cli"}
+        )
+        with (
+            patch("keboola_agent_cli.auto_update.__version__", "1.0.0"),
+            patch("keboola_agent_cli.auto_update.distribution", return_value=mock_dist),
+        ):
+            assert _is_dev_install() is False
+
+    def test_distribution_raises(self):
+        """If importlib.metadata fails, should not crash and return False."""
+        with (
+            patch("keboola_agent_cli.auto_update.__version__", "1.0.0"),
+            patch(
+                "keboola_agent_cli.auto_update.distribution",
+                side_effect=Exception("not found"),
+            ),
+        ):
+            assert _is_dev_install() is False
+
+
+# ---------------------------------------------------------------------------
+# Version cache
+# ---------------------------------------------------------------------------
+class TestVersionCache:
+    """Tests for _read_cache, _write_cache, and _is_cache_fresh."""
+
+    def test_read_missing_cache(self, tmp_path):
+        with patch(
+            "keboola_agent_cli.auto_update._get_cache_path",
+            return_value=tmp_path / "nonexistent.json",
+        ):
+            assert _read_cache() is None
+
+    def test_read_corrupt_cache(self, tmp_path):
+        cache_file = tmp_path / "version_cache.json"
+        cache_file.write_text("not valid json!!!", encoding="utf-8")
+        with patch("keboola_agent_cli.auto_update._get_cache_path", return_value=cache_file):
+            assert _read_cache() is None
+
+    def test_read_cache_missing_keys(self, tmp_path):
+        cache_file = tmp_path / "version_cache.json"
+        cache_file.write_text('{"foo": "bar"}', encoding="utf-8")
+        with patch("keboola_agent_cli.auto_update._get_cache_path", return_value=cache_file):
+            assert _read_cache() is None
+
+    def test_read_valid_cache(self, tmp_path):
+        cache_file = tmp_path / "version_cache.json"
+        payload = {"last_check": time.time(), "latest_version": "1.2.3"}
+        cache_file.write_text(json.dumps(payload), encoding="utf-8")
+        with patch("keboola_agent_cli.auto_update._get_cache_path", return_value=cache_file):
+            result = _read_cache()
+            assert result is not None
+            assert result["latest_version"] == "1.2.3"
+
+    def test_write_cache(self, tmp_path):
+        cache_file = tmp_path / "version_cache.json"
+        with patch("keboola_agent_cli.auto_update._get_cache_path", return_value=cache_file):
+            _write_cache("2.0.0")
+        data = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert data["latest_version"] == "2.0.0"
+        assert "last_check" in data
+
+    def test_write_cache_creates_dir(self, tmp_path):
+        cache_file = tmp_path / "subdir" / "nested" / "version_cache.json"
+        with patch("keboola_agent_cli.auto_update._get_cache_path", return_value=cache_file):
+            _write_cache("3.0.0")
+        assert cache_file.is_file()
+        data = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert data["latest_version"] == "3.0.0"
+
+    def test_cache_fresh_within_ttl(self):
+        cache = {"last_check": time.time() - 100, "latest_version": "1.0.0"}
+        assert _is_cache_fresh(cache, 3600) is True
+
+    def test_cache_stale_after_ttl(self):
+        cache = {"last_check": time.time() - 7200, "latest_version": "1.0.0"}
+        assert _is_cache_fresh(cache, 3600) is False
+
+    def test_cache_fresh_with_bad_data(self):
+        cache = {"last_check": "not a number", "latest_version": "1.0.0"}
+        assert _is_cache_fresh(cache, 3600) is False
+
+
+# ---------------------------------------------------------------------------
+# _perform_update
+# ---------------------------------------------------------------------------
+class TestPerformUpdate:
+    """Tests for the _perform_update() function."""
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_update_with_uv_success(self, mock_run, mock_which):
+        mock_which.return_value = "/usr/local/bin/uv"
+        mock_run.return_value = MagicMock(returncode=0)
+        assert _perform_update("2.0.0") is True
+        # Verify uv was called
+        call_args = mock_run.call_args
+        assert "uv" in call_args[0][0][0]
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_update_with_uv_failure(self, mock_run, mock_which):
+        mock_which.return_value = "/usr/local/bin/uv"
+        mock_run.return_value = MagicMock(returncode=1, stderr="error")
+        assert _perform_update("2.0.0") is False
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_update_pip_fallback(self, mock_run, mock_which):
+        # uv not found, pip found
+        mock_which.side_effect = lambda cmd: (
+            None if cmd == "uv" else "/usr/bin/pip" if cmd == "pip" else None
+        )
+        mock_run.return_value = MagicMock(returncode=0)
+        assert _perform_update("2.0.0") is True
+        call_args = mock_run.call_args
+        assert "pip" in call_args[0][0][0]
+
+    @patch("shutil.which")
+    def test_update_no_tools(self, mock_which):
+        mock_which.return_value = None
+        assert _perform_update("2.0.0") is False
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_update_timeout(self, mock_run, mock_which):
+        import subprocess as sp
+
+        mock_which.return_value = "/usr/local/bin/uv"
+        mock_run.side_effect = sp.TimeoutExpired(cmd="uv", timeout=120)
+        assert _perform_update("2.0.0") is False
+
+
+# ---------------------------------------------------------------------------
+# _re_exec
+# ---------------------------------------------------------------------------
+class TestReExec:
+    """Tests for the _re_exec() function."""
+
+    @patch("os.execvpe")
+    @patch("shutil.which", return_value="/usr/local/bin/kbagent")
+    def test_execvpe_called_with_skip_env(self, mock_which, mock_execvpe):
+        with patch("sys.argv", ["kbagent", "config", "list"]):
+            _re_exec()
+        mock_execvpe.assert_called_once()
+        args = mock_execvpe.call_args
+        assert args[0][0] == "kbagent"
+        assert args[0][1] == ["kbagent", "config", "list"]
+        env = args[0][2]
+        assert env[ENV_SKIP_UPDATE] == "1"
+
+    @patch("os.execvpe")
+    @patch("shutil.which", return_value=None)
+    def test_fallback_to_python_m(self, mock_which, mock_execvpe):
+        with (
+            patch("sys.argv", ["kbagent", "config", "list"]),
+            patch("sys.executable", "/usr/bin/python3"),
+        ):
+            _re_exec()
+        mock_execvpe.assert_called_once()
+        args = mock_execvpe.call_args
+        assert args[0][0] == "/usr/bin/python3"
+        assert args[0][1] == ["/usr/bin/python3", "-m", "keboola_agent_cli", "config", "list"]
+        env = args[0][2]
+        assert env[ENV_SKIP_UPDATE] == "1"
+
+
+# ---------------------------------------------------------------------------
+# maybe_auto_update (integration)
+# ---------------------------------------------------------------------------
+class TestMaybeAutoUpdate:
+    """Tests for the maybe_auto_update() orchestrator."""
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=True)
+    def test_skip_conditions_respected(self, mock_skip):
+        # Should return immediately without doing anything
+        maybe_auto_update()
+        mock_skip.assert_called_once()
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache")
+    @patch("keboola_agent_cli.auto_update._is_cache_fresh", return_value=True)
+    @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True)
+    def test_cache_fresh_no_fetch(self, mock_up_to_date, mock_fresh, mock_cache, mock_skip):
+        mock_cache.return_value = {"last_check": time.time(), "latest_version": "1.0.0"}
+        with patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version") as mock_fetch:
+            maybe_auto_update()
+            mock_fetch.assert_not_called()
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
+    @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="2.0.0")
+    @patch("keboola_agent_cli.auto_update._write_cache")
+    @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True)
+    def test_cache_stale_fetches(
+        self, mock_up_to_date, mock_write, mock_fetch, mock_cache, mock_skip
+    ):
+        maybe_auto_update()
+        mock_fetch.assert_called_once()
+        mock_write.assert_called_once_with("2.0.0")
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
+    @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="1.0.0")
+    @patch("keboola_agent_cli.auto_update._write_cache")
+    @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True)
+    @patch("keboola_agent_cli.auto_update._perform_update")
+    def test_up_to_date_no_update(
+        self, mock_update, mock_up_to_date, mock_write, mock_fetch, mock_cache, mock_skip
+    ):
+        maybe_auto_update()
+        mock_update.assert_not_called()
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
+    @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="2.0.0")
+    @patch("keboola_agent_cli.auto_update._write_cache")
+    @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=False)
+    @patch("keboola_agent_cli.auto_update._perform_update", return_value=True)
+    @patch("keboola_agent_cli.auto_update._re_exec")
+    @patch("keboola_agent_cli.auto_update.__version__", "1.0.0")
+    def test_newer_available_updates_and_reexec(
+        self,
+        mock_reexec,
+        mock_update,
+        mock_up_to_date,
+        mock_write,
+        mock_fetch,
+        mock_cache,
+        mock_skip,
+    ):
+        maybe_auto_update()
+        mock_update.assert_called_once_with("2.0.0")
+        mock_reexec.assert_called_once()
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
+    @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="2.0.0")
+    @patch("keboola_agent_cli.auto_update._write_cache")
+    @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=False)
+    @patch("keboola_agent_cli.auto_update._perform_update", return_value=False)
+    @patch("keboola_agent_cli.auto_update._re_exec")
+    @patch("keboola_agent_cli.auto_update.__version__", "1.0.0")
+    def test_update_failure_continues(
+        self,
+        mock_reexec,
+        mock_update,
+        mock_up_to_date,
+        mock_write,
+        mock_fetch,
+        mock_cache,
+        mock_skip,
+    ):
+        """If _perform_update returns False, re-exec should NOT be called."""
+        maybe_auto_update()
+        mock_update.assert_called_once()
+        mock_reexec.assert_not_called()
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
+    @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value=None)
+    @patch("keboola_agent_cli.auto_update._perform_update")
+    def test_fetch_failure_continues(self, mock_update, mock_fetch, mock_cache, mock_skip):
+        """If fetch returns None, should continue without updating."""
+        maybe_auto_update()
+        mock_update.assert_not_called()
+
+    @patch(
+        "keboola_agent_cli.auto_update._should_skip",
+        side_effect=RuntimeError("kaboom"),
+    )
+    def test_exception_never_crashes(self, mock_skip):
+        """Any exception inside maybe_auto_update must be swallowed."""
+        # Should NOT raise
+        maybe_auto_update()
+
+    @patch("keboola_agent_cli.auto_update._should_skip", return_value=False)
+    @patch("keboola_agent_cli.auto_update._read_cache")
+    @patch("keboola_agent_cli.auto_update._is_cache_fresh", return_value=True)
+    @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=None)
+    @patch("keboola_agent_cli.auto_update._perform_update")
+    def test_version_comparison_none_no_update(
+        self, mock_update, mock_up_to_date, mock_fresh, mock_cache, mock_skip
+    ):
+        """If _is_up_to_date returns None (can't compare), no update."""
+        mock_cache.return_value = {"last_check": time.time(), "latest_version": "1.0.0"}
+        maybe_auto_update()
+        mock_update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _get_cache_path
+# ---------------------------------------------------------------------------
+class TestGetCachePath:
+    """Tests for _get_cache_path()."""
+
+    def test_returns_path_with_filename(self):
+        path = _get_cache_path()
+        assert path.name == "version_cache.json"
+        assert "keboola-agent-cli" in str(path)


### PR DESCRIPTION
## Summary

- Add automatic self-update on every CLI invocation (Claude Code-style)
- Version cache with 1-hour TTL avoids network calls on every run
- After update, `os.execvpe()` re-launches the same command in the new version
- `KBAGENT_SKIP_UPDATE=1` env var prevents infinite re-exec loops
- Opt-out via `KBAGENT_AUTO_UPDATE=false`
- Skips for: dev/editable installs, `update`/`version` commands
- Blanket `try/except` ensures auto-update never crashes the CLI
- 40 new tests covering all functions and edge cases

## Test plan

- [ ] `make check` passes (lint + format + 1445 tests)
- [ ] `KBAGENT_AUTO_UPDATE=false kbagent version` -- no auto-update
- [ ] `KBAGENT_SKIP_UPDATE=1 kbagent version` -- no auto-update  
- [ ] Dev editable install: auto-update skipped automatically
- [ ] Offline: auto-update fails silently, CLI works normally