### PR TITLE
fix: register dev branches in manifest during sync pull/push/diff

### DIFF
--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -53,7 +53,7 @@ from ..sync.manifest import (
     load_manifest,
     save_manifest,
 )
-from ..sync.naming import config_path, config_row_path
+from ..sync.naming import config_path, config_row_path, sanitize_name
 from .base import BaseService
 
 logger = logging.getLogger(__name__)
@@ -232,6 +232,7 @@ class SyncService(BaseService):
         samples_data: dict[str, str] = {}  # table_id -> CSV string
         with client:
             components = client.list_components_with_configs(branch_id=branch_id)
+            self._ensure_branch_registered(manifest, branch_id, client)
 
             if not no_storage:
                 try:
@@ -295,6 +296,10 @@ class SyncService(BaseService):
         existing_file_hashes: dict[str, str] = {
             f"{c.component_id}/{c.id}": c.metadata.get("pull_hash", "")
             for c in manifest.configurations
+        }
+        # Track branch_id per config to detect branch switches
+        existing_branch_ids: dict[str, int] = {
+            f"{c.component_id}/{c.id}": c.branch_id for c in manifest.configurations
         }
 
         for component in components:
@@ -377,9 +382,19 @@ class SyncService(BaseService):
                     )
                 else:
                     # Check if remote actually changed since last pull.
-                    # If pull_config_hash matches, skip write (idempotent).
+                    # If pull_config_hash matches AND branch hasn't changed,
+                    # skip write (idempotent).  A branch switch means files
+                    # live in a different directory, so we must re-write.
                     old_cfg_hash = existing_config_hashes.get(lookup_key, "")
-                    remote_unchanged = not is_new and old_cfg_hash and old_cfg_hash == api_cfg_hash
+                    branch_switched = existing_branch_ids.get(lookup_key, branch_id or 0) != (
+                        branch_id or 0
+                    )
+                    remote_unchanged = (
+                        not is_new
+                        and not branch_switched
+                        and old_cfg_hash
+                        and old_cfg_hash == api_cfg_hash
+                    )
 
                     if remote_unchanged:
                         # Nothing changed -- reuse existing file hash
@@ -639,6 +654,7 @@ class SyncService(BaseService):
         client = self._client_factory(project.stack_url, project.token)
         with client:
             components = client.list_components_with_configs(branch_id=branch_id)
+            self._ensure_branch_registered(manifest, branch_id, client)
 
         # Build remote configs lookup: "{component_id}/{config_id}" -> API data
         remote_configs: dict[str, dict[str, Any]] = {}
@@ -865,9 +881,11 @@ class SyncService(BaseService):
         errors: list[dict[str, str]] = []
         pushed_details: list[dict[str, str]] = []
         manifest_dirty = False
-        branch_path = self._find_branch_path(manifest, branch_id)
 
         with client:
+            self._ensure_branch_registered(manifest, branch_id, client)
+            branch_path = self._find_branch_path(manifest, branch_id)
+
             for change in changes:
                 change_type = change["change_type"]
                 component_id = change["component_id"]
@@ -2012,6 +2030,51 @@ class SyncService(BaseService):
             logger.warning("Failed to parse %s", config_file)
             return None
 
+    def _ensure_branch_registered(
+        self,
+        manifest: Manifest,
+        branch_id: int | None,
+        client: Any,
+    ) -> str | None:
+        """Ensure *branch_id* has an entry in ``manifest.branches``.
+
+        If *branch_id* is ``None`` (production) or already present, this is
+        a no-op.  Otherwise the branch name is fetched from the API and a
+        new :class:`ManifestBranch` is appended.
+
+        Returns:
+            The new branch path if one was added, ``None`` otherwise.
+        """
+        if branch_id is None:
+            return None
+
+        # Already registered?
+        for branch in manifest.branches:
+            if branch.id == branch_id:
+                return None
+
+        # Fetch branch info from API to get a human-readable name
+        all_branches = client.list_dev_branches()
+        branch_name = ""
+        for b in all_branches:
+            if b.get("id") == branch_id:
+                branch_name = b.get("name", "")
+                break
+
+        # Generate filesystem-safe path
+        path = sanitize_name(branch_name) if branch_name else ""
+        if not path:
+            path = f"branch-{branch_id}"
+
+        # Handle path uniqueness -- avoid collisions with existing entries
+        existing_paths = {br.path for br in manifest.branches}
+        if path in existing_paths:
+            path = f"{path}-{branch_id}"
+
+        manifest.branches.append(ManifestBranch(id=branch_id, path=path))
+        logger.info("Registered dev branch %d as '%s' in manifest", branch_id, path)
+        return path
+
     def _find_branch_path(self, manifest: Manifest, branch_id: int | None) -> str:
         """Find the branch directory name for a given branch ID.
 
@@ -2024,7 +2087,11 @@ class SyncService(BaseService):
         for branch in manifest.branches:
             if branch.id == branch_id:
                 return branch.path
-        # Fallback to default branch
+        # Fallback to default branch -- should not happen after _ensure_branch_registered
+        logger.warning(
+            "Branch ID %s not found in manifest, falling back to default path",
+            branch_id,
+        )
         return manifest.branches[0].path if manifest.branches else "main"
 
     def _find_untracked_configs(

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -21,7 +21,7 @@ from keboola_agent_cli.constants import (
 from keboola_agent_cli.errors import ConfigError
 from keboola_agent_cli.models import TokenVerifyResponse
 from keboola_agent_cli.services.sync_service import SyncService
-from keboola_agent_cli.sync.manifest import load_manifest
+from keboola_agent_cli.sync.manifest import Manifest, load_manifest
 
 # ---------------------------------------------------------------------------
 # Sample API data
@@ -1509,3 +1509,137 @@ class TestBranchStatus:
         assert result["git_branching"] is True
         assert result["git_branch"] == "feature-x"
         assert result["linked"] is False
+
+
+# ===================================================================
+# _ensure_branch_registered tests
+# ===================================================================
+
+
+class TestEnsureBranchRegistered:
+    """Tests for SyncService._ensure_branch_registered()."""
+
+    @staticmethod
+    def _make_manifest(branches: list[dict] | None = None) -> Manifest:
+        """Build a minimal Manifest with given branches."""
+        from keboola_agent_cli.sync.manifest import (
+            ManifestBranch,
+            ManifestGitBranching,
+            ManifestNaming,
+            ManifestProject,
+        )
+
+        return Manifest(
+            version=MANIFEST_VERSION,
+            project=ManifestProject(id=258, api_host="connection.keboola.com"),
+            naming=ManifestNaming(),
+            git_branching=ManifestGitBranching(),
+            branches=[ManifestBranch(**b) for b in (branches or [{"id": 12345, "path": "main"}])],
+            configurations=[],
+        )
+
+    def test_noop_when_branch_id_is_none(self) -> None:
+        """No-op for production (branch_id=None)."""
+        store = MagicMock()
+        svc = SyncService(config_store=store)
+        manifest = self._make_manifest()
+        client = MagicMock()
+
+        result = svc._ensure_branch_registered(manifest, None, client)
+
+        assert result is None
+        client.list_dev_branches.assert_not_called()
+        assert len(manifest.branches) == 1
+
+    def test_noop_when_branch_already_registered(self) -> None:
+        """No-op when branch_id is already in manifest.branches."""
+        store = MagicMock()
+        svc = SyncService(config_store=store)
+        manifest = self._make_manifest(
+            branches=[
+                {"id": 12345, "path": "main"},
+                {"id": 99999, "path": "feature-x"},
+            ]
+        )
+        client = MagicMock()
+
+        result = svc._ensure_branch_registered(manifest, 99999, client)
+
+        assert result is None
+        client.list_dev_branches.assert_not_called()
+        assert len(manifest.branches) == 2
+
+    def test_adds_missing_branch(self) -> None:
+        """Adds a new branch entry when branch_id is missing from manifest."""
+        store = MagicMock()
+        svc = SyncService(config_store=store)
+        manifest = self._make_manifest()
+        client = MagicMock()
+        client.list_dev_branches.return_value = [
+            {"id": 12345, "name": "Main", "isDefault": True},
+            {"id": 99999, "name": "My Feature Branch", "isDefault": False},
+        ]
+
+        result = svc._ensure_branch_registered(manifest, 99999, client)
+
+        assert result == "my-feature-branch"
+        assert len(manifest.branches) == 2
+        new_branch = manifest.branches[1]
+        assert new_branch.id == 99999
+        assert new_branch.path == "my-feature-branch"
+
+    def test_handles_path_collision(self) -> None:
+        """Appends branch_id when sanitized name collides with existing path."""
+        store = MagicMock()
+        svc = SyncService(config_store=store)
+        # Pre-populate with a branch that has path "main" (which is the default)
+        manifest = self._make_manifest(
+            branches=[
+                {"id": 12345, "path": "main"},
+                {"id": 88888, "path": "feature-x"},
+            ]
+        )
+        client = MagicMock()
+        # New branch whose sanitized name would be "feature-x" -- collision
+        client.list_dev_branches.return_value = [
+            {"id": 77777, "name": "Feature X", "isDefault": False},
+        ]
+
+        result = svc._ensure_branch_registered(manifest, 77777, client)
+
+        assert result == "feature-x-77777"
+        assert len(manifest.branches) == 3
+        assert manifest.branches[2].path == "feature-x-77777"
+
+    def test_handles_empty_branch_name(self) -> None:
+        """Falls back to 'branch-{id}' when branch name is empty."""
+        store = MagicMock()
+        svc = SyncService(config_store=store)
+        manifest = self._make_manifest()
+        client = MagicMock()
+        client.list_dev_branches.return_value = [
+            {"id": 55555, "name": "", "isDefault": False},
+        ]
+
+        result = svc._ensure_branch_registered(manifest, 55555, client)
+
+        assert result == "branch-55555"
+        assert len(manifest.branches) == 2
+        assert manifest.branches[1].path == "branch-55555"
+
+    def test_handles_branch_not_found_in_api(self) -> None:
+        """Falls back to 'branch-{id}' when branch_id not in API response."""
+        store = MagicMock()
+        svc = SyncService(config_store=store)
+        manifest = self._make_manifest()
+        client = MagicMock()
+        # API returns branches but none match the requested ID
+        client.list_dev_branches.return_value = [
+            {"id": 12345, "name": "Main", "isDefault": True},
+        ]
+
+        result = svc._ensure_branch_registered(manifest, 44444, client)
+
+        assert result == "branch-44444"
+        assert len(manifest.branches) == 2
+        assert manifest.branches[1].path == "branch-44444"


### PR DESCRIPTION
## Summary

Fixes #121 — `sync pull` on a dev branch wrote data into `main/` without updating the manifest.

- **Root cause**: `_find_branch_path()` silently fell back to `manifest.branches[0].path` when the dev branch wasn't registered. `init_sync()` only seeds the default branch, and `pull()` never added new entries.
- **Fix**: New `_ensure_branch_registered()` method fetches branch metadata from the API and appends a `ManifestBranch` entry before any file I/O. Called in `pull()`, `push()`, and `diff()`.
- **Secondary fix**: Detect branch switches so `pull` re-writes files into the correct directory even when config hashes haven't changed (dev branch is a copy of main, so hashes match but the target directory is different).

## Changes
- `sync_service.py`: Add `_ensure_branch_registered()`, wire into `pull/push/diff`, add `branch_switched` detection, add warning log in `_find_branch_path()` fallback
- `test_sync_service.py`: 6 new tests for `_ensure_branch_registered` (no-op cases, normal add, path collision, empty name, API miss)

## Test plan
- [x] `make check` passes (1451 tests, lint, format)
- [x] Live API test: pull default → switch to dev branch → pull again → files in separate directory, manifest has both branches
- [x] Verified `_find_branch_path()` now resolves correctly for registered dev branches