### PR TITLE
docs: update plugin docs for v0.18.0, remove sync BETA label

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/branch-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/branch-workflow.md
@@ -40,3 +40,4 @@ kbagent --json branch merge --project ALIAS
 - **MCP tools respect active branch**: tool calls automatically use the active branch without extra flags.
 - **Config commands respect active branch**: `config list`, `config detail`, and `config search` auto-scope to the active branch. Use `--branch ID` to override.
 - **Workspaces respect active branch**: `workspace create` and `workspace delete` operate in the active branch context.
+- **Sync respects active branch**: `sync pull` writes dev branch configs into a separate directory (e.g. `fix-etl/` instead of `main/`). `sync diff` and `sync push` also auto-scope to the active branch. See [sync-workflow.md](sync-workflow.md) for details.

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -231,6 +231,31 @@ numeric postfix (`"tmp.carts2"`). Keep the original name for the "source"
 table (typically the Setup/materialization code that creates the full copy).
 Update all references in the code that creates and uses the renamed table.
 
+## Auto-update
+
+kbagent automatically checks for updates on every invocation. When a newer version
+is available on PyPI, it installs the update and re-executes the same command
+seamlessly. This is transparent -- no user action required.
+
+- Opt-out: `KBAGENT_AUTO_UPDATE=false`
+- Version cache: checks PyPI at most once per hour
+- Skipped for: dev/editable installs, `update`/`version` commands
+- Never crashes the CLI -- update failures are silently ignored
+
+## Sync and dev branches
+
+When an active branch is set (`branch use --branch ID`), sync commands automatically
+scope to that branch:
+
+- `sync pull` writes configs into a **separate directory** named after the branch
+  (e.g. `fix-etl/` instead of `main/`)
+- `sync diff` and `sync push` read/write from the correct branch directory
+- The manifest tracks all branches in `manifest.branches[]`
+- Switching back to main (`branch reset`) makes sync target `main/` again
+
+This means you can have production and dev branch configs side by side on disk
+without them overwriting each other.
+
 ## Common mistakes
 
 - **Forgetting `--json`**: without it, output is human-formatted Rich text, not parseable

--- a/plugins/kbagent/skills/kbagent/references/sync-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/sync-workflow.md
@@ -73,7 +73,53 @@ Storage metadata is also pulled (read-only, not tracked in manifest):
 | `storage/tables/{bucket}/{table}.json` | Per-table schema, columns, row count, size |
 | `storage/samples/{bucket}/{table}/sample.csv` | Data samples (opt-in: `--with-samples`) |
 
-## Git-branching workflow (recommended)
+## Branch use workflow (simple dev branches)
+
+Use `branch use` to work with dev branches without git-branching setup.
+Each branch gets its own directory on disk.
+
+```bash
+# Pull production first
+kbagent sync pull --project prod --force
+
+# Create a dev branch (auto-activates)
+kbagent --json branch create --project prod --name "fix-etl"
+# -> Branch 'fix-etl' activated
+
+# Pull the dev branch -- configs go into a separate directory
+kbagent sync pull --project prod --force
+# -> Pulled 42 configurations into fix-etl/
+
+# Edit configs in fix-etl/, push changes
+kbagent sync push --project prod
+
+# When done, merge and switch back
+kbagent --json branch merge --project prod   # returns merge URL
+kbagent sync pull --project prod --force      # refresh main/
+```
+
+### How it works
+
+- `sync pull` detects the active branch and auto-registers it in `manifest.json`
+- Each dev branch gets a sanitized directory name (e.g. branch "My Feature" -> `my-feature/`)
+- The manifest tracks which branch each config belongs to
+- Switching branches (`branch use` / `branch reset`) changes where pull writes and push reads
+- `sync diff` and `sync push` also respect the active branch
+
+### Directory structure
+
+```
+project-root/
+  .keboola/manifest.json   # branches: [{id: 123, path: "main"}, {id: 456, path: "fix-etl"}]
+  main/                     # production configs
+    extractor/...
+    transformation/...
+  fix-etl/                  # dev branch configs (separate directory)
+    extractor/...
+    transformation/...
+```
+
+## Git-branching workflow (recommended for teams)
 
 Maps git branches to Keboola dev branches for safe parallel development.
 

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -334,6 +334,8 @@ Use `kbagent <command> --help` for full flag details and examples.
      KBC_MASTER_TOKEN_*       Per-project master token (e.g. KBC_MASTER_TOKEN_PROD)
      KBAGENT_CONFIG_DIR       Override config directory
      KBAGENT_MAX_PARALLEL_WORKERS  Max concurrent threads for multi-project ops (default 10, max 100)
+     KBAGENT_AUTO_UPDATE      Set to "false" to disable automatic update on startup
+     KBAGENT_MCP_TRANSPORT    MCP transport mode: "http" (default, persistent) or "stdio" (subprocess)
 
 8. Config resolution order:
      --config-dir flag > KBAGENT_CONFIG_DIR env > .kbagent/ in CWD/parents > ~/.config/keboola-agent-cli/

--- a/src/keboola_agent_cli/commands/sync.py
+++ b/src/keboola_agent_cli/commands/sync.py
@@ -12,7 +12,7 @@ import typer
 from ..errors import ConfigError, KeboolaApiError
 from ._helpers import check_cli_permission, get_formatter, get_service, map_error_to_exit_code
 
-sync_app = typer.Typer(help="(BETA) Sync project configurations with local filesystem")
+sync_app = typer.Typer(help="Sync project configurations with local filesystem")
 
 
 @sync_app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary

- Remove `(BETA)` label from `sync` command — sync is now stable
- Document `branch use` + sync workflow in `sync-workflow.md` (separate directories per dev branch)
- Add sync integration note to `branch-workflow.md`
- Document auto-update behavior and opt-out in `gotchas.md`
- Add `KBAGENT_AUTO_UPDATE` and `KBAGENT_MCP_TRANSPORT` env vars to `kbagent context`

## Test plan
- [x] `make check` passes (1451 tests)