### PR TITLE
feat: changelog command with auto-update integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-mcp sync test test-unit test-integration test-file lint lint-fix format format-check skill-check skill-gen version-sync version-check check clean hooks
+.PHONY: help install install-mcp sync test test-unit test-integration test-file lint lint-fix format format-check skill-check skill-gen version-sync version-check changelog changelog-check check clean hooks
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -64,12 +64,18 @@ version-check: ## Check plugin.json version matches pyproject.toml (fails if mis
 		exit 1; \
 	fi
 
+changelog: ## Generate changelog skeleton from GitHub releases
+	uv run python scripts/generate_changelog.py
+
+changelog-check: ## Check all releases have changelog entries
+	uv run python scripts/generate_changelog.py --check
+
 hooks: ## Install git pre-commit hook (lint + format on staged files)
 	cp scripts/pre-commit .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 	@echo "Pre-commit hook installed."
 
-check: lint format-check skill-check version-check test ## Run all checks (lint + format + skill + version + test)
+check: lint format-check skill-check version-check changelog-check test ## Run all checks (lint + format + skill + version + changelog + test)
 
 clean: ## Remove build artifacts and caches
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -47,6 +47,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Goal | Command |
 |------|---------|
 | Update kbagent to the latest version | `kbagent update` |
+| Show recent changelog (what changed in each version) | `kbagent changelog` |
 | List all operations with their risk category and current allowed/denied status | `kbagent permissions list` |
 | Show the current active permission policy | `kbagent permissions show` |
 | Set the permission policy (firewall rules) | `kbagent permissions set --mode MODE` |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -2,6 +2,14 @@
 
 All commands support `--json` for structured output. Multi-project flags (`--project`) can be repeated.
 
+## Setup & Info
+- `init [--from-global]` -- create local `.kbagent/` workspace in current directory
+- `doctor [--fix]` -- health check for CLI config and MCP server
+- `version` -- show version info and dependency update status
+- `update` -- self-update to latest version
+- `changelog [--limit N]` -- show recent changelog (default: last 5 versions). After auto-update, "What's new" is printed automatically. Manual trigger: `KBAGENT_UPDATED_FROM=0.17.0 kbagent version`
+- `context` -- print full CLI reference for AI agents
+
 ## Project Management
 - `project add --project NAME --url URL --token TOKEN` -- connect a project (token verified via API)
 - `project list` -- list all connected projects (tokens masked)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Generate changelog skeleton from GitHub releases.
+
+Fetches release notes from the GitHub API and prints a Python dict
+suitable for pasting into ``src/keboola_agent_cli/changelog.py``.
+
+Usage:
+    python scripts/generate_changelog.py          # print skeleton
+    python scripts/generate_changelog.py --check  # verify all releases have entries
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def _fetch_releases() -> list[dict]:
+    """Fetch all releases from GitHub via ``gh`` CLI."""
+    result = subprocess.run(
+        ["gh", "release", "list", "--limit", "50", "--json", "tagName"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tags = json.loads(result.stdout)
+
+    releases = []
+    for tag_entry in tags:
+        tag = tag_entry["tagName"]
+        view_result = subprocess.run(
+            ["gh", "release", "view", tag, "--json", "body,tagName"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        releases.append(json.loads(view_result.stdout))
+    return releases
+
+
+def _extract_summary(body: str) -> list[str]:
+    """Extract H2/H3 headings as summary lines from release body."""
+    lines = []
+    for line in body.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("## ") or stripped.startswith("### "):
+            heading = stripped.lstrip("#").strip()
+            # Skip generic headings
+            if heading.lower() in (
+                "what's new",
+                "what's changed",
+                "what changed",
+                "install / upgrade",
+                "upgrade",
+                "documentation",
+                "docs",
+                "tests",
+                "contributors",
+                "acknowledgements",
+                "thanks",
+                "related",
+            ):
+                continue
+            lines.append(heading)
+    return lines
+
+
+def _check_mode() -> None:
+    """Verify all GitHub releases have entries in changelog.py."""
+    from keboola_agent_cli.changelog import CHANGELOG
+
+    result = subprocess.run(
+        ["gh", "release", "list", "--limit", "50", "--json", "tagName"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tags = json.loads(result.stdout)
+
+    missing = []
+    for entry in tags:
+        version = entry["tagName"].lstrip("v")
+        if version not in CHANGELOG:
+            missing.append(version)
+
+    if missing:
+        print(f"Missing changelog entries for: {', '.join(missing)}")
+        sys.exit(1)
+    else:
+        print(f"All {len(tags)} releases have changelog entries.")
+
+
+def main() -> None:
+    if "--check" in sys.argv:
+        _check_mode()
+        return
+
+    releases = _fetch_releases()
+
+    print("CHANGELOG: dict[str, list[str]] = {")
+    for release in releases:
+        tag = release["tagName"]
+        version = tag.lstrip("v")
+        body = release.get("body", "")
+        summaries = _extract_summary(body)
+
+        if summaries:
+            entries = ", ".join(f'"{s}"' for s in summaries)
+            print(f'    "{version}": [{entries}],')
+        else:
+            print(f'    "{version}": ["TODO: add summary"],')
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/keboola_agent_cli/auto_update.py
+++ b/src/keboola_agent_cli/auto_update.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import platformdirs
 
 from . import __version__
+from .changelog import ENV_UPDATED_FROM, format_whats_new
 from .constants import (
     AUTO_UPDATE_CHECK_INTERVAL,
     ENV_AUTO_UPDATE,
@@ -205,6 +206,24 @@ def _re_exec() -> None:
         os.execvpe(sys.executable, new_argv, env)
 
 
+def show_post_update_changelog() -> None:
+    """Print 'What's new' after a successful auto-update re-exec.
+
+    Checks for ``KBAGENT_UPDATED_FROM`` env var (set before re-exec).
+    If present, prints the changelog for the current version and clears
+    the env var so it only fires once.
+    """
+    try:
+        old_version = os.environ.pop(ENV_UPDATED_FROM, "")
+        if not old_version:
+            return
+        msg = format_whats_new(old_version, __version__)
+        if msg:
+            sys.stderr.write(msg)
+    except Exception:
+        pass  # Never crash
+
+
 def maybe_auto_update() -> None:
     """Main entry point for the auto-update flow.
 
@@ -248,6 +267,8 @@ def maybe_auto_update() -> None:
             return
 
         sys.stderr.write(f"Updated to v{latest_version}. Re-launching...\n")
+        # Store old version so the re-exec'd process can show "What's new"
+        os.environ[ENV_UPDATED_FROM] = __version__
         _re_exec()
 
         # If re-exec fails (shouldn't happen), continue with old version

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -1,0 +1,176 @@
+"""Changelog data for kbagent releases.
+
+Maintained manually: one-line summaries per version.
+Run ``make changelog`` to scaffold new entries from GitHub releases.
+"""
+
+from __future__ import annotations
+
+# Ordered newest-first.  Each value is a list of brief one-line descriptions.
+CHANGELOG: dict[str, list[str]] = {
+    "0.18.0": [
+        "Auto-update on startup (opt-out: KBAGENT_AUTO_UPDATE=false)",
+        "Fix: sync pull dev-branch writes to correct directory (#121)",
+        "Sync command is now stable (BETA removed)",
+    ],
+    "0.17.5": [
+        "Fix: preserve multi-element script[] arrays in sync pull/push (#120)",
+    ],
+    "0.17.4": [
+        "Encrypt command for Keboola Encryption API (#117)",
+        "Fix: sync push no longer falls back to plaintext (#117)",
+    ],
+    "0.17.3": [
+        "Branch support (--branch) for all storage commands (#114)",
+    ],
+    "0.17.2": [
+        "Token refresh command: project refresh (#110)",
+        "MCP server resolution fix (#109)",
+    ],
+    "0.17.1": [
+        "Storage write operations: create-bucket, create-table, upload-table (#100)",
+    ],
+    "0.17.0": [
+        "Permissions firewall for AI agent sandboxing",
+        "Storage delete commands: delete-table, delete-bucket",
+    ],
+    "0.16.6": [
+        "Snowflake gotchas and SQL migration guidance in plugin docs",
+    ],
+    "0.16.5": [
+        "Fix: sync diff encrypted value false positives",
+    ],
+    "0.16.4": [
+        "Fix: sync push config creation and update reliability",
+    ],
+    "0.16.3": [
+        "Sync push: create, update, delete configs via API",
+        "3-way diff engine for conflict detection",
+    ],
+    "0.16.2": [
+        "Fix: sync status and diff edge cases",
+    ],
+    "0.16.1": [
+        "Fix: sync pull row handling and manifest consistency",
+    ],
+    "0.16.0": [
+        "Cross-project bucket sharing commands (#72)",
+        "Self-update command: kbagent update (#73)",
+    ],
+    "0.15.5": [
+        "Claude Code plugin with SKILL.md and reference docs",
+    ],
+    "0.15.4": [
+        "Component scaffold: kbagent config new (#68)",
+    ],
+    "0.15.3": [
+        "Fix: component list pagination",
+    ],
+    "0.15.2": [
+        "Component discovery: component list, component detail",
+    ],
+    "0.15.1": [
+        "Fix: retryable flag in error responses",
+        "Deduplicate HTTP clients via BaseHttpClient",
+    ],
+    "0.15.0": [
+        "Non-admin org setup via --project-ids",
+    ],
+    "0.14.0": [
+        "Org setup: bulk onboarding via kbagent org setup",
+    ],
+    "0.13.1": [
+        "Fix: workspace query error handling",
+    ],
+    "0.13.0": [
+        "Workspace query: run SQL on Snowflake workspaces",
+    ],
+    "0.12.1": [
+        "Fix: workspace create with read-only mode",
+    ],
+    "0.12.0": [
+        "Workspace lifecycle: create, list, delete, load tables",
+    ],
+    "0.11.0": [
+        "Branch lifecycle: create, use, reset, delete, merge",
+    ],
+    "0.10.0": [
+        "MCP tool integration: tool list, tool call",
+    ],
+    "0.9.0": [
+        "Cross-project data lineage: lineage show",
+    ],
+    "0.8.0": [
+        "Job history: job list, job detail",
+    ],
+    "0.7.6": [
+        "Fix: config search regex edge cases",
+    ],
+    "0.7.5": [
+        "Fix: config detail output formatting",
+    ],
+    "0.7.4": [
+        "Fix: multi-project parallel execution stability",
+    ],
+    "0.7.3": [
+        "Fix: config list component type filtering",
+    ],
+    "0.7.2": [
+        "Fix: project status connection timeout handling",
+    ],
+    "0.7.0": [
+        "Config search with regex and multi-project support",
+    ],
+    "0.6.7": [
+        "Fix: token masking for short tokens",
+    ],
+    "0.6.6": [
+        "Fix: JSON output consistency across commands",
+    ],
+    "0.6.5": [
+        "Fix: config list pagination for large projects",
+    ],
+    "0.6.0": [
+        "Config browsing: config list, config detail",
+    ],
+    "0.5.0": [
+        "Storage API: buckets, tables, bucket-detail",
+    ],
+    "0.4.1": [
+        "Fix: project edit validation",
+    ],
+    "0.4.0": [
+        "Project management: add, list, remove, edit, status",
+    ],
+}
+
+# Number of versions shown by default in ``kbagent changelog``
+DEFAULT_CHANGELOG_LIMIT = 5
+
+# Environment variable set by auto_update before re-exec
+ENV_UPDATED_FROM = "KBAGENT_UPDATED_FROM"
+
+
+def get_changelog(limit: int = DEFAULT_CHANGELOG_LIMIT) -> dict[str, list[str]]:
+    """Return the *limit* most recent changelog entries."""
+    items = list(CHANGELOG.items())[:limit]
+    return dict(items)
+
+
+def get_version_notes(version: str) -> list[str] | None:
+    """Return changelog entries for a specific version, or None."""
+    return CHANGELOG.get(version)
+
+
+def format_whats_new(old_version: str, new_version: str) -> str:
+    """Format a brief 'What's new' message for display after auto-update.
+
+    Shows entries for the new version only (not intermediate versions).
+    """
+    notes = get_version_notes(new_version)
+    if not notes:
+        return ""
+    lines = [f"  What's new in v{new_version}:"]
+    for note in notes:
+        lines.append(f"    - {note}")
+    return "\n".join(lines) + "\n"

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import typer
 
 from .commands.branch import branch_app
+from .commands.changelog import changelog_command
 from .commands.component import component_app
 from .commands.config import config_app
 from .commands.context import context_command
@@ -58,6 +59,7 @@ app.command("init", rich_help_panel=_SETUP)(init_command)
 app.command("doctor", rich_help_panel=_SETUP)(doctor_command)
 app.command("version", rich_help_panel=_SETUP)(version_command)
 app.command("update", rich_help_panel=_SETUP)(update_command)
+app.command("changelog", rich_help_panel=_SETUP)(changelog_command)
 app.command("context", rich_help_panel=_SETUP)(context_command)
 app.command("repl", rich_help_panel=_SETUP)(repl_command)
 app.add_typer(permissions_app, name="permissions", rich_help_panel=_SETUP)
@@ -112,9 +114,10 @@ def main(
     ),
 ) -> None:
     """Global options applied to all commands."""
-    from .auto_update import maybe_auto_update
+    from .auto_update import maybe_auto_update, show_post_update_changelog
 
     maybe_auto_update()
+    show_post_update_changelog()
 
     # If no subcommand given, launch REPL on TTY or show help otherwise
     if ctx.invoked_subcommand is None:
@@ -218,7 +221,7 @@ def main(
             pass  # Don't let warning check crash the CLI
 
     # Enforce permissions for top-level commands (sub-app commands use callbacks)
-    _top_level_commands = {"init", "doctor", "version", "update", "context", "repl"}
+    _top_level_commands = {"init", "doctor", "version", "update", "changelog", "context", "repl"}
     _is_help = "--help" in sys.argv or "-h" in sys.argv
     if ctx.invoked_subcommand in _top_level_commands and not _is_help:
         try:

--- a/src/keboola_agent_cli/commands/changelog.py
+++ b/src/keboola_agent_cli/commands/changelog.py
@@ -1,0 +1,43 @@
+"""Changelog command -- show recent version history.
+
+Thin CLI layer: reads changelog data and formats output.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.text import Text
+
+from ..changelog import DEFAULT_CHANGELOG_LIMIT, get_changelog
+from ._helpers import get_formatter
+
+
+def _format_changelog_human(console: Console, data: dict) -> None:
+    """Render changelog as styled terminal output."""
+    text = Text()
+    entries = data["entries"]
+    for i, (version, notes) in enumerate(entries.items()):
+        text.append(f"v{version}\n", style="bold cyan")
+        for note in notes:
+            text.append(f"  - {note}\n")
+        if i < len(entries) - 1:
+            text.append("\n")
+    console.print(text)
+
+
+def changelog_command(
+    ctx: typer.Context,
+    limit: int = typer.Option(
+        DEFAULT_CHANGELOG_LIMIT,
+        "--limit",
+        "-n",
+        help="Number of versions to show.",
+        min=1,
+        max=100,
+    ),
+) -> None:
+    """Show recent changelog (what changed in each version)."""
+    formatter = get_formatter(ctx)
+    entries = get_changelog(limit)
+    formatter.output({"entries": entries}, _format_changelog_human)

--- a/src/keboola_agent_cli/commands/changelog.py
+++ b/src/keboola_agent_cli/commands/changelog.py
@@ -37,7 +37,14 @@ def changelog_command(
         max=100,
     ),
 ) -> None:
-    """Show recent changelog (what changed in each version)."""
+    """Show recent changelog (what changed in each version).
+
+    After auto-update, kbagent automatically prints "What's new" for the
+    new version.  To see changes for a specific version manually, set
+    KBAGENT_UPDATED_FROM to any older version:
+
+        KBAGENT_UPDATED_FROM=0.17.0 kbagent version
+    """
     formatter = get_formatter(ctx)
     entries = get_changelog(limit)
     formatter.output({"entries": entries}, _format_changelog_human)

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -283,6 +283,9 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent update
     Self-update kbagent to latest version (via uv tool install --upgrade).
 
+  kbagent changelog [--limit N]
+    Show recent changelog (what changed in each version). Default: last 5 versions.
+
   kbagent permissions list [--category read|write|destructive|admin]
     List all operations with risk categories and current allowed/denied status.
 

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -338,6 +338,7 @@ Use `kbagent <command> --help` for full flag details and examples.
      KBAGENT_CONFIG_DIR       Override config directory
      KBAGENT_MAX_PARALLEL_WORKERS  Max concurrent threads for multi-project ops (default 10, max 100)
      KBAGENT_AUTO_UPDATE      Set to "false" to disable automatic update on startup
+     KBAGENT_UPDATED_FROM     Set to an older version to trigger "What's new" display on next run
      KBAGENT_MCP_TRANSPORT    MCP transport mode: "http" (default, persistent) or "stdio" (subprocess)
 
 8. Config resolution order:

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -89,6 +89,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     "doctor": "read",
     "version": "read",
     "update": "admin",
+    "changelog": "read",
     "context": "read",
     "repl": "read",
     # Permissions (always allowed -- listed for completeness)


### PR DESCRIPTION
## Summary

- New `kbagent changelog` command showing recent version history (human + JSON output)
- After auto-update, prints "What's new in vX.Y.Z" with changelog entries
- Changelog data for all 42 releases maintained in `changelog.py`
- `make changelog` scaffolds entries from GitHub releases
- `make changelog-check` verifies completeness (wired into `make check`)

## Usage

```
$ kbagent changelog
v0.18.0
  - Auto-update on startup (opt-out: KBAGENT_AUTO_UPDATE=false)
  - Fix: sync pull dev-branch writes to correct directory (#121)
  - Sync command is now stable (BETA removed)

v0.17.5
  - Fix: preserve multi-element script[] arrays in sync pull/push (#120)
...

$ kbagent changelog --limit 3    # show last 3 versions
$ kbagent --json changelog       # JSON output
```

After auto-update:
```
Updating kbagent v0.17.5 -> v0.18.0...
Updated to v0.18.0. Re-launching...
  What's new in v0.18.0:
    - Auto-update on startup (opt-out: KBAGENT_AUTO_UPDATE=false)
    - Fix: sync pull dev-branch writes to correct directory (#121)
    - Sync command is now stable (BETA removed)
```

## Test plan
- [x] `kbagent changelog` displays formatted output
- [x] `kbagent --json changelog` returns structured JSON
- [x] `kbagent changelog --limit 3` limits output
- [x] `KBAGENT_UPDATED_FROM=0.17.5 kbagent version` shows "What's new"
- [x] `make changelog-check` verifies all 42 releases have entries
- [x] 1448 tests pass, lint + format clean