### PR TITLE
fix: clear KBAGENT_UPDATED_FROM between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ def _force_stdio_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KBAGENT_MCP_TRANSPORT", "stdio")
 
 
+@pytest.fixture(autouse=True)
+def _clear_updated_from(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent auto-update changelog leaking between tests."""
+    monkeypatch.delenv("KBAGENT_UPDATED_FROM", raising=False)
+
+
 @pytest.fixture
 def tmp_config_dir(tmp_path: Path) -> Path:
     """Provide a temporary directory for configuration files."""


### PR DESCRIPTION
Auto-update test sets KBAGENT_UPDATED_FROM env var but _re_exec is mocked, so the var leaks to subsequent CLI tests causing JSON parsing failures. Add autouse fixture to clear it.