### PR TITLE
feat: add storage download-table command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ kbagent storage tables --project NAME [--bucket-id ID] [--branch ID]
 kbagent storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]
 kbagent storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]
 kbagent storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]
+kbagent storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]
 kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
 kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ kbagent job detail --project NAME --job-id ID
 kbagent storage buckets [--project NAME] [--branch ID]
 kbagent storage bucket-detail --project NAME --bucket-id ID [--branch ID]
 kbagent storage tables --project NAME [--bucket-id ID] [--branch ID]
+kbagent storage table-detail --project NAME --table-id ID [--branch ID]
 kbagent storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]
 kbagent storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]
 kbagent storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -75,6 +75,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Create a new storage bucket | `kbagent storage create-bucket --project PROJECT --stage STAGE --name NAME` |
 | Create a new storage table with typed columns | `kbagent storage create-table --project PROJECT --bucket-id BUCKET-ID --name NAME --column COLUMN` |
 | Upload a CSV file into a storage table | `kbagent storage upload-table --project PROJECT --table-id TABLE-ID --file FILE` |
+| Export a storage table to a local CSV file | `kbagent storage download-table --project PROJECT --table-id TABLE-ID` |
 | List storage tables from a project | `kbagent storage tables --project PROJECT` |
 | Delete one or more storage tables | `kbagent storage delete-table --project PROJECT --table-id TABLE-ID` |
 | Delete one or more storage buckets | `kbagent storage delete-bucket --project PROJECT --bucket-id BUCKET-ID` |

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -72,6 +72,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Show detailed information about a specific job | `kbagent job detail --project PROJECT --job-id JOB-ID` |
 | List storage buckets with sharing/linked bucket information | `kbagent storage buckets` |
 | Show detailed bucket info including Snowflake direct access paths | `kbagent storage bucket-detail --project PROJECT --bucket-id BUCKET-ID` |
+| Show detailed table info including columns and types | `kbagent storage table-detail --project PROJECT --table-id TABLE-ID` |
 | Create a new storage bucket | `kbagent storage create-bucket --project PROJECT --stage STAGE --name NAME` |
 | Create a new storage table with typed columns | `kbagent storage create-table --project PROJECT --bucket-id BUCKET-ID --name NAME --column COLUMN` |
 | Upload a CSV file into a storage table | `kbagent storage upload-table --project PROJECT --table-id TABLE-ID --file FILE` |

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -623,6 +623,25 @@ class KeboolaClient(BaseHttpClient):
         response = self._request("GET", f"{prefix}/buckets/{safe_id}")
         return response.json()
 
+    def get_table_detail(
+        self,
+        table_id: str,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Get detailed information about a storage table.
+
+        Args:
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Table detail dict including columns, metadata, bucket info.
+        """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        safe_id = quote(table_id, safe="")
+        response = self._request("GET", f"{prefix}/tables/{safe_id}")
+        return response.json()
+
     def list_tables(
         self,
         bucket_id: str | None = None,

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -22,6 +22,8 @@ from .constants import (
     DEFAULT_JOB_LIMIT,
     DEFAULT_JOBS_PER_CONFIG,
     DEFAULT_TIMEOUT,
+    EXPORT_JOB_MAX_WAIT,
+    FILE_DOWNLOAD_TIMEOUT,
     FILE_UPLOAD_TIMEOUT,
     IMPORT_JOB_MAX_WAIT,
     QUERY_JOB_MAX_WAIT,
@@ -1103,6 +1105,149 @@ class KeboolaClient(BaseHttpClient):
         )
         return response.text
 
+    def export_table_async(
+        self,
+        table_id: str,
+        columns: list[str] | None = None,
+        limit: int | None = None,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Start an async table export and wait for completion.
+
+        Args:
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+            columns: Optional list of column names to export.
+            limit: Optional max number of rows to export.
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Completed export job dict (results contain file info).
+        """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        safe_id = quote(table_id, safe="")
+        params: dict[str, Any] = {}
+        if columns:
+            params["columns"] = ",".join(columns)
+        if limit is not None:
+            params["limit"] = str(limit)
+        response = self._request(
+            "POST",
+            f"{prefix}/tables/{safe_id}/export-async",
+            data=params,
+        )
+        return self._wait_for_storage_job(response.json(), max_wait=EXPORT_JOB_MAX_WAIT)
+
+    def get_file_info(self, file_id: int) -> dict[str, Any]:
+        """Get file metadata including download URL.
+
+        Args:
+            file_id: Storage file ID (from export job results).
+
+        Returns:
+            File resource dict with 'url', 'isSliced', 'sizeBytes', etc.
+        """
+        response = self._request(
+            "GET",
+            f"/v2/storage/files/{file_id}",
+            params={"federationToken": "1"},
+        )
+        return response.json()
+
+    def download_sliced_file(self, file_detail: dict[str, Any], output_path: str) -> int:
+        """Download a sliced file by fetching manifest and concatenating slices.
+
+        Handles S3 (SigV4 auth) and GCS (bearer token) providers.
+        Decompresses gzipped slices transparently.
+
+        The manifest `url` from file info is already a presigned URL (download
+        directly). Manifest entries have cloud-native URLs (s3://, gs://) that
+        need auth — we build HTTPS URLs from the s3Path/gcsPath credentials.
+
+        Args:
+            file_detail: Full file info dict from get_file_info()
+                (must include provider credentials from federationToken=1).
+            output_path: Local file path to write to.
+
+        Returns:
+            Number of bytes written.
+        """
+        import gzip
+        import json as json_mod
+
+        provider = file_detail.get("provider", "")
+        downloader = _CloudDownloader.create(file_detail)
+
+        # Step 1: Download the manifest (url is already presigned, no extra auth)
+        with httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http:
+            resp = http.get(file_detail["url"])
+            resp.raise_for_status()
+            manifest_data = resp.content
+
+        manifest = json_mod.loads(manifest_data)
+        entries = manifest.get("entries", [])
+        if not entries:
+            raise KeboolaApiError(
+                message="Sliced file manifest has no entries",
+                status_code=500,
+                error_code="EXPORT_EMPTY_MANIFEST",
+                retryable=False,
+            )
+
+        logger.info("Downloading %d slices (provider=%s)", len(entries), provider)
+
+        # Step 2: Resolve the base URL from cloud path info
+        base_url = downloader.resolve_base_url(file_detail)
+
+        # Step 3: Download and concatenate all slices
+        total = 0
+        with open(output_path, "wb") as fh:
+            for entry in entries:
+                entry_url = entry.get("url", "")
+                # Strip cloud prefix (s3://bucket/key/ or gs://bucket/key/)
+                # to get relative slice name, then build HTTPS URL
+                slice_url = downloader.resolve_slice_url(base_url, entry_url, file_detail)
+                raw = downloader.download_bytes(slice_url)
+                # Decompress if gzipped
+                if entry_url.split("?")[0].endswith(".gz"):
+                    raw = gzip.decompress(raw)
+                fh.write(raw)
+                total += len(raw)
+
+        return total
+
+    def download_file(self, url: str, output_path: str) -> int:
+        """Download a non-sliced file from a presigned URL.
+
+        Handles gzip decompression transparently.
+
+        Args:
+            url: Presigned download URL from file info.
+            output_path: Local file path to write to.
+
+        Returns:
+            Number of bytes written.
+        """
+        import gzip
+
+        with (
+            httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http,
+            http.stream("GET", url) as response,
+        ):
+            response.raise_for_status()
+            is_gzipped = url.rstrip("?").split("?")[0].endswith(".gz")
+            if is_gzipped:
+                compressed = b"".join(response.iter_bytes())
+                data = gzip.decompress(compressed)
+                Path(output_path).write_bytes(data)
+                return len(data)
+            else:
+                total = 0
+                with open(output_path, "wb") as fh:
+                    for chunk in response.iter_bytes():
+                        fh.write(chunk)
+                        total += len(chunk)
+                return total
+
     def list_jobs(
         self,
         component_id: str | None = None,
@@ -1519,3 +1664,220 @@ class KeboolaClient(BaseHttpClient):
             error_code="QUERY_JOB_TIMEOUT",
             retryable=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Cloud storage download helpers (S3 SigV4, GCS bearer, ABS signed URL)
+# ---------------------------------------------------------------------------
+
+
+class _CloudDownloader:
+    """Abstraction for downloading from cloud storage using Keboola file credentials.
+
+    Supports three cloud backends:
+    - AWS S3: Uses SigV4 signing with temporary credentials
+    - GCP GCS: Uses OAuth2 bearer token
+    - Azure ABS: Uses presigned/SAS URLs
+    """
+
+    def __init__(self, provider: str, auth_fn: Any) -> None:
+        self._provider = provider
+        self._auth_fn = auth_fn
+
+    @staticmethod
+    def create(file_detail: dict[str, Any]) -> "_CloudDownloader":
+        """Create a downloader from file detail response.
+
+        Args:
+            file_detail: Response from GET /v2/storage/files/{id}?federationToken=1.
+        """
+        provider = file_detail.get("provider", "")
+
+        if provider == "aws":
+            creds = file_detail.get("credentials", {})
+            region = file_detail.get("region", "us-east-1")
+            return _CloudDownloader(
+                provider="aws",
+                auth_fn=lambda url: _s3_signed_headers(url, creds, region),
+            )
+        elif provider == "gcp":
+            gcs_creds = file_detail.get("gcsCredentials", {})
+            token = gcs_creds.get("access_token", "")
+            token_type = gcs_creds.get("token_type", "Bearer")
+            return _CloudDownloader(
+                provider="gcp",
+                auth_fn=lambda _url: {"Authorization": f"{token_type} {token}"},
+            )
+        else:
+            # Azure / other: presigned URLs, no extra auth needed
+            return _CloudDownloader(provider=provider, auth_fn=lambda _url: {})
+
+    def resolve_base_url(self, file_detail: dict[str, Any]) -> str:
+        """Build the HTTPS base URL for downloading slices.
+
+        Returns:
+            Base HTTPS URL (e.g. "https://bucket.s3.region.amazonaws.com/key/prefix/").
+        """
+        if self._provider == "aws":
+            s3_path = file_detail.get("s3Path", {})
+            bucket = s3_path.get("bucket", "")
+            key = s3_path.get("key", "")
+            region = file_detail.get("region", "us-east-1")
+            return f"https://{bucket}.s3.{region}.amazonaws.com/{key}"
+        elif self._provider == "gcp":
+            gcs_path = file_detail.get("gcsPath", {})
+            bucket = gcs_path.get("bucket", "")
+            key = gcs_path.get("key", "")
+            return f"https://storage.googleapis.com/{bucket}/{key}"
+        else:
+            # Azure/other: entries should be full URLs
+            return ""
+
+    def resolve_slice_url(
+        self,
+        base_url: str,
+        entry_url: str,
+        file_detail: dict[str, Any],
+    ) -> str:
+        """Convert a manifest entry URL to a downloadable HTTPS URL.
+
+        Manifest entries use cloud-native URLs (s3://bucket/key/slice.gz).
+        This strips the cloud prefix and appends the relative slice path
+        to the HTTPS base URL.
+
+        Args:
+            base_url: HTTPS base URL from resolve_base_url().
+            entry_url: Raw entry URL from manifest (e.g. "s3://bucket/key/slice.gz").
+            file_detail: Full file detail dict.
+
+        Returns:
+            Full HTTPS URL for the slice.
+        """
+        if self._provider == "aws":
+            # entry_url: "s3://bucket/key/prefix/slice.csv.gz"
+            # base_url: "https://bucket.s3.region.amazonaws.com/key/prefix/"
+            s3_path = file_detail.get("s3Path", {})
+            bucket = s3_path.get("bucket", "")
+            key = s3_path.get("key", "")
+            prefix = f"s3://{bucket}/{key}"
+            relative = entry_url.removeprefix(prefix) if entry_url.startswith(prefix) else entry_url
+            return base_url + relative
+        elif self._provider == "gcp":
+            # entry_url: "gs://bucket/key/prefix/slice.csv.gz"
+            gcs_path = file_detail.get("gcsPath", {})
+            bucket = gcs_path.get("bucket", "")
+            key = gcs_path.get("key", "")
+            prefix = f"gs://{bucket}/{key}"
+            relative = entry_url.removeprefix(prefix) if entry_url.startswith(prefix) else entry_url
+            return base_url + relative
+        else:
+            # Azure/other: entry URLs should be full HTTPS URLs
+            return entry_url
+
+    def download_bytes(self, url: str) -> bytes:
+        """Download content from a cloud URL with appropriate authentication."""
+        headers = self._auth_fn(url)
+        with httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http:
+            response = http.get(url, headers=headers)
+            response.raise_for_status()
+            return response.content
+
+
+def _s3_signed_headers(url: str, creds: dict[str, str], region: str) -> dict[str, str]:
+    """Generate AWS SigV4 signed headers for an S3 GET request.
+
+    Implements minimal AWS Signature Version 4 signing using only stdlib
+    (hmac, hashlib, urllib.parse). No boto3/botocore dependency required.
+
+    Args:
+        url: Full S3 URL (https://bucket.s3.region.amazonaws.com/key).
+        creds: Dict with AccessKeyId, SecretAccessKey, SessionToken.
+        region: AWS region (e.g. "us-east-1").
+
+    Returns:
+        Dict of headers to include in the request.
+    """
+    import datetime
+    import hashlib
+    import hmac
+    from urllib.parse import unquote, urlparse
+
+    access_key = creds["AccessKeyId"]
+    secret_key = creds["SecretAccessKey"]
+    session_token = creds.get("SessionToken", "")
+
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    path = parsed.path or "/"
+    query = parsed.query or ""
+
+    now = datetime.datetime.now(datetime.UTC)
+    date_stamp = now.strftime("%Y%m%d")
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+
+    service = "s3"
+    scope = f"{date_stamp}/{region}/{service}/aws4_request"
+
+    # Canonical request
+    canonical_uri = quote(unquote(path), safe="/~")
+    # Sort query params
+    if query:
+        params_list = sorted(query.split("&"))
+        canonical_querystring = "&".join(params_list)
+    else:
+        canonical_querystring = ""
+
+    headers_to_sign: dict[str, str] = {"host": host, "x-amz-date": amz_date}
+    if session_token:
+        headers_to_sign["x-amz-security-token"] = session_token
+
+    signed_headers = ";".join(sorted(headers_to_sign.keys()))
+    canonical_headers = "".join(f"{k}:{v}\n" for k, v in sorted(headers_to_sign.items()))
+
+    payload_hash = hashlib.sha256(b"").hexdigest()  # empty body for GET
+
+    canonical_request = "\n".join(
+        [
+            "GET",
+            canonical_uri,
+            canonical_querystring,
+            canonical_headers,
+            signed_headers,
+            payload_hash,
+        ]
+    )
+
+    # String to sign
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            amz_date,
+            scope,
+            hashlib.sha256(canonical_request.encode("utf-8")).hexdigest(),
+        ]
+    )
+
+    # Signing key
+    def _hmac_sha256(key: bytes, msg: str) -> bytes:
+        return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+    k_date = _hmac_sha256(f"AWS4{secret_key}".encode(), date_stamp)
+    k_region = _hmac_sha256(k_date, region)
+    k_service = _hmac_sha256(k_region, service)
+    k_signing = _hmac_sha256(k_service, "aws4_request")
+
+    signature = hmac.new(k_signing, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    authorization = (
+        f"AWS4-HMAC-SHA256 Credential={access_key}/{scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+
+    result: dict[str, str] = {
+        "Authorization": authorization,
+        "x-amz-date": amz_date,
+        "x-amz-content-sha256": payload_hash,
+    }
+    if session_token:
+        result["x-amz-security-token"] = session_token
+    return result

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -195,6 +195,77 @@ def storage_bucket_detail(
                 )
 
 
+@storage_app.command("table-detail")
+def storage_table_detail(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    table_id: str = typer.Option(
+        ...,
+        "--table-id",
+        help="Table ID (e.g. 'in.c-my-bucket.my-table')",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """Show detailed table info including columns and types."""
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    try:
+        result = service.get_table_detail(
+            alias=project,
+            table_id=table_id,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        formatter.console.print(f"[bold]Table:[/bold] {result['table_id']}")
+        formatter.console.print(f"  Name: {result['display_name'] or result['name']}")
+        formatter.console.print(f"  Bucket: {result['bucket_id']}")
+        formatter.console.print(f"  Rows: {result['rows_count']:,}")
+        size_mb = result["data_size_bytes"] / (1024 * 1024)
+        formatter.console.print(f"  Size: {size_mb:.2f} MB")
+        if result["primary_key"]:
+            formatter.console.print(f"  Primary key: {', '.join(result['primary_key'])}")
+        if result["last_import_date"]:
+            formatter.console.print(f"  Last import: {result['last_import_date']}")
+
+        if result["column_details"]:
+            formatter.console.print()
+            from rich.table import Table
+
+            table = Table(title="Columns")
+            table.add_column("Name", style="bold cyan")
+            table.add_column("Type", style="dim")
+            table.add_column("Nullable", style="dim")
+
+            for col in result["column_details"]:
+                table.add_row(
+                    col["name"],
+                    col.get("type", ""),
+                    "yes" if col.get("nullable") else "",
+                )
+
+            formatter.console.print(table)
+
+
 @storage_app.command("create-bucket")
 def storage_create_bucket(
     ctx: typer.Context,

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -445,6 +445,89 @@ def storage_upload_table(
                 formatter.console.print(f"  [yellow]Warning:[/yellow] {w}")
 
 
+@storage_app.command("download-table")
+def storage_download_table(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    table_id: str = typer.Option(
+        ...,
+        "--table-id",
+        help="Table ID to export (e.g. 'in.c-my-bucket.my-table')",
+    ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        help="Output file path (default: {table_name}.csv)",
+    ),
+    columns: list[str] | None = typer.Option(
+        None,
+        "--columns",
+        help="Column names to export (repeat for multiple: --columns col1 --columns col2)",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        help="Max number of rows to export",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """Export a storage table to a local CSV file.
+
+    Downloads table data via the async export API. Handles gzip
+    decompression transparently. Use --columns to select specific
+    columns and --limit to cap row count.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    if not formatter.json_mode:
+        msg = f"Exporting [cyan]{table_id}[/cyan]"
+        if columns:
+            msg += f" (columns: {', '.join(columns)})"
+        if limit:
+            msg += f" (limit: {limit})"
+        msg += "..."
+        formatter.console.print(msg)
+
+    try:
+        result = service.download_table(
+            alias=project,
+            table_id=table_id,
+            output_path=output,
+            columns=columns,
+            limit=limit,
+            branch_id=effective_branch,
+        )
+    except ValueError as exc:
+        formatter.error(message=str(exc), error_code="INVALID_ARGUMENT")
+        raise typer.Exit(code=2) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        size_mb = result["file_size_bytes"] / (1024 * 1024)
+        formatter.console.print(
+            f"[bold green]Exported:[/bold green] {result['table_id']} -> {result['output_path']} "
+            f"({size_mb:.2f} MB)"
+        )
+
+
 @storage_app.command("tables")
 def storage_tables(
     ctx: typer.Context,

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -66,6 +66,14 @@ FILE_UPLOAD_TIMEOUT: httpx.Timeout = httpx.Timeout(
     connect=30.0, read=300.0, write=3600.0, pool=30.0
 )
 
+# --- File Download Timeout ---
+FILE_DOWNLOAD_TIMEOUT: httpx.Timeout = httpx.Timeout(
+    connect=30.0, read=3600.0, write=10.0, pool=30.0
+)
+
+# --- Export Job ---
+EXPORT_JOB_MAX_WAIT: float = 600.0  # 10 min for table export jobs (large tables)
+
 # --- Parallel Workers ---
 MAX_PARALLEL_WORKERS_LIMIT: int = 100
 

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -66,6 +66,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     "storage.buckets": "read",
     "storage.bucket-detail": "read",
     "storage.tables": "read",
+    "storage.download-table": "read",
     # Storage write
     "storage.create-bucket": "write",
     "storage.create-table": "write",

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -66,6 +66,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     "storage.buckets": "read",
     "storage.bucket-detail": "read",
     "storage.tables": "read",
+    "storage.table-detail": "read",
     "storage.download-table": "read",
     # Storage write
     "storage.create-bucket": "write",

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -208,6 +208,62 @@ class StorageService(BaseService):
 
         return result
 
+    def get_table_detail(
+        self,
+        alias: str,
+        table_id: str,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Get detailed info about a storage table including columns.
+
+        Args:
+            alias: Project alias.
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with table metadata, columns, and size info.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            table = client.get_table_detail(table_id, branch_id=branch_id)
+        finally:
+            client.close()
+
+        columns = table.get("columns", [])
+        column_metadata = table.get("columnMetadata", {})
+
+        column_details = []
+        for col in columns:
+            col_info: dict[str, Any] = {"name": col}
+            meta = column_metadata.get(col, [])
+            for m in meta:
+                if m.get("key") == "KBC.datatype.basetype":
+                    col_info["type"] = m.get("value", "")
+                elif m.get("key") == "KBC.datatype.nullable":
+                    col_info["nullable"] = m.get("value", "") == "1"
+            column_details.append(col_info)
+
+        return {
+            "project_alias": alias,
+            "table_id": table.get("id", table_id),
+            "name": table.get("name", ""),
+            "display_name": table.get("displayName", ""),
+            "bucket_id": table.get("bucket", {}).get("id", ""),
+            "columns": columns,
+            "column_details": column_details,
+            "primary_key": table.get("primaryKey", []),
+            "rows_count": table.get("rowsCount", 0),
+            "data_size_bytes": table.get("dataSizeBytes", 0),
+            "is_alias": table.get("isAlias", False),
+            "last_import_date": table.get("lastImportDate", ""),
+            "last_change_date": table.get("lastChangeDate", ""),
+            "created": table.get("created", ""),
+        }
+
     def list_tables(
         self,
         alias: str,

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -34,6 +34,26 @@ def _read_csv_header(file_path: str, delimiter: str = ",") -> list[str]:
     return columns
 
 
+def _prepend_csv_header(file_path: str, columns: list[str]) -> None:
+    """Prepend a CSV header row to an existing file.
+
+    Reads the file content, writes header + content back.
+    Uses CSV quoting for column names to match Keboola's RFC4180 format.
+    """
+    import io
+
+    writer_buf = io.StringIO()
+    writer = csv.writer(writer_buf, quoting=csv.QUOTE_ALL)
+    writer.writerow(columns)
+    header_line = writer_buf.getvalue()
+
+    p = Path(file_path)
+    original = p.read_bytes()
+    with p.open("wb") as fh:
+        fh.write(header_line.encode("utf-8"))
+        fh.write(original)
+
+
 class StorageService(BaseService):
     """Business logic for storage bucket and table operations.
 
@@ -451,6 +471,111 @@ class StorageService(BaseService):
             "warnings": results.get("warnings", []),
             "auto_created_bucket": auto_created_bucket,
             "auto_created_table": auto_created_table,
+        }
+
+    # ------------------------------------------------------------------
+    # Download / export operations
+    # ------------------------------------------------------------------
+
+    def download_table(
+        self,
+        alias: str,
+        table_id: str,
+        output_path: str | None = None,
+        columns: list[str] | None = None,
+        limit: int | None = None,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Export a storage table to a local CSV file.
+
+        Uses the async export flow: export-async -> poll job -> get file
+        info -> download from cloud URL. Handles gzip decompression
+        transparently.
+
+        Args:
+            alias: Project alias.
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+            output_path: Local file path to write to. If None, derives
+                from table name (e.g. "my-table.csv").
+            columns: Optional list of column names to export.
+            limit: Optional max number of rows to export.
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with export metadata: path, size, rows, table_id, etc.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        # Derive output filename from table ID if not specified
+        if not output_path:
+            table_name = table_id.rsplit(".", 1)[-1] if "." in table_id else table_id
+            output_path = f"{table_name}.csv"
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            # Step 0: Get table columns for CSV header
+            table_detail = client.list_tables(include="columns", branch_id=branch_id)
+            table_columns = columns  # Use explicit columns if specified
+            if not table_columns:
+                for t in table_detail:
+                    if t.get("id") == table_id:
+                        table_columns = t.get("columns", [])
+                        break
+
+            # Step 1: Start async export and wait for completion
+            job = client.export_table_async(
+                table_id=table_id,
+                columns=columns,
+                limit=limit,
+                branch_id=branch_id,
+            )
+
+            # Step 2: Get file info from job results
+            file_info = job.get("results", {}).get("file", {})
+            file_id = file_info.get("id")
+            if not file_id:
+                raise KeboolaApiError(
+                    message="Export job completed but no file ID in results",
+                    status_code=500,
+                    error_code="EXPORT_NO_FILE",
+                    retryable=False,
+                )
+
+            # Step 3: Get download URL
+            file_detail = client.get_file_info(file_id)
+            download_url = file_detail.get("url")
+            if not download_url:
+                raise KeboolaApiError(
+                    message=f"No download URL for file {file_id}",
+                    status_code=500,
+                    error_code="EXPORT_NO_URL",
+                    retryable=False,
+                )
+
+            # Step 4: Download the file
+            if file_detail.get("isSliced"):
+                bytes_written = client.download_sliced_file(file_detail, output_path)
+            else:
+                bytes_written = client.download_file(download_url, output_path)
+
+            # Step 5: Prepend CSV header row
+            if table_columns:
+                _prepend_csv_header(output_path, table_columns)
+                # Recalculate size after adding header
+                bytes_written = Path(output_path).stat().st_size
+        finally:
+            client.close()
+
+        return {
+            "project_alias": alias,
+            "table_id": table_id,
+            "output_path": str(Path(output_path).resolve()),
+            "file_size_bytes": bytes_written,
+            "columns": table_columns or [],
+            "limit": limit,
         }
 
     # ------------------------------------------------------------------

--- a/tests/test_storage_write.py
+++ b/tests/test_storage_write.py
@@ -1203,3 +1203,421 @@ class TestUploadTableBranch:
         assert result.exit_code == 0
         call_kwargs = svc.upload_table.call_args.kwargs
         assert call_kwargs["branch_id"] == 33
+
+
+# ---------------------------------------------------------------------------
+# Service tests: download_table
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadTableService:
+    """Tests for StorageService.download_table()."""
+
+    def test_success_full_export(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 42}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 42,
+            "url": "https://s3.example.com/data.csv",
+            "isSliced": False,
+        }
+        mock_client.list_tables.return_value = [
+            {"id": "in.c-b.users", "columns": ["id", "name", "email"]},
+        ]
+
+        out_file = tmp_path / "output.csv"
+
+        def _fake_download(url, path):
+            Path(path).write_text('"1","Alice","a@b.c"\n')
+            return 1024
+
+        mock_client.download_file.side_effect = _fake_download
+        service = _make_service(store, mock_client)
+
+        result = service.download_table(
+            alias="test",
+            table_id="in.c-b.users",
+            output_path=str(out_file),
+        )
+
+        assert result["table_id"] == "in.c-b.users"
+        assert result["output_path"] == str(out_file.resolve())
+        assert result["columns"] == ["id", "name", "email"]
+        # Header was prepended
+        content = out_file.read_text()
+        assert content.startswith('"id","name","email"\n')
+        mock_client.export_table_async.assert_called_once_with(
+            table_id="in.c-b.users",
+            columns=None,
+            limit=None,
+            branch_id=None,
+        )
+        mock_client.get_file_info.assert_called_once_with(42)
+        mock_client.close.assert_called_once()
+
+    def test_with_columns_and_limit(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 99}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 99,
+            "url": "https://s3.example.com/filtered.csv",
+            "isSliced": False,
+        }
+        out_file = tmp_path / "events.csv"
+
+        def _fake_download(url, path):
+            Path(path).write_text('"1","Alice"\n')
+            return 512
+
+        mock_client.download_file.side_effect = _fake_download
+        mock_client.list_tables.return_value = []
+        service = _make_service(store, mock_client)
+
+        result = service.download_table(
+            alias="test",
+            table_id="in.c-b.events",
+            output_path=str(out_file),
+            columns=["id", "name"],
+            limit=100,
+        )
+
+        assert result["columns"] == ["id", "name"]
+        assert result["limit"] == 100
+        # Check header was prepended
+        content = out_file.read_text()
+        assert content.startswith('"id","name"\n')
+        mock_client.export_table_async.assert_called_once_with(
+            table_id="in.c-b.events",
+            columns=["id", "name"],
+            limit=100,
+            branch_id=None,
+        )
+
+    def test_derives_filename_from_table_id(self, tmp_path: Path) -> None:
+        import os
+
+        os.chdir(tmp_path)
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 1}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 1,
+            "url": "https://s3.example.com/data.csv",
+            "isSliced": False,
+        }
+        mock_client.list_tables.return_value = []
+
+        def _fake_download(url, path):
+            Path(path).write_text('"data"\n')
+            return 256
+
+        mock_client.download_file.side_effect = _fake_download
+        service = _make_service(store, mock_client)
+
+        result = service.download_table(
+            alias="test",
+            table_id="in.c-my-bucket.my-table",
+        )
+
+        assert result["output_path"].endswith("my-table.csv")
+
+    def test_sliced_file_calls_download_sliced(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 55}},
+        }
+        file_detail = {
+            "id": 55,
+            "url": "https://s3.example.com/manifest",
+            "isSliced": True,
+            "provider": "aws",
+        }
+        mock_client.get_file_info.return_value = file_detail
+        mock_client.list_tables.return_value = [
+            {"id": "in.c-b.huge", "columns": ["a", "b"]},
+        ]
+        out_path = str(tmp_path / "out.csv")
+
+        def _fake_sliced_download(detail, path):
+            Path(path).write_text('"1","2"\n')
+            return 4096
+
+        mock_client.download_sliced_file.side_effect = _fake_sliced_download
+        service = _make_service(store, mock_client)
+
+        result = service.download_table(
+            alias="test",
+            table_id="in.c-b.huge",
+            output_path=out_path,
+        )
+
+        assert result["columns"] == ["a", "b"]
+        mock_client.download_sliced_file.assert_called_once_with(file_detail, out_path)
+        mock_client.close.assert_called_once()
+
+    def test_no_file_id_raises_error(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {},
+        }
+        mock_client.list_tables.return_value = []
+        service = _make_service(store, mock_client)
+
+        with pytest.raises(KeboolaApiError, match="no file ID"):
+            service.download_table(
+                alias="test",
+                table_id="in.c-b.t",
+                output_path=str(tmp_path / "out.csv"),
+            )
+
+        mock_client.close.assert_called_once()
+
+    def test_api_error_propagates(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.side_effect = KeboolaApiError(
+            "Table not found", status_code=404, error_code="NOT_FOUND"
+        )
+        service = _make_service(store, mock_client)
+
+        with pytest.raises(KeboolaApiError):
+            service.download_table(
+                alias="test",
+                table_id="in.c-b.missing",
+                output_path=str(tmp_path / "out.csv"),
+            )
+
+        mock_client.close.assert_called_once()
+
+    def test_with_branch_id(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 7}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 7,
+            "url": "https://s3.example.com/branch.csv",
+            "isSliced": False,
+        }
+        mock_client.list_tables.return_value = []
+
+        def _fake_download(url, path):
+            Path(path).write_text('"data"\n')
+            return 128
+
+        mock_client.download_file.side_effect = _fake_download
+        service = _make_service(store, mock_client)
+
+        service.download_table(
+            alias="test",
+            table_id="in.c-b.t",
+            output_path=str(tmp_path / "out.csv"),
+            branch_id=42,
+        )
+
+        mock_client.export_table_async.assert_called_once_with(
+            table_id="in.c-b.t",
+            columns=None,
+            limit=None,
+            branch_id=42,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI tests: download-table
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadTableCLI:
+    """CLI tests for `kbagent storage download-table`."""
+
+    def test_download_table_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.download_table.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-b.users",
+                "output_path": "/tmp/users.csv",
+                "file_size_bytes": 2048,
+                "columns": None,
+                "limit": None,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "download-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-b.users",
+                    "--output",
+                    "/tmp/users.csv",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["table_id"] == "in.c-b.users"
+        assert data["file_size_bytes"] == 2048
+        svc.download_table.assert_called_once_with(
+            alias="test",
+            table_id="in.c-b.users",
+            output_path="/tmp/users.csv",
+            columns=None,
+            limit=None,
+            branch_id=None,
+        )
+
+    def test_download_table_with_columns_and_limit(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.download_table.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-b.events",
+                "output_path": "/tmp/events.csv",
+                "file_size_bytes": 512,
+                "columns": ["id", "name"],
+                "limit": 50,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "download-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-b.events",
+                    "--output",
+                    "/tmp/events.csv",
+                    "--columns",
+                    "id",
+                    "--columns",
+                    "name",
+                    "--limit",
+                    "50",
+                ],
+            )
+        assert result.exit_code == 0
+        svc.download_table.assert_called_once_with(
+            alias="test",
+            table_id="in.c-b.events",
+            output_path="/tmp/events.csv",
+            columns=["id", "name"],
+            limit=50,
+            branch_id=None,
+        )
+
+    def test_download_table_api_error(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.download_table.side_effect = KeboolaApiError(
+                "Table not found", status_code=404, error_code="NOT_FOUND"
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "download-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-b.missing",
+                ],
+            )
+        assert result.exit_code == 1
+
+    def test_download_table_human_mode(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.download_table.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-b.users",
+                "output_path": "/tmp/users.csv",
+                "file_size_bytes": 1048576,
+                "columns": None,
+                "limit": None,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "storage",
+                    "download-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-b.users",
+                    "--output",
+                    "/tmp/users.csv",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Exported" in result.output
+
+    def test_download_table_with_branch(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.download_table.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-b.data",
+                "output_path": "/tmp/data.csv",
+                "file_size_bytes": 100,
+                "columns": None,
+                "limit": None,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "download-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-b.data",
+                    "--branch",
+                    "33",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.download_table.call_args.kwargs
+        assert call_kwargs["branch_id"] == 33


### PR DESCRIPTION
## Summary

- New `kbagent storage download-table` command that exports Storage table data to a local CSV file
- Uses async export API (`export-async` -> poll job -> download from cloud)
- Supports **sliced files** with cloud-native auth (AWS S3 SigV4 signing, GCS bearer token, Azure presigned URLs) - zero new dependencies
- Auto-prepends CSV header row from table metadata
- Options: `--columns` (filter columns), `--limit` (cap rows), `--output` (file path), `--branch` (dev branch)

Closes #130

## Test plan

- [ ] `kbagent storage download-table --project padak --table-id in.c-keboola-ex-slack-464093756.users --output /tmp/test.csv` -- full export
- [ ] `--columns name --columns profile_email --limit 5` -- filtered export  
- [ ] `--json` mode returns structured output with path, size, columns
- [ ] Default filename derived from table name when `--output` omitted
- [ ] `--branch` works with dev branches
- [ ] Error handling: invalid table ID, invalid columns