### PR TITLE
fix: add x-ms-blob-type header for Azure uploads

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -983,10 +983,14 @@ class KeboolaClient(BaseHttpClient):
                         response = http.post(url, files=form_fields)
                     success_codes = (200, 204)
                 else:
-                    # ABS or other signed URL: raw PUT
+                    # ABS (Azure Blob Storage) or other signed URL: raw PUT
                     with p.open("rb") as fh:
-                        response = http.put(url, content=fh)
-                    success_codes = (200,)
+                        response = http.put(
+                            url,
+                            content=fh,
+                            headers={"x-ms-blob-type": "BlockBlob"},
+                        )
+                    success_codes = (200, 201)
 
         if response.status_code not in success_codes:
             raise KeboolaApiError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1874,6 +1874,33 @@ class TestUploadToCloud:
         assert exc_info.value.status_code == 403
 
 
+class TestUploadToCloudAzure:
+    """Tests for _upload_to_cloud Azure Blob Storage path."""
+
+    def test_abs_put_includes_blob_type_header(self, httpx_mock, tmp_path) -> None:
+        """Azure PUT must include x-ms-blob-type: BlockBlob header."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b"id\n1\n")
+        abs_url = "https://kbcftp.blob.core.windows.net/exp-15/file.csv?sv=2024-05-04&sig=abc"
+        httpx_mock.add_response(url=abs_url, method="PUT", status_code=201)
+        upload_info = {"url": abs_url, "uploadParams": {}}
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            client._upload_to_cloud(upload_info, str(csv_file))
+
+        put_req = next(r for r in httpx_mock.get_requests() if r.method == "PUT")
+        assert put_req.headers.get("x-ms-blob-type") == "BlockBlob"
+
+    def test_abs_put_accepts_201(self, httpx_mock, tmp_path) -> None:
+        """Azure returns 201 Created on success — must not raise."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b"id\n1\n")
+        abs_url = "https://kbcftp.blob.core.windows.net/exp-15/file.csv?sv=2024-05-04&sig=xyz"
+        httpx_mock.add_response(url=abs_url, method="PUT", status_code=201)
+        upload_info = {"url": abs_url, "uploadParams": {}}
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            client._upload_to_cloud(upload_info, str(csv_file))  # should not raise
+
+
 class TestImportTableAsync:
     """Tests for KeboolaClient.import_table_async()."""
 


### PR DESCRIPTION
## Summary

- Azure Blob Storage PUT requires `x-ms-blob-type: BlockBlob` header -- without it the request fails with 400 `MissingRequiredHeader`
- Also accept HTTP 201 (Azure returns `Created`, not `200` like S3/GCS)

Closes #131

## Test plan

- [x] Unit tests: `TestUploadToCloudAzure` verifies header is present and 201 is accepted
- [ ] Manual test on Azure project (needs project with write-enabled SAS token)