### PR TITLE
fix: Azure upload uses absUploadParams with write-capable SAS

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -946,8 +946,10 @@ class KeboolaClient(BaseHttpClient):
             included as form fields first; the file field is appended last
             (S3 policy requires the file to be the final part).
 
-        ABS/other signed URL (``uploadParams`` empty/null):
-            Raw PUT of the file bytes directly to ``url``.
+        Azure stack (``absUploadParams`` present):
+            PUT to ABS container URL constructed from SASConnectionString.
+            The ``url`` field is read-only — upload must use the write-capable
+            SAS from ``absUploadParams.absCredentials.SASConnectionString``.
 
         Args:
             upload_info: Full response dict from prepare_file_upload().
@@ -956,6 +958,8 @@ class KeboolaClient(BaseHttpClient):
         p = Path(file_path)
 
         gcs_params = upload_info.get("gcsUploadParams")
+        abs_params = upload_info.get("absUploadParams")
+
         if gcs_params:
             # GCP: PUT via GCS JSON API with short-lived OAuth2 bearer token
             bucket = gcs_params["bucket"]
@@ -969,6 +973,16 @@ class KeboolaClient(BaseHttpClient):
                     headers={"Authorization": f"Bearer {access_token}"},
                 )
             success_codes = (200,)
+        elif abs_params:
+            # Azure Blob Storage: PUT with write-capable SAS from absUploadParams
+            upload_url = _build_abs_upload_url(abs_params)
+            with p.open("rb") as fh, httpx.Client(timeout=FILE_UPLOAD_TIMEOUT) as http:
+                response = http.put(
+                    upload_url,
+                    content=fh,
+                    headers={"x-ms-blob-type": "BlockBlob"},
+                )
+            success_codes = (200, 201)
         else:
             url = upload_info["url"]
             upload_params = upload_info.get("uploadParams") or {}
@@ -983,13 +997,9 @@ class KeboolaClient(BaseHttpClient):
                         response = http.post(url, files=form_fields)
                     success_codes = (200, 204)
                 else:
-                    # ABS (Azure Blob Storage) or other signed URL: raw PUT
+                    # Fallback: signed URL PUT (no extra auth needed)
                     with p.open("rb") as fh:
-                        response = http.put(
-                            url,
-                            content=fh,
-                            headers={"x-ms-blob-type": "BlockBlob"},
-                        )
+                        response = http.put(url, content=fh)
                     success_codes = (200, 201)
 
         if response.status_code not in success_codes:
@@ -1687,6 +1697,44 @@ class KeboolaClient(BaseHttpClient):
             error_code="QUERY_JOB_TIMEOUT",
             retryable=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Cloud storage upload helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_abs_upload_url(abs_params: dict[str, Any]) -> str:
+    """Build Azure Blob Storage upload URL from absUploadParams.
+
+    Parses SASConnectionString to extract BlobEndpoint and SharedAccessSignature,
+    then constructs: ``{BlobEndpoint}/{container}/{blobName}?{SAS}``.
+
+    The ``url`` field in the API response is read-only (``sp=rl``).
+    The write-capable SAS (``sp=rwl``) is only in ``absUploadParams``.
+
+    Args:
+        abs_params: The absUploadParams dict from files/prepare response.
+
+    Returns:
+        Full HTTPS URL with write-capable SAS token.
+    """
+    blob_name = abs_params["blobName"]
+    container = abs_params["container"]
+    sas_string = abs_params["absCredentials"]["SASConnectionString"]
+
+    # Format: "BlobEndpoint=https://...;SharedAccessSignature=sv=2017-11-09&..."
+    # partition("=") splits on first "=" only, preserving "=" in SAS values.
+    parts: dict[str, str] = {}
+    for segment in sas_string.split(";"):
+        key, sep, value = segment.partition("=")
+        if sep:
+            parts[key] = value
+
+    blob_endpoint = parts.get("BlobEndpoint", "").rstrip("/")
+    sas = parts.get("SharedAccessSignature", "")
+
+    return f"{blob_endpoint}/{container}/{blob_name}?{sas}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1874,16 +1874,50 @@ class TestUploadToCloud:
         assert exc_info.value.status_code == 403
 
 
+_ABS_SAS = (
+    "BlobEndpoint=https://kbcftp.blob.core.windows.net;"
+    "SharedAccessSignature=sv=2017-11-09&sr=c&sp=rwl&sig=abc123"
+)
+_ABS_UPLOAD_PARAMS = {
+    "blobName": "data.csv",
+    "accountName": "kbcftp",
+    "container": "exp-15-files-123",
+    "absCredentials": {"SASConnectionString": _ABS_SAS},
+}
+
+
 class TestUploadToCloudAzure:
     """Tests for _upload_to_cloud Azure Blob Storage path."""
+
+    def test_abs_put_uses_write_sas(self, httpx_mock, tmp_path) -> None:
+        """Azure upload constructs URL from absUploadParams (not read-only url)."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b"id\n1\n")
+        expected_url = (
+            "https://kbcftp.blob.core.windows.net/exp-15-files-123/data.csv"
+            "?sv=2017-11-09&sr=c&sp=rwl&sig=abc123"
+        )
+        httpx_mock.add_response(url=expected_url, method="PUT", status_code=201)
+        upload_info = {
+            "url": "https://kbcftp.blob.core.windows.net/read-only?sp=rl",
+            "absUploadParams": _ABS_UPLOAD_PARAMS,
+        }
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            client._upload_to_cloud(upload_info, str(csv_file))
+
+        put_req = next(r for r in httpx_mock.get_requests() if r.method == "PUT")
+        assert "sp=rwl" in str(put_req.url)
+        assert "read-only" not in str(put_req.url)
 
     def test_abs_put_includes_blob_type_header(self, httpx_mock, tmp_path) -> None:
         """Azure PUT must include x-ms-blob-type: BlockBlob header."""
         csv_file = tmp_path / "data.csv"
         csv_file.write_bytes(b"id\n1\n")
-        abs_url = "https://kbcftp.blob.core.windows.net/exp-15/file.csv?sv=2024-05-04&sig=abc"
-        httpx_mock.add_response(url=abs_url, method="PUT", status_code=201)
-        upload_info = {"url": abs_url, "uploadParams": {}}
+        httpx_mock.add_response(method="PUT", status_code=201)
+        upload_info = {
+            "url": "https://kbcftp.blob.core.windows.net/read-only?sp=rl",
+            "absUploadParams": _ABS_UPLOAD_PARAMS,
+        }
         with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
             client._upload_to_cloud(upload_info, str(csv_file))
 
@@ -1894,11 +1928,36 @@ class TestUploadToCloudAzure:
         """Azure returns 201 Created on success — must not raise."""
         csv_file = tmp_path / "data.csv"
         csv_file.write_bytes(b"id\n1\n")
-        abs_url = "https://kbcftp.blob.core.windows.net/exp-15/file.csv?sv=2024-05-04&sig=xyz"
-        httpx_mock.add_response(url=abs_url, method="PUT", status_code=201)
-        upload_info = {"url": abs_url, "uploadParams": {}}
+        httpx_mock.add_response(method="PUT", status_code=201)
+        upload_info = {
+            "url": "https://kbcftp.blob.core.windows.net/read-only?sp=rl",
+            "absUploadParams": _ABS_UPLOAD_PARAMS,
+        }
         with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
             client._upload_to_cloud(upload_info, str(csv_file))  # should not raise
+
+
+class TestBuildAbsUploadUrl:
+    """Tests for _build_abs_upload_url helper."""
+
+    def test_parses_connection_string(self) -> None:
+        from keboola_agent_cli.client import _build_abs_upload_url
+
+        params = {
+            "blobName": "test.csv",
+            "container": "exp-15-files-123",
+            "absCredentials": {
+                "SASConnectionString": (
+                    "BlobEndpoint=https://account.blob.core.windows.net;"
+                    "SharedAccessSignature=sv=2017-11-09&sr=c&sp=rwl&sig=abc%2Bxyz"
+                ),
+            },
+        }
+        url = _build_abs_upload_url(params)
+        assert url == (
+            "https://account.blob.core.windows.net/exp-15-files-123/test.csv"
+            "?sv=2017-11-09&sr=c&sp=rwl&sig=abc%2Bxyz"
+        )
 
 
 class TestImportTableAsync:


### PR DESCRIPTION
## Summary

- Azure `files/prepare` returns two SAS tokens: `url` (read-only `sp=rl`) and `absUploadParams.absCredentials.SASConnectionString` (write `sp=rwl`)
- Old code used `url` for PUT -> 403 `AuthorizationPermissionMismatch`
- Now parses `absUploadParams` to construct proper upload URL (matching Go SDK behavior)
- Also adds `x-ms-blob-type: BlockBlob` header and accepts HTTP 201

Closes #131

## Test plan

- [x] Unit tests: `TestUploadToCloudAzure` (write SAS, header, 201)
- [x] Unit test: `TestBuildAbsUploadUrl` (SASConnectionString parsing)
- [x] Manual test: `kbagent storage upload-table --project padak-azure` succeeds