### PR TITLE
fix: sync branch roundtrip issues

### DIFF
--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -601,11 +601,26 @@ class SyncService(BaseService):
                 )
                 continue
 
-            # Compare file hash against the hash stored at pull time
+            # Compare file hash against the hash stored at pull time.
+            # Check both _config.yml AND extracted code files (transform.sql etc.)
+            # to match the same logic used by diff().
             current_hash = self._file_hash(config_file)
             pull_hash = cfg.metadata.get("pull_hash", "")
+            config_unchanged = bool(pull_hash and current_hash == pull_hash)
 
-            if pull_hash and current_hash == pull_hash:
+            extras_unchanged = True
+            stored_extra = cfg.metadata.get("pull_extra_hashes", {})
+            for fname, stored_h in stored_extra.items():
+                fpath = config_dir / fname
+                if fpath.exists():
+                    if self._file_hash(fpath) != stored_h:
+                        extras_unchanged = False
+                        break
+                else:
+                    extras_unchanged = False
+                    break
+
+            if config_unchanged and extras_unchanged:
                 unchanged += 1
             else:
                 modified.append(
@@ -953,10 +968,23 @@ class SyncService(BaseService):
                                 new_cfg_hash = config_hash(local_data)
                             else:
                                 new_cfg_hash = ""
+                            # Refresh extra hashes for extracted code files
+                            new_extra: dict[str, str] = {}
+                            for fname in [
+                                "_description.md",
+                                "transform.sql",
+                                "transform.py",
+                                "code.py",
+                                "pyproject.toml",
+                            ]:
+                                fpath = config_dir / fname
+                                if fpath.exists():
+                                    new_extra[fname] = self._file_hash(fpath)
                             for cfg in manifest.configurations:
                                 if cfg.component_id == component_id and cfg.id == config_id:
                                     cfg.metadata["pull_hash"] = new_file_hash
                                     cfg.metadata["pull_config_hash"] = new_cfg_hash
+                                    cfg.metadata["pull_extra_hashes"] = new_extra
                                     break
                             manifest_dirty = True
                         updated += 1
@@ -2097,14 +2125,25 @@ class SyncService(BaseService):
     def _find_untracked_configs(
         self, project_root: Path, manifest: Manifest
     ) -> list[dict[str, str]]:
-        """Scan for _config.yml files that are not tracked in the manifest."""
+        """Scan for _config.yml files that are not tracked in the manifest.
+
+        Only scans branch directories that have at least one tracked
+        configuration. This prevents phantom "added" configs from
+        inactive/old branch directories left over from a previous pull.
+        """
         tracked_paths: set[str] = set()
+        active_branch_ids: set[int] = set()
         for cfg in manifest.configurations:
             branch_path = self._find_branch_path(manifest, cfg.branch_id)
             tracked_paths.add(str(project_root / branch_path / cfg.path))
+            active_branch_ids.add(cfg.branch_id)
 
         added: list[dict[str, str]] = []
         for branch in manifest.branches:
+            # Only scan branches that have tracked configs — skip inactive
+            # branch directories to avoid phantom "added" configs.
+            if branch.id not in active_branch_ids:
+                continue
             branch_dir = project_root / branch.path
             if not branch_dir.exists():
                 continue

--- a/src/keboola_agent_cli/sync/code_extraction.py
+++ b/src/keboola_agent_cli/sync/code_extraction.py
@@ -182,6 +182,7 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
     current_block: dict[str, Any] | None = None
     current_code: dict[str, Any] | None = None
     current_script_lines: list[str] = []
+    orphan_lines: list[str] = []
 
     for line in content.split("\n"):
         stripped = line.strip()
@@ -198,6 +199,7 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
             block_name = stripped[len("/* ===== BLOCK:") :].rstrip(" =*/").strip()
             current_block = {"name": block_name, "codes": []}
             blocks.append(current_block)
+            orphan_lines = []
             continue
 
         # Check for code marker
@@ -210,11 +212,19 @@ def _parse_sql_blocks(content: str) -> list[dict[str, Any]]:
 
             code_name = stripped[len("/* ===== CODE:") :].rstrip(" =*/").strip()
             current_code = {"name": code_name}
+            # Prepend any orphan lines collected between BLOCK and this CODE marker
+            if orphan_lines:
+                current_script_lines = list(orphan_lines)
+                orphan_lines = []
             continue
 
-        # Regular line - add to current code's script
+        # Regular line
         if current_code is not None:
             current_script_lines.append(line)
+        elif current_block is not None and stripped:
+            # Lines between BLOCK marker and first CODE marker — preserve them
+            # so they're not silently discarded on roundtrip.
+            orphan_lines.append(line)
 
     # Don't forget the last code block
     if current_code is not None and current_block is not None:


### PR DESCRIPTION
## Summary

Three fixes for sync branch roundtrip issues:

**Finding 1: `sync status` ignores code file changes**
- `status()` now checks `pull_extra_hashes` (transform.sql, code.py, etc.) alongside `_config.yml` hash, matching `diff()` behavior
- `push()` now refreshes `pull_extra_hashes` after pushing so next status/diff is consistent

**Finding 2: phantom "added" configs from old branch directory**
- `_find_untracked_configs` now only scans branch directories that have tracked configurations
- Prevents 36+ phantom "added" configs when switching between branches

**Finding 3: SQL parser drops content between BLOCK and CODE markers**
- `_parse_sql_blocks` now preserves orphan lines between a BLOCK marker and first CODE marker
- Content is prepended to the first code's script instead of being silently discarded

Closes #132

## Test plan

- [x] 1467 unit tests pass
- [x] Manual: edit `transform.sql` only -> `sync status` shows modified=1 (was 0 before fix)
- [x] Manual: `sync diff` also detects the same change (consistent)
- [x] Manual: create dev branch, pull -> old `main/` dir does NOT cause phantom added=37 (was 37 before fix)
- [x] Unit: `_parse_sql_blocks` preserves content between BLOCK and CODE markers