### PR TITLE
chore: bump version to 0.18.2

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -41,9 +41,11 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `storage buckets [--project NAME] [--branch ID]` -- list buckets with sharing/linked info (branch-aware)
 - `storage bucket-detail --project NAME --bucket-id ID [--branch ID]` -- bucket detail with Snowflake paths (branch-aware)
 - `storage tables --project NAME [--bucket-id ID] [--branch ID]` -- list tables, optionally by bucket (branch-aware)
+- `storage table-detail --project NAME --table-id ID [--branch ID]` -- table detail with columns, types, primary key, row count (branch-aware)
 - `storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]` -- create bucket (branch-aware)
 - `storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]` -- create typed table (branch-aware)
 - `storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]` -- upload CSV (branch-aware)
+- `storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]` -- export table to CSV (branch-aware)
 - `storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]` -- delete tables (branch-aware)
 - `storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete buckets (branch-aware)
 

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -15,6 +15,8 @@ Not all commands return data the same way. Key differences:
 | `workspace list` | `{"workspaces": [...], "errors": [...]}` |
 | `branch list` | `{"branches": [...]}` |
 | `config search` | `{"matches": [...], "errors": [...], "stats": {...}}` |
+| `storage table-detail` | `{"table_id": ..., "columns": [...], "column_details": [...]}` |
+| `storage download-table` | `{"table_id": ..., "output_path": ..., "file_size_bytes": N}` |
 
 Always check the actual response structure rather than assuming a pattern.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.18.1"
+version = "0.18.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,15 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.18.2": [
+        "New: storage download-table -- export table data to CSV (#130)",
+        "New: storage table-detail -- show columns, types, primary key (#130)",
+        "Fix: Azure upload uses absUploadParams with write-capable SAS (#131)",
+        "Fix: AWS upload uses federation token with SigV4 signing (#131)",
+        "Fix: sync status detects code file changes (transform.sql etc.) (#132)",
+        "Fix: sync status no longer shows phantom configs after branch switch (#132)",
+        "Fix: SQL parser preserves content between BLOCK and CODE markers (#132)",
+    ],
     "0.18.1": [
         "Changelog command: kbagent changelog (#126)",
         "What's new display after auto-update",

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -120,6 +120,9 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent storage tables --project NAME [--bucket-id BUCKET_ID] [--branch ID]
     List storage tables, optionally filtered by bucket. Branch-aware.
 
+  kbagent storage table-detail --project NAME --table-id TABLE_ID [--branch ID]
+    Show detailed table info: columns (with types if available), primary key, row count, size, last import date. Branch-aware.
+
   kbagent storage create-bucket --project NAME --stage STAGE --name BUCKET_NAME [--description D] [--backend B] [--branch ID]
     Create a new storage bucket. Stage must be "in" or "out". Branch-aware.
 
@@ -131,6 +134,11 @@ Use `kbagent <command> --help` for full flag details and examples.
     Upload CSV into a table. Auto-creates bucket and table if missing (columns inferred as STRING from CSV header).
     Use --no-auto-create to require the table to already exist.
     Full load by default; --incremental to append rows. Supports files up to 5 GB via async file-first upload flow. Branch-aware.
+
+  kbagent storage download-table --project NAME --table-id TABLE_ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]
+    Export table data to a local CSV file. Async export with streaming download.
+    Default filename: TABLE_NAME.csv. Use --columns to select columns (see table-detail for names).
+    Use --limit to cap row count. Handles sliced files and gzip decompression transparently. Branch-aware.
 
   kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
     Delete one or more tables. Batch: repeat --table-id. --dry-run to preview. Branch-aware.

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Version 0.18.2 release with:

**New features:**
- `storage download-table` -- export table data to CSV with sliced file support (#130)
- `storage table-detail` -- show columns, types, primary key (#130)

**Bug fixes:**
- Azure upload uses `absUploadParams` with write-capable SAS (#131)
- AWS upload uses federation token with SigV4 signing (#131)
- `sync status` detects code file changes (transform.sql etc.) (#132)
- `sync status` no longer shows phantom configs after branch switch (#132)
- SQL parser preserves content between BLOCK and CODE markers (#132)

**Docs:**
- Updated `kbagent context`, SKILL.md, commands-reference.md, gotchas.md