### PR TITLE
feat: add job run command

### DIFF
--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -70,6 +70,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Generate boilerplate configuration files for a Keboola component | `kbagent config new --component-id COMPONENT-ID` |
 | List jobs from connected projects | `kbagent job list` |
 | Show detailed information about a specific job | `kbagent job detail --project PROJECT --job-id JOB-ID` |
+| Run a job for a component configuration | `kbagent job run --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | List storage buckets with sharing/linked bucket information | `kbagent storage buckets` |
 | Show detailed bucket info including Snowflake direct access paths | `kbagent storage bucket-detail --project PROJECT --bucket-id BUCKET-ID` |
 | Show detailed table info including columns and types | `kbagent storage table-detail --project PROJECT --table-id TABLE-ID` |

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1382,6 +1382,7 @@ class KeboolaClient(BaseHttpClient):
         component_id: str,
         config_id: str,
         config_data: dict[str, Any] | None = None,
+        config_row_ids: list[str] | None = None,
         mode: str = "run",
     ) -> dict[str, Any]:
         """Create and run a Queue API job.
@@ -1390,6 +1391,8 @@ class KeboolaClient(BaseHttpClient):
             component_id: Component ID (e.g. keboola.sandboxes).
             config_id: Configuration ID.
             config_data: Optional runtime config data override.
+            config_row_ids: Optional list of config row IDs to run
+                (omit to run entire config).
             mode: Job mode (default: run).
 
         Returns:
@@ -1402,14 +1405,19 @@ class KeboolaClient(BaseHttpClient):
         }
         if config_data:
             body["configData"] = config_data
+        if config_row_ids:
+            body["configRowIds"] = config_row_ids
         response = self._queue_request("POST", "/jobs", json=body)
         return response.json()
 
-    def wait_for_queue_job(self, job_id: str) -> dict[str, Any]:
+    def wait_for_queue_job(
+        self, job_id: str, max_wait: float = STORAGE_JOB_MAX_WAIT
+    ) -> dict[str, Any]:
         """Poll a Queue API job until it reaches a terminal state.
 
         Args:
             job_id: The Queue job ID.
+            max_wait: Maximum seconds to wait (default: STORAGE_JOB_MAX_WAIT).
 
         Returns:
             Completed job dict.
@@ -1417,7 +1425,7 @@ class KeboolaClient(BaseHttpClient):
         Raises:
             KeboolaApiError: If the job fails or times out.
         """
-        deadline = time.monotonic() + STORAGE_JOB_MAX_WAIT
+        deadline = time.monotonic() + max_wait
         while time.monotonic() < deadline:
             job = self.get_job_detail(job_id)
             if job.get("isFinished"):
@@ -1438,7 +1446,7 @@ class KeboolaClient(BaseHttpClient):
             time.sleep(STORAGE_JOB_POLL_INTERVAL)
 
         raise KeboolaApiError(
-            message=f"Queue job {job_id} did not complete within {STORAGE_JOB_MAX_WAIT}s",
+            message=f"Queue job {job_id} did not complete within {max_wait}s",
             status_code=504,
             error_code="QUEUE_JOB_TIMEOUT",
             retryable=True,

--- a/src/keboola_agent_cli/commands/job.py
+++ b/src/keboola_agent_cli/commands/job.py
@@ -1,4 +1,4 @@
-"""Job browsing commands - list job history from Queue API.
+"""Job commands - list history, show detail, and run jobs via Queue API.
 
 Thin CLI layer: parses arguments, calls JobService, formats output.
 No business logic belongs here.
@@ -6,7 +6,7 @@ No business logic belongs here.
 
 import typer
 
-from ..constants import DEFAULT_JOB_LIMIT, MAX_JOB_LIMIT, VALID_STATUSES
+from ..constants import DEFAULT_JOB_LIMIT, DEFAULT_JOB_RUN_TIMEOUT, MAX_JOB_LIMIT, VALID_STATUSES
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_job_detail, format_jobs_table
 from ._helpers import (
@@ -17,7 +17,7 @@ from ._helpers import (
     map_error_to_exit_code,
 )
 
-job_app = typer.Typer(help="Browse job history")
+job_app = typer.Typer(help="Browse job history and run jobs")
 
 
 @job_app.callback(invoke_without_command=True)
@@ -126,3 +126,100 @@ def job_detail(
             retryable=exc.retryable,
         )
         raise typer.Exit(code=exit_code) from None
+
+
+@job_app.command("run")
+def job_run(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    component_id: str = typer.Option(
+        ...,
+        "--component-id",
+        help="Component ID (e.g. keboola.snowflake-transformation)",
+    ),
+    config_id: str = typer.Option(
+        ...,
+        "--config-id",
+        help="Configuration ID",
+    ),
+    row_id: list[str] | None = typer.Option(
+        None,
+        "--row-id",
+        help="Config row ID(s) to run (repeat for multiple; omit to run entire config)",
+    ),
+    wait: bool = typer.Option(
+        False,
+        "--wait",
+        help="Wait for job to finish (poll until terminal state)",
+    ),
+    timeout: float = typer.Option(
+        DEFAULT_JOB_RUN_TIMEOUT,
+        "--timeout",
+        help="Max seconds to wait when --wait is set",
+    ),
+) -> None:
+    """Run a job for a component configuration.
+
+    Creates a Queue API job and optionally waits for completion.
+    Use --row-id to run specific configuration rows.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "job_service")
+
+    if not formatter.json_mode:
+        msg = f"Running [cyan]{component_id}[/cyan] / [cyan]{config_id}[/cyan]"
+        if row_id:
+            msg += f" (rows: {', '.join(row_id)})"
+        if wait:
+            msg += f" [dim](waiting up to {timeout:.0f}s)[/dim]"
+        msg += "..."
+        formatter.console.print(msg)
+
+    try:
+        result = service.run_job(
+            alias=project,
+            component_id=component_id,
+            config_id=config_id,
+            config_row_ids=row_id,
+            wait=wait,
+            timeout=timeout,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(
+            message=exc.message,
+            error_code=exc.error_code,
+            project=project,
+            retryable=exc.retryable,
+        )
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        job_id = result.get("id", "?")
+        status = result.get("status", "unknown")
+        if status in ("success", "terminated"):
+            formatter.console.print(f"[bold green]Job {job_id}:[/bold green] {status}")
+        elif status == "error":
+            error_msg = ""
+            job_result = result.get("result", {})
+            if isinstance(job_result, dict):
+                error_msg = job_result.get("message", "")
+            formatter.console.print(f"[bold red]Job {job_id}:[/bold red] {status}")
+            if error_msg:
+                formatter.console.print(f"  Error: {error_msg}")
+            raise typer.Exit(code=1)
+        else:
+            formatter.console.print(f"[bold blue]Job {job_id}:[/bold blue] {status}")
+            if not wait:
+                formatter.console.print(
+                    "  Use --wait to poll until completion, "
+                    f"or: kbagent job detail --project {project} --job-id {job_id}"
+                )

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -108,6 +108,9 @@ VERSION_CACHE_FILENAME: str = "version_cache.json"
 AI_SERVICE_TIMEOUT: httpx.Timeout = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
 SECRET_PLACEHOLDER: str = "<YOUR_SECRET>"
 
+# --- Job Run ---
+DEFAULT_JOB_RUN_TIMEOUT: float = 300.0  # 5 min default for --wait polling
+
 # --- Permission Exit Code ---
 EXIT_PERMISSION_DENIED: int = 6
 

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -30,6 +30,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     # Job history
     "job.list": "read",
     "job.detail": "read",
+    "job.run": "write",
     # Lineage
     "lineage.show": "read",
     # Sharing

--- a/src/keboola_agent_cli/services/job_service.py
+++ b/src/keboola_agent_cli/services/job_service.py
@@ -147,3 +147,46 @@ class JobService(BaseService):
 
         detail["project_alias"] = alias
         return detail
+
+    def run_job(
+        self,
+        alias: str,
+        component_id: str,
+        config_id: str,
+        config_row_ids: list[str] | None = None,
+        wait: bool = False,
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        """Create and optionally wait for a Queue API job.
+
+        Args:
+            alias: Project alias.
+            component_id: Component ID to run.
+            config_id: Configuration ID to run.
+            config_row_ids: Optional row IDs (omit to run entire config).
+            wait: If True, poll until job finishes or timeout.
+            timeout: Max seconds to wait (only used when wait=True).
+
+        Returns:
+            Job dict with project_alias. If wait=True, returns the
+            completed job; otherwise returns the initial job response.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            job = client.create_job(
+                component_id=component_id,
+                config_id=config_id,
+                config_row_ids=config_row_ids,
+            )
+            job_id = str(job.get("id", ""))
+
+            if wait and job_id:
+                job = client.wait_for_queue_job(job_id, max_wait=timeout)
+        finally:
+            client.close()
+
+        job["project_alias"] = alias
+        return job


### PR DESCRIPTION
## Summary

- New `kbagent job run` command to create and optionally wait for Queue API jobs
- Supports `--row-id` (repeatable) for running specific config rows
- `--wait` polls until job completes; `--timeout` controls max wait (default 300s)
- `client.create_job()` now supports `config_row_ids` parameter
- `wait_for_queue_job()` now has parametrizable timeout

Closes #135

## Test plan

- [x] `job run` without --wait: creates job, shows ID and hint
- [x] `job run --wait`: polls until success (27s on Snowflake transformation)
- [x] `--json` mode returns full job detail with status, duration
- [x] 1467 unit tests pass
