### PR TITLE
feat: Storage Files commands (#134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,10 +247,10 @@ kbagent storage upload-table --project NAME --table-id ID --file PATH [--increme
 kbagent storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]
 kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
 kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
-kbagent storage file-list --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
+kbagent storage files --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
 kbagent storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]
 kbagent storage file-download --project NAME [--file-id ID | --tag TAG ...] [--output FILE]
-kbagent storage file-info --project NAME --file-id ID
+kbagent storage file-detail --project NAME --file-id ID
 kbagent storage file-delete --project NAME --file-id ID [--file-id ...] [--dry-run] [--yes]
 kbagent storage file-tag --project NAME --file-id ID [--add TAG ...] [--remove TAG ...]
 kbagent storage load-file --project NAME --file-id ID --table-id ID [--incremental] [--delimiter D] [--enclosure E] [--branch ID]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,14 @@ kbagent storage upload-table --project NAME --table-id ID --file PATH [--increme
 kbagent storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]
 kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
 kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
+kbagent storage file-list --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
+kbagent storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]
+kbagent storage file-download --project NAME [--file-id ID | --tag TAG ...] [--output FILE]
+kbagent storage file-info --project NAME --file-id ID
+kbagent storage file-delete --project NAME --file-id ID [--file-id ...] [--dry-run] [--yes]
+kbagent storage file-tag --project NAME --file-id ID [--add TAG ...] [--remove TAG ...]
+kbagent storage load-file --project NAME --file-id ID --table-id ID [--incremental] [--delimiter D] [--enclosure E] [--branch ID]
+kbagent storage unload-table --project NAME --table-id ID [--columns COL ...] [--limit N] [--tag TAG ...] [--download] [--output FILE] [--branch ID]
 
 kbagent lineage show [--project NAME]   # also works as just: kbagent lineage
 

--- a/docs/plan-134-storage-files.md
+++ b/docs/plan-134-storage-files.md
@@ -1,0 +1,365 @@
+# Plan: Storage File Commands (#134)
+
+## Goal
+
+Add direct Storage Files API commands to `kbagent`. Currently files are only
+used internally by `upload-table` / `download-table`. Users need standalone
+file operations for:
+
+- Uploading arbitrary files (ZIP, JSON, images, artifacts)
+- Downloading component output files
+- Listing and filtering files by tags
+- Managing file tags (add/remove)
+- Loading an uploaded file into a table (file → table import)
+- Unloading a table into a file (table export → downloadable file)
+
+## Existing Infrastructure
+
+What already works in `client.py` (reusable as-is):
+
+| Method | Line | What it does |
+|--------|------|-------------|
+| `prepare_file_upload()` | 904 | POST `/v2/storage/files/prepare` — registers file, returns presigned URL |
+| `_upload_to_cloud()` | 928 | Uploads bytes to GCP/AWS/Azure using credentials from prepare |
+| `get_file_info()` | 1186 | GET `/v2/storage/files/{id}?federationToken=1` — metadata + download URL |
+| `download_file()` | 1264 | Downloads non-sliced file with gzip handling |
+| `download_sliced_file()` | 1202 | Downloads sliced file (manifest + concatenate parts) |
+| `import_table_async()` | 1026 | POST import-async — imports a prepared file into a table |
+| `export_table_async()` | 1154 | POST export-async — exports table to a file |
+
+What is **missing** in `client.py`:
+
+| Method | API endpoint | Purpose |
+|--------|-------------|---------|
+| `list_files()` | GET `/v2/storage/files` | List files with filtering (tags, limit, offset, since) |
+| `delete_file()` | DELETE `/v2/storage/files/{id}` | Delete a file |
+| `tag_file()` | POST `/v2/storage/files/{id}/tags` | Add tags to existing file |
+| `untag_file()` | DELETE `/v2/storage/files/{id}/tags/{tag}` | Remove tag from file |
+
+The `prepare_file_upload()` method needs extension — currently only sends
+`name` + `sizeBytes` + `federationToken`. Storage Files API also accepts:
+`tags[]`, `isPermanent`, `isPublic`, `notify`.
+
+---
+
+## New CLI Commands
+
+### 1. `storage file-list`
+
+```bash
+# List recent files (default limit 20)
+kbagent storage file-list --project ALIAS
+
+# Filter by tags (AND logic — all tags must match)
+kbagent storage file-list --project ALIAS --tag output --tag monthly
+
+# Pagination
+kbagent storage file-list --project ALIAS --limit 50 --offset 100
+
+# Since timestamp
+kbagent storage file-list --project ALIAS --since 2026-04-01T00:00:00Z
+
+# With branch
+kbagent storage file-list --project ALIAS --branch 1234
+```
+
+JSON output per file: `id`, `name`, `sizeBytes`, `created`, `tags`,
+`isSliced`, `isPermanent`, `creatorToken.description`.
+
+### 2. `storage file-upload`
+
+```bash
+# Upload a file
+kbagent storage file-upload --project ALIAS --file ./data.csv
+
+# With tags and permanent flag
+kbagent storage file-upload --project ALIAS --file ./report.zip \
+  --tag report --tag 2026-Q1 --permanent
+
+# Custom name (default = local filename)
+kbagent storage file-upload --project ALIAS --file ./tmp_export.csv \
+  --name "monthly-report.csv"
+
+# With branch
+kbagent storage file-upload --project ALIAS --file ./data.csv --branch 1234
+```
+
+Returns: file ID, name, size, tags, cloud URL.
+
+### 3. `storage file-download`
+
+```bash
+# Download by file ID (output to current dir, original filename)
+kbagent storage file-download --project ALIAS --file-id 12345
+
+# Custom output path
+kbagent storage file-download --project ALIAS --file-id 12345 --output ./report.csv
+```
+
+Handles both sliced and non-sliced files transparently
+(reuses existing `download_file` / `download_sliced_file`).
+
+### 4. `storage file-info`
+
+```bash
+# Show file metadata (without downloading)
+kbagent storage file-info --project ALIAS --file-id 12345
+```
+
+Shows: id, name, size, created, tags, isSliced, isPermanent, component,
+config, creator token description.
+
+### 5. `storage file-delete`
+
+```bash
+# Delete a file
+kbagent storage file-delete --project ALIAS --file-id 12345
+
+# Batch delete
+kbagent storage file-delete --project ALIAS --file-id 12345 --file-id 67890
+
+# Dry-run
+kbagent storage file-delete --project ALIAS --file-id 12345 --dry-run
+```
+
+### 6. `storage file-tag`
+
+```bash
+# Add tags to a file
+kbagent storage file-tag --project ALIAS --file-id 12345 --add report --add 2026-Q1
+
+# Remove tags from a file
+kbagent storage file-tag --project ALIAS --file-id 12345 --remove draft
+
+# Both in one call
+kbagent storage file-tag --project ALIAS --file-id 12345 --add final --remove draft
+```
+
+### 7. `storage load-file` (file → table)
+
+Load an already-uploaded file into a table. This is the "file-based import"
+path — useful when the file is already in Storage Files (e.g., uploaded by
+a component, or via `file-upload`).
+
+```bash
+# Load file into existing table
+kbagent storage load-file --project ALIAS --file-id 12345 --table-id in.c-main.users
+
+# Incremental load
+kbagent storage load-file --project ALIAS --file-id 12345 --table-id in.c-main.users \
+  --incremental
+
+# With CSV options
+kbagent storage load-file --project ALIAS --file-id 12345 --table-id in.c-main.users \
+  --delimiter ";" --enclosure "'"
+
+# With branch
+kbagent storage load-file --project ALIAS --file-id 12345 --table-id in.c-main.users \
+  --branch 1234
+```
+
+Internally: calls `import_table_async()` with the given `dataFileId`.
+
+### 8. `storage unload-table` (table → file)
+
+Export a table to a Storage File that can then be downloaded or used by
+other components.
+
+```bash
+# Unload table to a file
+kbagent storage unload-table --project ALIAS --table-id in.c-main.users
+
+# With column filter and limit
+kbagent storage unload-table --project ALIAS --table-id in.c-main.users \
+  --columns name --columns email --limit 1000
+
+# Tag the output file
+kbagent storage unload-table --project ALIAS --table-id in.c-main.users \
+  --tag export --tag daily-snapshot
+
+# Unload + immediately download
+kbagent storage unload-table --project ALIAS --table-id in.c-main.users \
+  --download --output ./export.csv
+
+# With branch
+kbagent storage unload-table --project ALIAS --table-id in.c-main.users \
+  --branch 1234
+```
+
+Internally: calls `export_table_async()` → gets file_id from result →
+optionally tags the file → returns file info (or downloads if `--download`).
+
+---
+
+## Implementation Phases
+
+### Phase 1: Client Layer (`client.py`)
+
+New methods to add:
+
+```python
+def list_files(
+    self,
+    limit: int = 20,
+    offset: int = 0,
+    tags: list[str] | None = None,
+    since: str | None = None,
+    branch_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """GET /v2/storage/files with query params."""
+
+def upload_file(
+    self,
+    file_path: str,
+    name: str | None = None,
+    tags: list[str] | None = None,
+    is_permanent: bool = False,
+    notify: bool = False,
+    branch_id: int | None = None,
+) -> dict[str, Any]:
+    """Public wrapper: prepare_file_upload + _upload_to_cloud.
+    Returns file resource dict with id, name, sizeBytes, tags, url."""
+
+def delete_file(self, file_id: int) -> None:
+    """DELETE /v2/storage/files/{file_id}."""
+
+def tag_file(self, file_id: int, tag: str) -> None:
+    """POST /v2/storage/files/{file_id}/tags with body {tag: ...}."""
+
+def untag_file(self, file_id: int, tag: str) -> None:
+    """DELETE /v2/storage/files/{file_id}/tags/{tag}."""
+```
+
+Extend `prepare_file_upload()`:
+- Add `tags`, `is_permanent`, `notify` parameters
+- Pass `tags[]`, `isPermanent`, `notify` in POST body
+
+Extend `import_table_async()` (if needed):
+- Verify it accepts `dataFileId` parameter for file-based imports
+  (vs. current inline `dataString` or prepared file from upload flow)
+
+### Phase 2: Service Layer (`services/storage_service.py`)
+
+New methods:
+
+```python
+def list_files(self, alias: str | None, limit, offset, tags, since) -> dict
+def upload_file(self, alias: str, file_path, name, tags, is_permanent) -> dict
+def download_file(self, alias: str, file_id: int, output_path: str | None) -> dict
+def get_file_info(self, alias: str, file_id: int) -> dict
+def delete_files(self, alias: str, file_ids: list[int], dry_run: bool) -> dict
+def tag_file(self, alias: str, file_id: int, add: list[str], remove: list[str]) -> dict
+def load_file_to_table(self, alias, file_id, table_id, incremental, delimiter, enclosure) -> dict
+def unload_table_to_file(self, alias, table_id, columns, limit, tags, download, output_path) -> dict
+```
+
+Each method follows the standard pattern:
+1. Resolve project from alias
+2. Create client
+3. Call client method(s)
+4. Return structured result dict
+
+### Phase 3: Command Layer (`commands/storage.py`)
+
+Add 8 new commands to `storage_app`:
+- `file-list`, `file-upload`, `file-download`, `file-info`
+- `file-delete`, `file-tag`
+- `load-file`, `unload-table`
+
+Each follows the existing command pattern:
+1. Thin Typer function — parse args, call service, format output
+2. Dual output: `--json` (structured) + Rich (human-readable tables)
+3. Error handling: catch `KeboolaApiError` / `ConfigError` → exit code
+
+### Phase 4: Tests
+
+New test files:
+- `tests/test_storage_files_cli.py` — CLI tests via CliRunner for all 8 commands
+- Extend `tests/test_client.py` — client method tests with mocked HTTP
+- Extend `tests/test_services.py` or new `tests/test_storage_service.py` — service logic
+
+### Phase 5: Plugin Update
+
+- Update `plugins/kbagent/skills/kbagent/SKILL.md` — add file commands to decision table
+- Update CLAUDE.md CLI command list
+
+---
+
+## Delivery Order
+
+| Step | Scope | Depends on |
+|------|-------|-----------|
+| 1 | `client.py`: `list_files`, `upload_file`, `delete_file`, `tag_file`, `untag_file` | — |
+| 2 | `client.py`: extend `prepare_file_upload` with tags/permanent params | Step 1 |
+| 3 | `storage_service.py`: file CRUD methods (list, upload, download, info, delete, tag) | Steps 1-2 |
+| 4 | `commands/storage.py`: `file-list`, `file-upload`, `file-download`, `file-info`, `file-delete`, `file-tag` | Step 3 |
+| 5 | `storage_service.py`: `load_file_to_table`, `unload_table_to_file` | Step 3 |
+| 6 | `commands/storage.py`: `load-file`, `unload-table` | Step 5 |
+| 7 | Tests for all of the above | Steps 1-6 |
+| 8 | Plugin SKILL.md + CLAUDE.md update | Steps 4, 6 |
+
+---
+
+## Edge Cases and Design Decisions
+
+### Sliced files
+Large exports produce sliced files (multiple parts). `download_sliced_file()`
+already handles this. `file-download` must check `isSliced` and route accordingly.
+
+### File size display
+Use human-readable sizes in Rich output (e.g., "42.5 MB") but exact bytes in JSON.
+
+### Tags as repeatable option
+Use `--tag TAG` (repeatable) consistent with how `--tables` works in workspace commands.
+NOT `--tags "a,b,c"` — Typer's `list[str]` handles repeatable options cleanly.
+
+### Default file naming
+`file-download` defaults output filename to the file's `name` field from API.
+`file-upload` defaults `name` to the local file's basename.
+
+### Permanent vs. temporary
+Storage Files are temporary by default (auto-deleted after ~15 days).
+`--permanent` flag makes them permanent. This is important for artifact storage.
+
+### load-file vs upload-table
+- `upload-table` = local file → cloud upload → table import (the existing command)
+- `load-file` = Storage File (already uploaded) → table import (new command)
+
+These serve different use cases. `upload-table` is for local files.
+`load-file` is for files already in Keboola (component outputs, previous uploads).
+
+### unload-table vs download-table
+- `download-table` = table → export → download to local file (existing command)
+- `unload-table` = table → export → Storage File (stays in Keboola, optional download)
+
+`unload-table` is useful when you want to keep the export as a file in Keboola
+for other components to consume, or to tag it for later retrieval.
+
+### Branch support
+All file commands support `--branch ID` via `resolve_branch()` helper.
+Branch-scoped file operations use `/v2/storage/branch/{id}/files` prefix.
+
+---
+
+## API Reference
+
+Storage Files API endpoints used:
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v2/storage/files` | List files (query: `limit`, `offset`, `tags[]`, `sinceId`, `q`) |
+| POST | `/v2/storage/files/prepare` | Prepare upload (body: `name`, `sizeBytes`, `tags[]`, `isPermanent`, `federationToken`) |
+| GET | `/v2/storage/files/{id}?federationToken=1` | File detail with download credentials |
+| DELETE | `/v2/storage/files/{id}` | Delete file |
+| POST | `/v2/storage/files/{id}/tags` | Add tag (body: `tag`) |
+| DELETE | `/v2/storage/files/{id}/tags/{tag}` | Remove tag |
+
+Table import from file:
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v2/storage/tables/{tableId}/import-async` | Import with `dataFileId` param |
+
+Table export to file:
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v2/storage/tables/{tableId}/export-async` | Returns job with file in results |

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -160,6 +160,7 @@ For detailed response parsing rules and common pitfalls, see [gotchas](reference
 | Creating new configurations | [scaffold-workflow](references/scaffold-workflow.md) |
 | MCP tools (multi-project read/write) | [mcp-workflow](references/mcp-workflow.md) |
 | Workspace SQL debugging | [workspace-workflow](references/workspace-workflow.md) |
+| Storage Files (upload, download, tags, load/unload) | [storage-files-workflow](references/storage-files-workflow.md) |
 | Bucket sharing & linking | [sharing-workflow](references/sharing-workflow.md) |
 | Dev branches | [branch-workflow](references/branch-workflow.md) |
 | Encrypting secrets for MCP tools | [encrypt-workflow](references/encrypt-workflow.md) |

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -74,20 +74,20 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Run a job for a component configuration | `kbagent job run --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | List storage buckets with sharing/linked bucket information | `kbagent storage buckets` |
 | Show detailed bucket info including Snowflake direct access paths | `kbagent storage bucket-detail --project PROJECT --bucket-id BUCKET-ID` |
+| List storage tables from a project | `kbagent storage tables --project PROJECT` |
 | Show detailed table info including columns and types | `kbagent storage table-detail --project PROJECT --table-id TABLE-ID` |
 | Create a new storage bucket | `kbagent storage create-bucket --project PROJECT --stage STAGE --name NAME` |
 | Create a new storage table with typed columns | `kbagent storage create-table --project PROJECT --bucket-id BUCKET-ID --name NAME --column COLUMN` |
 | Upload a CSV file into a storage table | `kbagent storage upload-table --project PROJECT --table-id TABLE-ID --file FILE` |
 | Export a storage table to a local CSV file | `kbagent storage download-table --project PROJECT --table-id TABLE-ID` |
-| List storage tables from a project | `kbagent storage tables --project PROJECT` |
 | Delete one or more storage tables | `kbagent storage delete-table --project PROJECT --table-id TABLE-ID` |
 | Delete one or more storage buckets | `kbagent storage delete-bucket --project PROJECT --bucket-id BUCKET-ID` |
-| List Storage Files with optional tag filtering | `kbagent storage file-list --project PROJECT` |
+| List Storage Files with optional tag filtering | `kbagent storage files --project PROJECT` |
+| Show Storage File metadata (without downloading) | `kbagent storage file-detail --project PROJECT --file-id FILE-ID` |
 | Upload a local file to Storage Files | `kbagent storage file-upload --project PROJECT --file FILE` |
 | Download a Storage File to local disk | `kbagent storage file-download --project PROJECT` |
-| Show Storage File metadata (without downloading) | `kbagent storage file-info --project PROJECT --file-id FILE-ID` |
-| Delete one or more Storage Files | `kbagent storage file-delete --project PROJECT --file-id FILE-ID` |
 | Add and/or remove tags on a Storage File | `kbagent storage file-tag --project PROJECT --file-id FILE-ID` |
+| Delete one or more Storage Files | `kbagent storage file-delete --project PROJECT --file-id FILE-ID` |
 | Load a Storage File into a table | `kbagent storage load-file --project PROJECT --file-id FILE-ID --table-id TABLE-ID` |
 | Export a table to a Storage File | `kbagent storage unload-table --project PROJECT --table-id TABLE-ID` |
 | List shared buckets available for linking | `kbagent sharing list` |

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -9,6 +9,7 @@ description: >
   as local files (GitOps), git-branching with Keboola dev branch isolation,
   sharing buckets across projects, linking shared data,
   encrypting secrets for MCP tool call workflows,
+  uploading/downloading Storage Files with tag management,
   and syncing storage metadata and job history. Triggers: kbagent, Keboola project,
   keboola configs, keboola jobs, keboola lineage, keboola transformations,
   keboola MCP tools, keboola workspace, SQL debugging, keboola branches,
@@ -81,6 +82,14 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | List storage tables from a project | `kbagent storage tables --project PROJECT` |
 | Delete one or more storage tables | `kbagent storage delete-table --project PROJECT --table-id TABLE-ID` |
 | Delete one or more storage buckets | `kbagent storage delete-bucket --project PROJECT --bucket-id BUCKET-ID` |
+| List Storage Files with optional tag filtering | `kbagent storage file-list --project PROJECT` |
+| Upload a local file to Storage Files | `kbagent storage file-upload --project PROJECT --file FILE` |
+| Download a Storage File to local disk | `kbagent storage file-download --project PROJECT` |
+| Show Storage File metadata (without downloading) | `kbagent storage file-info --project PROJECT --file-id FILE-ID` |
+| Delete one or more Storage Files | `kbagent storage file-delete --project PROJECT --file-id FILE-ID` |
+| Add and/or remove tags on a Storage File | `kbagent storage file-tag --project PROJECT --file-id FILE-ID` |
+| Load a Storage File into a table | `kbagent storage load-file --project PROJECT --file-id FILE-ID --table-id TABLE-ID` |
+| Export a table to a Storage File | `kbagent storage unload-table --project PROJECT --table-id TABLE-ID` |
 | List shared buckets available for linking | `kbagent sharing list` |
 | Enable sharing on a bucket | `kbagent sharing share --project PROJECT --bucket-id BUCKET-ID --type SHARING-TYPE` |
 | Disable sharing on a bucket | `kbagent sharing unshare --project PROJECT --bucket-id BUCKET-ID` |

--- a/plugins/kbagent/skills/kbagent/references/storage-files-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/storage-files-workflow.md
@@ -1,0 +1,170 @@
+# Storage Files Workflow
+
+Storage Files is a staging area in Keboola for arbitrary files -- CSV data,
+ZIP archives, JSON configs, component artifacts, and logs. Files are temporary
+by default (auto-deleted after ~15 days) unless marked as permanent.
+
+## Quick reference
+
+| Command | Purpose |
+|---------|---------|
+| `storage files` | List files (with tag filtering) |
+| `storage file-detail` | Show file metadata |
+| `storage file-upload` | Upload a local file |
+| `storage file-download` | Download a file (by ID or by tag) |
+| `storage file-tag` | Add/remove tags |
+| `storage file-delete` | Delete files |
+| `storage load-file` | Import an uploaded file into a table |
+| `storage unload-table` | Export a table to a Storage File |
+
+## Upload a file with tags
+
+```bash
+kbagent --json storage file-upload \
+  --project ALIAS \
+  --file ./data.csv \
+  --tag report --tag 2026-Q1 \
+  --permanent
+```
+
+- `--tag` is repeatable (assigns multiple tags at upload time)
+- `--permanent` prevents auto-deletion after 15 days
+- `--name` overrides the filename (default: local file basename)
+- Returns `id` -- save it for later operations
+
+## List and filter files by tags
+
+```bash
+# All recent files
+kbagent --json storage files --project ALIAS
+
+# Filter by tags (AND logic -- all tags must match)
+kbagent --json storage files --project ALIAS --tag report --tag 2026-Q1
+
+# Full-text search on file name
+kbagent --json storage files --project ALIAS --query "monthly"
+
+# Pagination
+kbagent --json storage files --project ALIAS --limit 50 --offset 100
+```
+
+## Download a file
+
+```bash
+# By file ID
+kbagent --json storage file-download --project ALIAS --file-id 12345
+
+# By tags (downloads the latest file matching ALL tags)
+kbagent --json storage file-download --project ALIAS --tag report --tag 2026-Q1
+
+# Custom output path
+kbagent --json storage file-download --project ALIAS --file-id 12345 --output ./report.csv
+```
+
+Download by tag is useful for automated pipelines where the file ID is unknown
+but the tag convention is stable.
+
+## Manage tags
+
+```bash
+# Add tags
+kbagent --json storage file-tag --project ALIAS --file-id 12345 --add final --add reviewed
+
+# Remove tags
+kbagent --json storage file-tag --project ALIAS --file-id 12345 --remove draft
+
+# Both in one call
+kbagent --json storage file-tag --project ALIAS --file-id 12345 --add final --remove draft
+```
+
+## Load a file into a table
+
+When a file is already in Storage (uploaded by a component, or via `file-upload`),
+import it directly into a table without re-uploading:
+
+```bash
+kbagent --json storage load-file \
+  --project ALIAS \
+  --file-id 12345 \
+  --table-id in.c-data.users \
+  --incremental
+```
+
+This is faster than `upload-table` because the file is already in the cloud --
+no local upload step needed. The table must already exist.
+
+## Export a table to a Storage File
+
+Create a file in Keboola from table data. Useful for making data available
+to other components, or for tagged snapshots:
+
+```bash
+# Export to file (stays in Keboola)
+kbagent --json storage unload-table \
+  --project ALIAS \
+  --table-id in.c-data.users \
+  --tag daily-snapshot --tag 2026-04-12
+
+# Export + download locally in one step
+kbagent --json storage unload-table \
+  --project ALIAS \
+  --table-id in.c-data.users \
+  --download --output ./users-export.csv
+```
+
+### unload-table vs download-table
+
+| | `download-table` | `unload-table` |
+|---|---|---|
+| File stays in Keboola | No (download only) | Yes (file persists) |
+| Can tag the output | No | Yes (`--tag`) |
+| Can download locally | Always | Optional (`--download`) |
+| Use case | Quick local export | Share data between components, snapshots |
+
+## Typical workflows
+
+### Artifact storage (CI/CD)
+
+```bash
+# Upload build artifact with tags
+kbagent --json storage file-upload \
+  --project prod \
+  --file ./build-output.zip \
+  --tag artifact --tag build-42 --tag latest \
+  --permanent
+
+# Later: download latest artifact by tag
+kbagent --json storage file-download \
+  --project prod \
+  --tag artifact --tag latest \
+  --output ./latest-build.zip
+```
+
+### Data exchange between components
+
+```bash
+# Component A exports results to a tagged file
+kbagent --json storage unload-table \
+  --project ALIAS \
+  --table-id out.c-results.predictions \
+  --tag ml-output --tag 2026-04-12
+
+# Component B picks up the latest tagged file and loads it
+FILE_ID=$(kbagent --json storage files --project ALIAS --tag ml-output --limit 1 \
+  | jq '.data.files[0].id')
+kbagent --json storage load-file \
+  --project ALIAS \
+  --file-id $FILE_ID \
+  --table-id in.c-pipeline.predictions
+```
+
+## Key behaviors
+
+- Files are **temporary by default** -- auto-deleted after ~15 days
+- Use `--permanent` to keep files indefinitely
+- Tag filtering uses **AND logic** -- all specified tags must match
+- `file-download --tag` downloads the **most recent** matching file
+- `load-file` skips the upload step -- the file is already in cloud storage
+- `unload-table` creates a **sliced file** for large tables (handled transparently on download)
+- All file commands support `--branch` for dev branch operations
+- Works across all cloud backends (AWS, GCP, Azure) transparently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.18.3"
+version = "0.18.4"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,14 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.18.4": [
+        "New: Storage Files commands -- files, file-detail, file-upload, file-download, file-tag, file-delete (#134)",
+        "New: load-file -- import an uploaded Storage File into a table (#134)",
+        "New: unload-table -- export a table to a Storage File with tags (#134)",
+        "New: download by tag -- file-download --tag fetches latest matching file (#134)",
+        "Fix: Azure sliced file download (azure:// URL handling in _CloudDownloader)",
+        "UX: storage --help groups commands into Buckets/Tables/Files sections",
+    ],
     "0.18.3": [
         "New: job run command with --row-id, --wait, --timeout (#135)",
     ],

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -905,6 +905,9 @@ class KeboolaClient(BaseHttpClient):
         self,
         name: str,
         size_bytes: int,
+        tags: list[str] | None = None,
+        is_permanent: bool = False,
+        notify: bool = False,
     ) -> dict[str, Any]:
         """Register a file with the Storage API and get a presigned upload URL.
 
@@ -913,6 +916,9 @@ class KeboolaClient(BaseHttpClient):
         Args:
             name: Filename (e.g. "data.csv").
             size_bytes: File size in bytes.
+            tags: Optional list of tags to assign to the file.
+            is_permanent: If True, file is not auto-deleted after 15 days.
+            notify: If True, send notification on upload completion.
 
         Returns:
             File resource dict including 'id' (fileId), 'url', 'uploadParams',
@@ -922,6 +928,13 @@ class KeboolaClient(BaseHttpClient):
         # federationToken=1 is required on newer stacks (AWS, Azure) to get
         # cloud-native credentials instead of deprecated presigned POST fields.
         body: dict[str, Any] = {"name": name, "sizeBytes": size_bytes, "federationToken": "1"}
+        if is_permanent:
+            body["isPermanent"] = "1"
+        if notify:
+            body["notify"] = "1"
+        if tags:
+            for i, tag in enumerate(tags):
+                body[f"tags[{i}]"] = tag
         response = self._request("POST", "/v2/storage/files/prepare", data=body)
         return response.json()
 
@@ -1198,6 +1211,112 @@ class KeboolaClient(BaseHttpClient):
             params={"federationToken": "1"},
         )
         return response.json()
+
+    def list_files(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+        tags: list[str] | None = None,
+        since_id: int | None = None,
+        query: str | None = None,
+        branch_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List Storage Files with optional filtering.
+
+        Args:
+            limit: Max number of files to return.
+            offset: Pagination offset.
+            tags: Filter by tags (AND logic — all tags must match).
+            since_id: Return only files with ID greater than this.
+            query: Full-text search query on file name.
+            branch_id: If set, list files from a specific dev branch.
+
+        Returns:
+            List of file resource dicts.
+        """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if tags:
+            for i, tag in enumerate(tags):
+                params[f"tags[{i}]"] = tag
+        if since_id is not None:
+            params["sinceId"] = since_id
+        if query:
+            params["q"] = query
+        response = self._request("GET", f"{prefix}/files", params=params)
+        return response.json()
+
+    def upload_file(
+        self,
+        file_path: str,
+        name: str | None = None,
+        tags: list[str] | None = None,
+        is_permanent: bool = False,
+        notify: bool = False,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Upload a local file to Storage Files.
+
+        Wraps prepare_file_upload + _upload_to_cloud into a single call.
+
+        Args:
+            file_path: Local path to the file to upload.
+            name: Custom filename (defaults to local file basename).
+            tags: Optional list of tags to assign.
+            is_permanent: If True, file is not auto-deleted after 15 days.
+            notify: If True, send notification on upload completion.
+            branch_id: If set, upload to a specific dev branch.
+
+        Returns:
+            File resource dict with id, name, sizeBytes, tags, url.
+        """
+        p = Path(file_path)
+        size_bytes = p.stat().st_size
+        file_name = name or p.name
+        upload_info = self.prepare_file_upload(
+            name=file_name,
+            size_bytes=size_bytes,
+            tags=tags,
+            is_permanent=is_permanent,
+            notify=notify,
+        )
+        self._upload_to_cloud(upload_info, file_path)
+        # Return file info (prepare response has the file metadata)
+        return {
+            "id": upload_info["id"],
+            "name": upload_info.get("name", file_name),
+            "sizeBytes": size_bytes,
+            "tags": upload_info.get("tags", tags or []),
+            "isPermanent": upload_info.get("isPermanent", is_permanent),
+            "created": upload_info.get("created"),
+        }
+
+    def delete_file(self, file_id: int) -> None:
+        """Delete a Storage File.
+
+        Args:
+            file_id: Storage file ID.
+        """
+        self._request("DELETE", f"/v2/storage/files/{file_id}")
+
+    def tag_file(self, file_id: int, tag: str) -> None:
+        """Add a tag to a Storage File.
+
+        Args:
+            file_id: Storage file ID.
+            tag: Tag string to add.
+        """
+        self._request("POST", f"/v2/storage/files/{file_id}/tags", data={"tag": tag})
+
+    def untag_file(self, file_id: int, tag: str) -> None:
+        """Remove a tag from a Storage File.
+
+        Args:
+            file_id: Storage file ID.
+            tag: Tag string to remove.
+        """
+        safe_tag = quote(tag, safe="")
+        self._request("DELETE", f"/v2/storage/files/{file_id}/tags/{safe_tag}")
 
     def download_sliced_file(self, file_detail: dict[str, Any], output_path: str) -> int:
         """Download a sliced file by fetching manifest and concatenating slices.

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1919,8 +1919,27 @@ class _CloudDownloader:
                 provider="gcp",
                 auth_fn=lambda _url: {"Authorization": f"{token_type} {token}"},
             )
+        elif provider == "azure":
+            # Azure: SAS token from absCredentials for authenticating slice downloads
+            abs_creds = file_detail.get("absCredentials", {})
+            sas_string = abs_creds.get("SASConnectionString", "")
+            # Parse "BlobEndpoint=https://...;SharedAccessSignature=sv=..."
+            sas_parts: dict[str, str] = {}
+            for segment in sas_string.split(";"):
+                key, sep, value = segment.partition("=")
+                if sep:
+                    sas_parts[key] = value
+            blob_endpoint = sas_parts.get("BlobEndpoint", "").rstrip("/")
+            sas = sas_parts.get("SharedAccessSignature", "")
+            return _CloudDownloader(
+                provider="azure",
+                auth_fn=lambda _url, _be=blob_endpoint, _sas=sas: {
+                    "_blob_endpoint": _be,
+                    "_sas": _sas,
+                },
+            )
         else:
-            # Azure / other: presigned URLs, no extra auth needed
+            # Other: presigned URLs, no extra auth needed
             return _CloudDownloader(provider=provider, auth_fn=lambda _url: {})
 
     def resolve_base_url(self, file_detail: dict[str, Any]) -> str:
@@ -1940,8 +1959,15 @@ class _CloudDownloader:
             bucket = gcs_path.get("bucket", "")
             key = gcs_path.get("key", "")
             return f"https://storage.googleapis.com/{bucket}/{key}"
+        elif self._provider == "azure":
+            # Azure: base URL from absCredentials endpoint + container
+            auth_info = self._auth_fn("")
+            blob_endpoint = auth_info.get("_blob_endpoint", "")
+            abs_path = file_detail.get("absPath", {})
+            container = abs_path.get("container", "")
+            return f"{blob_endpoint}/{container}/"
         else:
-            # Azure/other: entries should be full URLs
+            # Other: entries should be full URLs
             return ""
 
     def resolve_slice_url(
@@ -1952,9 +1978,9 @@ class _CloudDownloader:
     ) -> str:
         """Convert a manifest entry URL to a downloadable HTTPS URL.
 
-        Manifest entries use cloud-native URLs (s3://bucket/key/slice.gz).
-        This strips the cloud prefix and appends the relative slice path
-        to the HTTPS base URL.
+        Manifest entries use cloud-native URLs (s3://bucket/key/slice.gz,
+        azure://container/blob). This strips the cloud prefix and builds
+        an HTTPS URL for download.
 
         Args:
             base_url: HTTPS base URL from resolve_base_url().
@@ -1981,13 +2007,25 @@ class _CloudDownloader:
             prefix = f"gs://{bucket}/{key}"
             relative = entry_url.removeprefix(prefix) if entry_url.startswith(prefix) else entry_url
             return base_url + relative
+        elif self._provider == "azure":
+            # entry_url: "azure://account.blob.core.windows.net/container/blob.gz"
+            # Replace azure:// with https:// and append SAS token
+            auth_info = self._auth_fn("")
+            sas = auth_info.get("_sas", "")
+            if entry_url.startswith("azure://"):
+                https_url = "https://" + entry_url[len("azure://") :]
+                return f"{https_url}?{sas}"
+            return entry_url
         else:
-            # Azure/other: entry URLs should be full HTTPS URLs
+            # Other: entry URLs should be full HTTPS URLs
             return entry_url
 
     def download_bytes(self, url: str) -> bytes:
         """Download content from a cloud URL with appropriate authentication."""
-        headers = self._auth_fn(url)
+        auth_result = self._auth_fn(url)
+        # Azure stores metadata (endpoint, SAS) in auth_fn result, not HTTP headers.
+        # The SAS token is embedded in the URL by resolve_slice_url().
+        headers = {k: v for k, v in auth_result.items() if not k.startswith("_")}
         with httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http:
             response = http.get(url, headers=headers)
             response.raise_for_status()

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -150,6 +150,36 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
     Delete one or more buckets. --force cascade-deletes tables. Linked/shared buckets protected. Branch-aware.
 
+### Storage Files
+
+  kbagent storage file-list --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
+    List Storage Files. --tag filters by tags (AND logic, repeat for multiple). --query for full-text search on name. Branch-aware.
+
+  kbagent storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]
+    Upload any file to Storage Files. --tag assigns tags (repeatable). --permanent prevents auto-deletion after 15 days.
+    --name overrides the filename (default: local filename). Branch-aware.
+
+  kbagent storage file-download --project NAME [--file-id ID | --tag TAG ...] [--output FILE]
+    Download a Storage File. Either --file-id (by ID) or --tag (latest file matching all tags).
+    --output sets local path (default: original filename). Handles sliced and gzipped files transparently.
+
+  kbagent storage file-info --project NAME --file-id ID
+    Show file metadata: name, size, tags, sliced/permanent status, creator token. Does not download.
+
+  kbagent storage file-delete --project NAME --file-id ID [--file-id ...] [--dry-run] [--yes]
+    Delete one or more Storage Files. Batch: repeat --file-id. --dry-run to preview.
+
+  kbagent storage file-tag --project NAME --file-id ID [--add TAG ...] [--remove TAG ...]
+    Add and/or remove tags on a file in a single operation. Both --add and --remove are repeatable.
+
+  kbagent storage load-file --project NAME --file-id ID --table-id TABLE_ID [--incremental] [--delimiter D] [--enclosure E] [--branch ID]
+    Import an already-uploaded Storage File into a table. Useful for files uploaded by components or file-upload.
+    --incremental to append rows. Branch-aware.
+
+  kbagent storage unload-table --project NAME --table-id TABLE_ID [--columns COL ...] [--limit N] [--tag TAG ...] [--download] [--output FILE] [--branch ID]
+    Export a table to a Storage File. The file stays in Keboola for other components to use.
+    --tag assigns tags to the exported file. --download also saves it locally. Branch-aware.
+
 ### Sharing (Cross-Project)
 
   kbagent sharing list [--project NAME]

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -152,7 +152,7 @@ Use `kbagent <command> --help` for full flag details and examples.
 
 ### Storage Files
 
-  kbagent storage file-list --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
+  kbagent storage files --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
     List Storage Files. --tag filters by tags (AND logic, repeat for multiple). --query for full-text search on name. Branch-aware.
 
   kbagent storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]
@@ -163,7 +163,7 @@ Use `kbagent <command> --help` for full flag details and examples.
     Download a Storage File. Either --file-id (by ID) or --tag (latest file matching all tags).
     --output sets local path (default: original filename). Handles sliced and gzipped files transparently.
 
-  kbagent storage file-info --project NAME --file-id ID
+  kbagent storage file-detail --project NAME --file-id ID
     Show file metadata: name, size, tags, sliced/permanent status, creator token. Does not download.
 
   kbagent storage file-delete --project NAME --file-id ID [--file-id ...] [--dry-run] [--yes]

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -750,8 +750,10 @@ def storage_delete_table(
     else:
         for tid in result["deleted"]:
             formatter.console.print(f"[bold green]Deleted:[/bold green] {tid}")
-        for f in result["failed"]:
-            formatter.console.print(f"[bold red]Failed:[/bold red] {f['id']}: {f['error']}")
+        for f_item in result["failed"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] {f_item['id']}: {f_item['error']}"
+            )
 
     if result["failed"]:
         raise typer.Exit(code=1)
@@ -825,8 +827,637 @@ def storage_delete_bucket(
         else:
             for bid in result["deleted"]:
                 formatter.console.print(f"[bold green]Deleted:[/bold green] {bid}")
-        for f in result["failed"]:
-            formatter.console.print(f"[bold red]Failed:[/bold red] {f['id']}: {f['error']}")
+        for f_item in result["failed"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] {f_item['id']}: {f_item['error']}"
+            )
 
     if result["failed"]:
         raise typer.Exit(code=1)
+
+
+# ------------------------------------------------------------------
+# File operations
+# ------------------------------------------------------------------
+
+
+def _format_file_size(size_bytes: int | None) -> str:
+    """Format file size in human-readable form."""
+    if size_bytes is None:
+        return "unknown"
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    if size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.2f} MB"
+    return f"{size_bytes / (1024 * 1024 * 1024):.2f} GB"
+
+
+@storage_app.command("file-list")
+def storage_file_list(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        help="Filter by tag (repeat for AND logic: --tag a --tag b)",
+    ),
+    limit: int = typer.Option(
+        20,
+        "--limit",
+        help="Max number of files to return",
+    ),
+    offset: int = typer.Option(
+        0,
+        "--offset",
+        help="Pagination offset",
+    ),
+    query: str | None = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Full-text search on file name",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """List Storage Files with optional tag filtering.
+
+    Lists files from the project's Storage Files API. Use --tag to filter
+    by tags (AND logic - all specified tags must match).
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    try:
+        result = service.list_files(
+            alias=project,
+            limit=limit,
+            offset=offset,
+            tags=tag,
+            query=query,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        files = result["files"]
+        if not files:
+            formatter.console.print("[dim]No files found.[/dim]")
+            return
+
+        from rich.table import Table
+
+        table = Table(title=f"Storage Files ({result['count']} files)")
+        table.add_column("ID", style="cyan")
+        table.add_column("Name")
+        table.add_column("Size", justify="right")
+        table.add_column("Tags")
+        table.add_column("Permanent")
+        table.add_column("Created")
+
+        for f in files:
+            tags_str = ", ".join(f.get("tags", []))
+            permanent = "yes" if f.get("isPermanent") else ""
+            created = f.get("created", "")[:19] if f.get("created") else ""
+            table.add_row(
+                str(f.get("id", "")),
+                f.get("name", ""),
+                _format_file_size(f.get("sizeBytes")),
+                tags_str,
+                permanent,
+                created,
+            )
+
+        formatter.console.print(table)
+
+
+@storage_app.command("file-upload")
+def storage_file_upload(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file: str = typer.Option(
+        ...,
+        "--file",
+        help="Path to the file to upload",
+    ),
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        help="Custom file name (default: local filename)",
+    ),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        help="Tag to assign (repeat for multiple: --tag a --tag b)",
+    ),
+    permanent: bool = typer.Option(
+        False,
+        "--permanent",
+        help="Make file permanent (not auto-deleted after 15 days)",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """Upload a local file to Storage Files.
+
+    Uploads any file (CSV, JSON, ZIP, etc.) to Keboola Storage Files.
+    Use --tag to assign tags and --permanent to prevent auto-deletion.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    p = Path(file)
+    if not p.is_file():
+        formatter.error(message=f"File not found: {file}", error_code="FILE_NOT_FOUND")
+        raise typer.Exit(code=2) from None
+
+    if not formatter.json_mode:
+        size_str = _format_file_size(p.stat().st_size)
+        formatter.console.print(f"Uploading [bold]{p.name}[/bold] ({size_str})...")
+
+    try:
+        result = service.upload_file(
+            alias=project,
+            file_path=file,
+            name=name,
+            tags=tag,
+            is_permanent=permanent,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        size_str = _format_file_size(result.get("file_size_bytes"))
+        tags_str = ", ".join(result.get("tags", []))
+        formatter.console.print(
+            f"[bold green]Uploaded:[/bold green] file ID {result['id']} "
+            f"({result.get('name', '')}), {size_str}"
+        )
+        if tags_str:
+            formatter.console.print(f"  Tags: {tags_str}")
+        if result.get("isPermanent"):
+            formatter.console.print("  Permanent: yes")
+
+
+@storage_app.command("file-download")
+def storage_file_download(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: int | None = typer.Option(
+        None,
+        "--file-id",
+        help="Storage file ID to download",
+    ),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        help="Download latest file matching tags (repeat for AND: --tag a --tag b)",
+    ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output file path (default: original filename)",
+    ),
+) -> None:
+    """Download a Storage File to local disk.
+
+    Download by file ID (--file-id) or by tags (--tag, downloads the latest
+    matching file). Handles both sliced and non-sliced files transparently.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    if not file_id and not tag:
+        formatter.error(
+            message="Either --file-id or --tag must be provided",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2) from None
+
+    if not formatter.json_mode:
+        if file_id:
+            formatter.console.print(f"Downloading file ID [cyan]{file_id}[/cyan]...")
+        else:
+            formatter.console.print(f"Downloading latest file with tags: {', '.join(tag or [])}...")
+
+    try:
+        result = service.download_file(
+            alias=project,
+            file_id=file_id,
+            tags=tag,
+            output_path=output,
+        )
+    except ValueError as exc:
+        formatter.error(message=str(exc), error_code="INVALID_ARGUMENT")
+        raise typer.Exit(code=2) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        size_str = _format_file_size(result["file_size_bytes"])
+        formatter.console.print(
+            f"[bold green]Downloaded:[/bold green] {result['file_name']} "
+            f"-> {result['output_path']} ({size_str})"
+        )
+
+
+@storage_app.command("file-info")
+def storage_file_info(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: int = typer.Option(
+        ...,
+        "--file-id",
+        help="Storage file ID",
+    ),
+) -> None:
+    """Show Storage File metadata (without downloading)."""
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    try:
+        result = service.get_file_info(alias=project, file_id=file_id)
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        formatter.console.print(f"[bold]File ID:[/bold] {result.get('id')}")
+        formatter.console.print(f"[bold]Name:[/bold] {result.get('name')}")
+        formatter.console.print(f"[bold]Size:[/bold] {_format_file_size(result.get('sizeBytes'))}")
+        formatter.console.print(f"[bold]Created:[/bold] {result.get('created', '')}")
+        formatter.console.print(f"[bold]Sliced:[/bold] {'yes' if result.get('isSliced') else 'no'}")
+        formatter.console.print(
+            f"[bold]Permanent:[/bold] {'yes' if result.get('isPermanent') else 'no'}"
+        )
+        tags_str = ", ".join(result.get("tags", []))
+        formatter.console.print(f"[bold]Tags:[/bold] {tags_str or '(none)'}")
+        creator = result.get("creatorToken", {})
+        if isinstance(creator, dict):
+            formatter.console.print(
+                f"[bold]Creator:[/bold] {creator.get('description', 'unknown')}"
+            )
+
+
+@storage_app.command("file-delete")
+def storage_file_delete(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: list[int] = typer.Option(
+        ...,
+        "--file-id",
+        help="Storage file ID to delete (repeat for multiple)",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be deleted without executing",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Delete one or more Storage Files."""
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    try:
+        result = service.delete_files(
+            alias=project,
+            file_ids=file_id,
+            dry_run=dry_run,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        if dry_run:
+            for fid in result.get("would_delete", []):
+                formatter.console.print(f"[bold blue]Would delete:[/bold blue] file ID {fid}")
+        else:
+            for fid in result["deleted"]:
+                formatter.console.print(f"[bold green]Deleted:[/bold green] file ID {fid}")
+        for f_err in result["failed"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] file ID {f_err['id']}: {f_err['error']}"
+            )
+
+    if result["failed"]:
+        raise typer.Exit(code=1)
+
+
+@storage_app.command("file-tag")
+def storage_file_tag(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: int = typer.Option(
+        ...,
+        "--file-id",
+        help="Storage file ID",
+    ),
+    add: list[str] | None = typer.Option(
+        None,
+        "--add",
+        help="Tag to add (repeat for multiple: --add a --add b)",
+    ),
+    remove: list[str] | None = typer.Option(
+        None,
+        "--remove",
+        help="Tag to remove (repeat for multiple: --remove a --remove b)",
+    ),
+) -> None:
+    """Add and/or remove tags on a Storage File.
+
+    Use --add and --remove to modify tags in a single operation.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    if not add and not remove:
+        formatter.error(
+            message="At least one of --add or --remove must be provided",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2) from None
+
+    try:
+        result = service.tag_file(
+            alias=project,
+            file_id=file_id,
+            add_tags=add,
+            remove_tags=remove,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        for tag_name in result["added"]:
+            formatter.console.print(f"[bold green]Added tag:[/bold green] {tag_name}")
+        for tag_name in result["removed"]:
+            formatter.console.print(f"[bold yellow]Removed tag:[/bold yellow] {tag_name}")
+        for err in result["errors"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] {err['action']} tag '{err['tag']}': {err['error']}"
+            )
+
+    if result["errors"]:
+        raise typer.Exit(code=1)
+
+
+@storage_app.command("load-file")
+def storage_load_file(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: int = typer.Option(
+        ...,
+        "--file-id",
+        help="Storage file ID to load into a table",
+    ),
+    table_id: str = typer.Option(
+        ...,
+        "--table-id",
+        help="Target table ID (e.g. 'in.c-my-bucket.my-table')",
+    ),
+    incremental: bool = typer.Option(
+        False,
+        "--incremental",
+        help="Append rows instead of full load",
+    ),
+    delimiter: str = typer.Option(
+        ",",
+        "--delimiter",
+        help="CSV column delimiter",
+    ),
+    enclosure: str = typer.Option(
+        '"',
+        "--enclosure",
+        help="CSV value enclosure character",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """Load a Storage File into a table.
+
+    Imports an already-uploaded file (from file-upload or component output)
+    into a storage table. Use --incremental to append rows.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    if not formatter.json_mode:
+        formatter.console.print(
+            f"Loading file ID [cyan]{file_id}[/cyan] into [cyan]{table_id}[/cyan]..."
+        )
+
+    try:
+        result = service.load_file_to_table(
+            alias=project,
+            file_id=file_id,
+            table_id=table_id,
+            incremental=incremental,
+            delimiter=delimiter,
+            enclosure=enclosure,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        load_type = "incremental" if result["incremental"] else "full"
+        formatter.console.print(
+            f"[bold green]Loaded:[/bold green] file {result['file_id']} -> "
+            f"{result['table_id']} ({load_type} load)"
+        )
+        if result["imported_rows"] is not None:
+            formatter.console.print(f"  Rows imported: {result['imported_rows']}")
+        for w in result.get("warnings", []):
+            formatter.console.print(f"  [yellow]Warning:[/yellow] {w}")
+
+
+@storage_app.command("unload-table")
+def storage_unload_table(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    table_id: str = typer.Option(
+        ...,
+        "--table-id",
+        help="Table ID to export (e.g. 'in.c-my-bucket.my-table')",
+    ),
+    columns: list[str] | None = typer.Option(
+        None,
+        "--columns",
+        help="Column names to export (repeat for multiple)",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        help="Max number of rows to export",
+    ),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        help="Tag to apply to the exported file (repeat for multiple)",
+    ),
+    download: bool = typer.Option(
+        False,
+        "--download",
+        help="Also download the exported file locally",
+    ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output file path (only with --download)",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """Export a table to a Storage File.
+
+    Creates a file in Storage that can be downloaded or consumed by other
+    components. Use --tag to tag the output file and --download to also
+    save it locally.
+    """
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    if not formatter.json_mode:
+        msg = f"Exporting [cyan]{table_id}[/cyan] to Storage File"
+        if download:
+            msg += " (with download)"
+        msg += "..."
+        formatter.console.print(msg)
+
+    try:
+        result = service.unload_table_to_file(
+            alias=project,
+            table_id=table_id,
+            columns=columns,
+            limit=limit,
+            tags=tag,
+            download=download,
+            output_path=output,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        size_str = _format_file_size(result.get("file_size_bytes"))
+        tags_str = ", ".join(result.get("tags", []))
+        formatter.console.print(
+            f"[bold green]Exported:[/bold green] {result['table_id']} -> "
+            f"file ID {result['file_id']} ({size_str})"
+        )
+        if tags_str:
+            formatter.console.print(f"  Tags: {tags_str}")
+        if result.get("downloaded"):
+            dl_size = _format_file_size(result.get("downloaded_bytes"))
+            formatter.console.print(f"  Downloaded to: {result['output_path']} ({dl_size})")

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -200,6 +200,75 @@ def storage_bucket_detail(
                 )
 
 
+@storage_app.command("tables", rich_help_panel=_TABLES)
+def storage_tables(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    bucket_id: str | None = typer.Option(
+        None,
+        "--bucket-id",
+        help="Filter tables by bucket ID",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """List storage tables from a project."""
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    try:
+        result = service.list_tables(
+            alias=project,
+            bucket_id=bucket_id,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        from rich.table import Table
+
+        tables = result["tables"]
+        if not tables:
+            formatter.console.print("[dim]No tables found.[/dim]")
+            return
+
+        table = Table(title=f"Tables - {result['project_alias']}")
+        table.add_column("Table ID", style="bold cyan")
+        table.add_column("Rows", justify="right")
+        table.add_column("Size", justify="right", style="dim")
+        table.add_column("Last Import", style="dim")
+
+        for t in tables:
+            size_mb = t["data_size_bytes"] / (1024 * 1024) if t["data_size_bytes"] else 0
+            last_import = t.get("last_import_date", "")
+            if last_import and "T" in last_import:
+                last_import = last_import.split("T")[0]
+            table.add_row(
+                t["id"],
+                str(t["rows_count"]),
+                f"{size_mb:.1f} MB",
+                last_import,
+            )
+
+        formatter.console.print(table)
+
+
 @storage_app.command("table-detail", rich_help_panel=_TABLES)
 def storage_table_detail(
     ctx: typer.Context,
@@ -604,75 +673,6 @@ def storage_download_table(
         )
 
 
-@storage_app.command("tables", rich_help_panel=_TABLES)
-def storage_tables(
-    ctx: typer.Context,
-    project: str = typer.Option(
-        ...,
-        "--project",
-        help="Project alias",
-    ),
-    bucket_id: str | None = typer.Option(
-        None,
-        "--bucket-id",
-        help="Filter tables by bucket ID",
-    ),
-    branch: int | None = typer.Option(
-        None,
-        "--branch",
-        help="Dev branch ID (defaults to active branch if set via 'branch use')",
-    ),
-) -> None:
-    """List storage tables from a project."""
-    formatter = get_formatter(ctx)
-    service = get_service(ctx, "storage_service")
-    config_store: ConfigStore = ctx.obj["config_store"]
-    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
-
-    try:
-        result = service.list_tables(
-            alias=project,
-            bucket_id=bucket_id,
-            branch_id=effective_branch,
-        )
-    except ConfigError as exc:
-        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
-        raise typer.Exit(code=5) from None
-    except KeboolaApiError as exc:
-        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
-        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
-
-    if formatter.json_mode:
-        formatter.output(result)
-    else:
-        from rich.table import Table
-
-        tables = result["tables"]
-        if not tables:
-            formatter.console.print("[dim]No tables found.[/dim]")
-            return
-
-        table = Table(title=f"Tables - {result['project_alias']}")
-        table.add_column("Table ID", style="bold cyan")
-        table.add_column("Rows", justify="right")
-        table.add_column("Size", justify="right", style="dim")
-        table.add_column("Last Import", style="dim")
-
-        for t in tables:
-            size_mb = t["data_size_bytes"] / (1024 * 1024) if t["data_size_bytes"] else 0
-            last_import = t.get("last_import_date", "")
-            if last_import and "T" in last_import:
-                last_import = last_import.split("T")[0]
-            table.add_row(
-                t["id"],
-                str(t["rows_count"]),
-                f"{size_mb:.1f} MB",
-                last_import,
-            )
-
-        formatter.console.print(table)
-
-
 @storage_app.command("delete-table", rich_help_panel=_TABLES)
 def storage_delete_table(
     ctx: typer.Context,
@@ -859,7 +859,7 @@ def _format_file_size(size_bytes: int | None) -> str:
     return f"{size_bytes / (1024 * 1024 * 1024):.2f} GB"
 
 
-@storage_app.command("file-list", rich_help_panel=_FILES)
+@storage_app.command("files", rich_help_panel=_FILES)
 def storage_file_list(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -952,6 +952,53 @@ def storage_file_list(
             )
 
         formatter.console.print(table)
+
+
+@storage_app.command("file-detail", rich_help_panel=_FILES)
+def storage_file_info(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: int = typer.Option(
+        ...,
+        "--file-id",
+        help="Storage file ID",
+    ),
+) -> None:
+    """Show Storage File metadata (without downloading)."""
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    try:
+        result = service.get_file_info(alias=project, file_id=file_id)
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        formatter.console.print(f"[bold]File ID:[/bold] {result.get('id')}")
+        formatter.console.print(f"[bold]Name:[/bold] {result.get('name')}")
+        formatter.console.print(f"[bold]Size:[/bold] {_format_file_size(result.get('sizeBytes'))}")
+        formatter.console.print(f"[bold]Created:[/bold] {result.get('created', '')}")
+        formatter.console.print(f"[bold]Sliced:[/bold] {'yes' if result.get('isSliced') else 'no'}")
+        formatter.console.print(
+            f"[bold]Permanent:[/bold] {'yes' if result.get('isPermanent') else 'no'}"
+        )
+        tags_str = ", ".join(result.get("tags", []))
+        formatter.console.print(f"[bold]Tags:[/bold] {tags_str or '(none)'}")
+        creator = result.get("creatorToken", {})
+        if isinstance(creator, dict):
+            formatter.console.print(
+                f"[bold]Creator:[/bold] {creator.get('description', 'unknown')}"
+            )
 
 
 @storage_app.command("file-upload", rich_help_panel=_FILES)
@@ -1111,113 +1158,6 @@ def storage_file_download(
         )
 
 
-@storage_app.command("file-info", rich_help_panel=_FILES)
-def storage_file_info(
-    ctx: typer.Context,
-    project: str = typer.Option(
-        ...,
-        "--project",
-        help="Project alias",
-    ),
-    file_id: int = typer.Option(
-        ...,
-        "--file-id",
-        help="Storage file ID",
-    ),
-) -> None:
-    """Show Storage File metadata (without downloading)."""
-    formatter = get_formatter(ctx)
-    service = get_service(ctx, "storage_service")
-
-    try:
-        result = service.get_file_info(alias=project, file_id=file_id)
-    except ConfigError as exc:
-        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
-        raise typer.Exit(code=5) from None
-    except KeboolaApiError as exc:
-        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
-        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
-
-    if formatter.json_mode:
-        formatter.output(result)
-    else:
-        formatter.console.print(f"[bold]File ID:[/bold] {result.get('id')}")
-        formatter.console.print(f"[bold]Name:[/bold] {result.get('name')}")
-        formatter.console.print(f"[bold]Size:[/bold] {_format_file_size(result.get('sizeBytes'))}")
-        formatter.console.print(f"[bold]Created:[/bold] {result.get('created', '')}")
-        formatter.console.print(f"[bold]Sliced:[/bold] {'yes' if result.get('isSliced') else 'no'}")
-        formatter.console.print(
-            f"[bold]Permanent:[/bold] {'yes' if result.get('isPermanent') else 'no'}"
-        )
-        tags_str = ", ".join(result.get("tags", []))
-        formatter.console.print(f"[bold]Tags:[/bold] {tags_str or '(none)'}")
-        creator = result.get("creatorToken", {})
-        if isinstance(creator, dict):
-            formatter.console.print(
-                f"[bold]Creator:[/bold] {creator.get('description', 'unknown')}"
-            )
-
-
-@storage_app.command("file-delete", rich_help_panel=_FILES)
-def storage_file_delete(
-    ctx: typer.Context,
-    project: str = typer.Option(
-        ...,
-        "--project",
-        help="Project alias",
-    ),
-    file_id: list[int] = typer.Option(
-        ...,
-        "--file-id",
-        help="Storage file ID to delete (repeat for multiple)",
-    ),
-    dry_run: bool = typer.Option(
-        False,
-        "--dry-run",
-        help="Show what would be deleted without executing",
-    ),
-    yes: bool = typer.Option(
-        False,
-        "--yes",
-        "-y",
-        help="Skip confirmation prompt",
-    ),
-) -> None:
-    """Delete one or more Storage Files."""
-    formatter = get_formatter(ctx)
-    service = get_service(ctx, "storage_service")
-
-    try:
-        result = service.delete_files(
-            alias=project,
-            file_ids=file_id,
-            dry_run=dry_run,
-        )
-    except ConfigError as exc:
-        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
-        raise typer.Exit(code=5) from None
-    except KeboolaApiError as exc:
-        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
-        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
-
-    if formatter.json_mode:
-        formatter.output(result)
-    else:
-        if dry_run:
-            for fid in result.get("would_delete", []):
-                formatter.console.print(f"[bold blue]Would delete:[/bold blue] file ID {fid}")
-        else:
-            for fid in result["deleted"]:
-                formatter.console.print(f"[bold green]Deleted:[/bold green] file ID {fid}")
-        for f_err in result["failed"]:
-            formatter.console.print(
-                f"[bold red]Failed:[/bold red] file ID {f_err['id']}: {f_err['error']}"
-            )
-
-    if result["failed"]:
-        raise typer.Exit(code=1)
-
-
 @storage_app.command("file-tag", rich_help_panel=_FILES)
 def storage_file_tag(
     ctx: typer.Context,
@@ -1283,6 +1223,66 @@ def storage_file_tag(
             )
 
     if result["errors"]:
+        raise typer.Exit(code=1)
+
+
+@storage_app.command("file-delete", rich_help_panel=_FILES)
+def storage_file_delete(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    file_id: list[int] = typer.Option(
+        ...,
+        "--file-id",
+        help="Storage file ID to delete (repeat for multiple)",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be deleted without executing",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Delete one or more Storage Files."""
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+
+    try:
+        result = service.delete_files(
+            alias=project,
+            file_ids=file_id,
+            dry_run=dry_run,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        if dry_run:
+            for fid in result.get("would_delete", []):
+                formatter.console.print(f"[bold blue]Would delete:[/bold blue] file ID {fid}")
+        else:
+            for fid in result["deleted"]:
+                formatter.console.print(f"[bold green]Deleted:[/bold green] file ID {fid}")
+        for f_err in result["failed"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] file ID {f_err['id']}: {f_err['error']}"
+            )
+
+    if result["failed"]:
         raise typer.Exit(code=1)
 
 

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -19,7 +19,12 @@ from ._helpers import (
     resolve_branch,
 )
 
-storage_app = typer.Typer(help="Browse and manage storage buckets and tables")
+storage_app = typer.Typer(help="Browse and manage storage buckets, tables, and files")
+
+# Rich help panel names for grouping in --help output
+_BUCKETS = "Buckets"
+_TABLES = "Tables"
+_FILES = "Files"
 
 
 @storage_app.callback(invoke_without_command=True)
@@ -27,7 +32,7 @@ def _storage_permission_check(ctx: typer.Context) -> None:
     check_cli_permission(ctx, "storage")
 
 
-@storage_app.command("buckets")
+@storage_app.command("buckets", rich_help_panel=_BUCKETS)
 def storage_buckets(
     ctx: typer.Context,
     project: list[str] | None = typer.Option(
@@ -110,7 +115,7 @@ def storage_buckets(
         emit_project_warnings(formatter, result)
 
 
-@storage_app.command("bucket-detail")
+@storage_app.command("bucket-detail", rich_help_panel=_BUCKETS)
 def storage_bucket_detail(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -195,7 +200,7 @@ def storage_bucket_detail(
                 )
 
 
-@storage_app.command("table-detail")
+@storage_app.command("table-detail", rich_help_panel=_TABLES)
 def storage_table_detail(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -266,7 +271,7 @@ def storage_table_detail(
             formatter.console.print(table)
 
 
-@storage_app.command("create-bucket")
+@storage_app.command("create-bucket", rich_help_panel=_BUCKETS)
 def storage_create_bucket(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -335,7 +340,7 @@ def storage_create_bucket(
             formatter.console.print(f"  Description: {result['description']}")
 
 
-@storage_app.command("create-table")
+@storage_app.command("create-table", rich_help_panel=_TABLES)
 def storage_create_table(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -406,7 +411,7 @@ def storage_create_table(
         formatter.console.print(f"  Columns: {', '.join(result['columns'])}")
 
 
-@storage_app.command("upload-table")
+@storage_app.command("upload-table", rich_help_panel=_TABLES)
 def storage_upload_table(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -516,7 +521,7 @@ def storage_upload_table(
                 formatter.console.print(f"  [yellow]Warning:[/yellow] {w}")
 
 
-@storage_app.command("download-table")
+@storage_app.command("download-table", rich_help_panel=_TABLES)
 def storage_download_table(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -599,7 +604,7 @@ def storage_download_table(
         )
 
 
-@storage_app.command("tables")
+@storage_app.command("tables", rich_help_panel=_TABLES)
 def storage_tables(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -668,7 +673,7 @@ def storage_tables(
         formatter.console.print(table)
 
 
-@storage_app.command("delete-table")
+@storage_app.command("delete-table", rich_help_panel=_TABLES)
 def storage_delete_table(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -759,7 +764,7 @@ def storage_delete_table(
         raise typer.Exit(code=1)
 
 
-@storage_app.command("delete-bucket")
+@storage_app.command("delete-bucket", rich_help_panel=_BUCKETS)
 def storage_delete_bucket(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -854,7 +859,7 @@ def _format_file_size(size_bytes: int | None) -> str:
     return f"{size_bytes / (1024 * 1024 * 1024):.2f} GB"
 
 
-@storage_app.command("file-list")
+@storage_app.command("file-list", rich_help_panel=_FILES)
 def storage_file_list(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -949,7 +954,7 @@ def storage_file_list(
         formatter.console.print(table)
 
 
-@storage_app.command("file-upload")
+@storage_app.command("file-upload", rich_help_panel=_FILES)
 def storage_file_upload(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -1033,7 +1038,7 @@ def storage_file_upload(
             formatter.console.print("  Permanent: yes")
 
 
-@storage_app.command("file-download")
+@storage_app.command("file-download", rich_help_panel=_FILES)
 def storage_file_download(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -1106,7 +1111,7 @@ def storage_file_download(
         )
 
 
-@storage_app.command("file-info")
+@storage_app.command("file-info", rich_help_panel=_FILES)
 def storage_file_info(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -1153,7 +1158,7 @@ def storage_file_info(
             )
 
 
-@storage_app.command("file-delete")
+@storage_app.command("file-delete", rich_help_panel=_FILES)
 def storage_file_delete(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -1213,7 +1218,7 @@ def storage_file_delete(
         raise typer.Exit(code=1)
 
 
-@storage_app.command("file-tag")
+@storage_app.command("file-tag", rich_help_panel=_FILES)
 def storage_file_tag(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -1281,7 +1286,7 @@ def storage_file_tag(
         raise typer.Exit(code=1)
 
 
-@storage_app.command("load-file")
+@storage_app.command("load-file", rich_help_panel=_FILES)
 def storage_load_file(
     ctx: typer.Context,
     project: str = typer.Option(
@@ -1366,7 +1371,7 @@ def storage_load_file(
             formatter.console.print(f"  [yellow]Warning:[/yellow] {w}")
 
 
-@storage_app.command("unload-table")
+@storage_app.command("unload-table", rich_help_panel=_FILES)
 def storage_unload_table(
     ctx: typer.Context,
     project: str = typer.Option(

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -74,8 +74,8 @@ OPERATION_REGISTRY: dict[str, str] = {
     "storage.create-table": "write",
     "storage.upload-table": "write",
     # Storage files
-    "storage.file-list": "read",
-    "storage.file-info": "read",
+    "storage.files": "read",
+    "storage.file-detail": "read",
     "storage.file-download": "read",
     "storage.file-upload": "write",
     "storage.file-tag": "write",

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -73,9 +73,18 @@ OPERATION_REGISTRY: dict[str, str] = {
     "storage.create-bucket": "write",
     "storage.create-table": "write",
     "storage.upload-table": "write",
+    # Storage files
+    "storage.file-list": "read",
+    "storage.file-info": "read",
+    "storage.file-download": "read",
+    "storage.file-upload": "write",
+    "storage.file-tag": "write",
+    "storage.load-file": "write",
+    "storage.unload-table": "read",
     # Storage destructive
     "storage.delete-table": "destructive",
     "storage.delete-bucket": "destructive",
+    "storage.file-delete": "destructive",
     # Encryption
     "encrypt.values": "write",
     # Sync / git workflow

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -791,6 +791,453 @@ class StorageService(BaseService):
         return result
 
     # ------------------------------------------------------------------
+    # File operations
+    # ------------------------------------------------------------------
+
+    def list_files(
+        self,
+        alias: str,
+        limit: int = 20,
+        offset: int = 0,
+        tags: list[str] | None = None,
+        since_id: int | None = None,
+        query: str | None = None,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """List Storage Files from a project.
+
+        Args:
+            alias: Project alias.
+            limit: Max number of files.
+            offset: Pagination offset.
+            tags: Filter by tags (AND logic).
+            since_id: Return only files newer than this ID.
+            query: Full-text search on file name.
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with project_alias and list of files.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            files = client.list_files(
+                limit=limit,
+                offset=offset,
+                tags=tags,
+                since_id=since_id,
+                query=query,
+                branch_id=branch_id,
+            )
+        finally:
+            client.close()
+
+        return {
+            "project_alias": alias,
+            "files": files,
+            "count": len(files),
+        }
+
+    def upload_file(
+        self,
+        alias: str,
+        file_path: str,
+        name: str | None = None,
+        tags: list[str] | None = None,
+        is_permanent: bool = False,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Upload a local file to Storage Files.
+
+        Args:
+            alias: Project alias.
+            file_path: Local path to the file.
+            name: Custom filename (defaults to local basename).
+            tags: Optional list of tags.
+            is_permanent: If True, file is not auto-deleted.
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with file metadata.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        file_size_bytes = Path(file_path).stat().st_size
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            result = client.upload_file(
+                file_path=file_path,
+                name=name,
+                tags=tags,
+                is_permanent=is_permanent,
+                branch_id=branch_id,
+            )
+        finally:
+            client.close()
+
+        result["project_alias"] = alias
+        result["file_size_bytes"] = file_size_bytes
+        return result
+
+    def get_file_info(
+        self,
+        alias: str,
+        file_id: int,
+    ) -> dict[str, Any]:
+        """Get Storage File metadata.
+
+        Args:
+            alias: Project alias.
+            file_id: Storage file ID.
+
+        Returns:
+            File resource dict.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            file_info = client.get_file_info(file_id)
+        finally:
+            client.close()
+
+        file_info["project_alias"] = alias
+        return file_info
+
+    def download_file(
+        self,
+        alias: str,
+        file_id: int | None = None,
+        tags: list[str] | None = None,
+        output_path: str | None = None,
+    ) -> dict[str, Any]:
+        """Download a Storage File to local disk.
+
+        Supports download by file ID or by tags (downloads latest matching file).
+        Handles both sliced and non-sliced files.
+
+        Args:
+            alias: Project alias.
+            file_id: Storage file ID (mutually exclusive with tags).
+            tags: Download latest file matching these tags.
+            output_path: Local output path (defaults to file's name).
+
+        Returns:
+            Dict with download metadata.
+        """
+        from ..errors import KeboolaApiError
+
+        if not file_id and not tags:
+            raise ValueError("Either --file-id or --tag must be provided")
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            # Resolve file ID from tags if needed
+            if not file_id:
+                files = client.list_files(limit=1, tags=tags)
+                if not files:
+                    tag_str = ", ".join(tags or [])
+                    raise KeboolaApiError(
+                        message=f"No files found matching tags: {tag_str}",
+                        status_code=404,
+                        error_code="FILE_NOT_FOUND",
+                        retryable=False,
+                    )
+                file_id = files[0]["id"]
+
+            file_detail = client.get_file_info(file_id)
+            file_name = file_detail.get("name", f"file_{file_id}")
+            effective_output = output_path or file_name
+
+            if file_detail.get("isSliced"):
+                bytes_written = client.download_sliced_file(file_detail, effective_output)
+            else:
+                download_url = file_detail.get("url")
+                if not download_url:
+                    raise KeboolaApiError(
+                        message=f"No download URL for file {file_id}",
+                        status_code=500,
+                        error_code="FILE_NO_URL",
+                        retryable=False,
+                    )
+                bytes_written = client.download_file(download_url, effective_output)
+        finally:
+            client.close()
+
+        return {
+            "project_alias": alias,
+            "file_id": file_id,
+            "file_name": file_name,
+            "output_path": str(Path(effective_output).resolve()),
+            "file_size_bytes": bytes_written,
+            "is_sliced": file_detail.get("isSliced", False),
+        }
+
+    def delete_files(
+        self,
+        alias: str,
+        file_ids: list[int],
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Delete one or more Storage Files.
+
+        Batch-tolerant: accumulates errors per file.
+
+        Args:
+            alias: Project alias.
+            file_ids: List of file IDs to delete.
+            dry_run: If True, only report what would be deleted.
+
+        Returns:
+            Dict with deleted, failed, dry_run lists.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        deleted: list[int] = []
+        failed: list[dict[str, Any]] = []
+        would_delete: list[int] = []
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            for fid in file_ids:
+                if dry_run:
+                    would_delete.append(fid)
+                    continue
+                try:
+                    client.delete_file(fid)
+                    deleted.append(fid)
+                except KeboolaApiError as exc:
+                    failed.append({"id": fid, "error": exc.message})
+        finally:
+            client.close()
+
+        result: dict[str, Any] = {
+            "project_alias": alias,
+            "deleted": deleted,
+            "failed": failed,
+            "dry_run": dry_run,
+        }
+        if dry_run:
+            result["would_delete"] = would_delete
+        return result
+
+    def tag_file(
+        self,
+        alias: str,
+        file_id: int,
+        add_tags: list[str] | None = None,
+        remove_tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Add and/or remove tags on a Storage File.
+
+        Args:
+            alias: Project alias.
+            file_id: Storage file ID.
+            add_tags: Tags to add.
+            remove_tags: Tags to remove.
+
+        Returns:
+            Dict with operation results.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        added: list[str] = []
+        removed: list[str] = []
+        errors: list[dict[str, str]] = []
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            for tag in add_tags or []:
+                try:
+                    client.tag_file(file_id, tag)
+                    added.append(tag)
+                except KeboolaApiError as exc:
+                    errors.append({"tag": tag, "action": "add", "error": exc.message})
+
+            for tag in remove_tags or []:
+                try:
+                    client.untag_file(file_id, tag)
+                    removed.append(tag)
+                except KeboolaApiError as exc:
+                    errors.append({"tag": tag, "action": "remove", "error": exc.message})
+        finally:
+            client.close()
+
+        return {
+            "project_alias": alias,
+            "file_id": file_id,
+            "added": added,
+            "removed": removed,
+            "errors": errors,
+        }
+
+    def load_file_to_table(
+        self,
+        alias: str,
+        file_id: int,
+        table_id: str,
+        incremental: bool = False,
+        delimiter: str = ",",
+        enclosure: str = '"',
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Load an existing Storage File into a table.
+
+        Triggers import-async with dataFileId. Useful for importing files
+        that are already in Storage (uploaded by components or file-upload).
+
+        Args:
+            alias: Project alias.
+            file_id: Storage file ID to import.
+            table_id: Target table ID.
+            incremental: Append rows (True) or full load (False).
+            delimiter: CSV column delimiter.
+            enclosure: CSV value enclosure character.
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with import results.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            job = client.import_table_async(
+                table_id=table_id,
+                file_id=file_id,
+                incremental=incremental,
+                delimiter=delimiter,
+                enclosure=enclosure,
+                branch_id=branch_id,
+            )
+        finally:
+            client.close()
+
+        results = job.get("results", {})
+        return {
+            "project_alias": alias,
+            "file_id": file_id,
+            "table_id": table_id,
+            "incremental": incremental,
+            "imported_rows": results.get("importedRowsCount"),
+            "warnings": results.get("warnings", []),
+        }
+
+    def unload_table_to_file(
+        self,
+        alias: str,
+        table_id: str,
+        columns: list[str] | None = None,
+        limit: int | None = None,
+        tags: list[str] | None = None,
+        download: bool = False,
+        output_path: str | None = None,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Export a table to a Storage File.
+
+        Creates a file in Storage that can be downloaded or used by other
+        components. Optionally tags the output file and downloads it locally.
+
+        Args:
+            alias: Project alias.
+            table_id: Table ID to export.
+            columns: Optional list of column names.
+            limit: Optional max rows.
+            tags: Tags to apply to the exported file.
+            download: If True, also download the file locally.
+            output_path: Local output path (only used when download=True).
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with export metadata and file info.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            # Step 1: Export table async
+            job = client.export_table_async(
+                table_id=table_id,
+                columns=columns,
+                limit=limit,
+                branch_id=branch_id,
+            )
+
+            # Step 2: Get file ID from job results
+            file_info = job.get("results", {}).get("file", {})
+            file_id = file_info.get("id")
+            if not file_id:
+                raise KeboolaApiError(
+                    message="Export job completed but no file ID in results",
+                    status_code=500,
+                    error_code="EXPORT_NO_FILE",
+                    retryable=False,
+                )
+
+            # Step 3: Tag the exported file
+            for tag in tags or []:
+                client.tag_file(file_id, tag)
+
+            # Step 4: Get full file detail
+            file_detail = client.get_file_info(file_id)
+
+            result: dict[str, Any] = {
+                "project_alias": alias,
+                "table_id": table_id,
+                "file_id": file_id,
+                "file_name": file_detail.get("name"),
+                "file_size_bytes": file_detail.get("sizeBytes"),
+                "is_sliced": file_detail.get("isSliced", False),
+                "tags": file_detail.get("tags", []),
+            }
+
+            # Step 5: Download if requested
+            if download:
+                effective_output = output_path or f"{table_id.rsplit('.', 1)[-1]}.csv"
+
+                if file_detail.get("isSliced"):
+                    bytes_written = client.download_sliced_file(file_detail, effective_output)
+                else:
+                    download_url = file_detail.get("url")
+                    if not download_url:
+                        raise KeboolaApiError(
+                            message=f"No download URL for file {file_id}",
+                            status_code=500,
+                            error_code="FILE_NO_URL",
+                            retryable=False,
+                        )
+                    bytes_written = client.download_file(download_url, effective_output)
+
+                result["downloaded"] = True
+                result["output_path"] = str(Path(effective_output).resolve())
+                result["downloaded_bytes"] = bytes_written
+            else:
+                result["downloaded"] = False
+        finally:
+            client.close()
+
+        return result
+
+    # ------------------------------------------------------------------
     # Parallel workers
     # ------------------------------------------------------------------
 

--- a/tests/test_storage_files.py
+++ b/tests/test_storage_files.py
@@ -1,0 +1,1073 @@
+"""Tests for Storage Files commands and service methods.
+
+Covers: file-list, file-upload, file-download, file-info,
+file-delete, file-tag, load-file, unload-table.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import KeboolaApiError
+from keboola_agent_cli.models import AppConfig, ProjectConfig
+from keboola_agent_cli.services.storage_service import StorageService
+
+runner = CliRunner()
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+SAMPLE_FILE = {
+    "id": 12345,
+    "name": "test-data.csv",
+    "sizeBytes": 1024,
+    "created": "2026-04-12T10:00:00+0000",
+    "isSliced": False,
+    "isPermanent": False,
+    "tags": ["report", "monthly"],
+    "creatorToken": {"id": 1, "description": "My Token"},
+    "url": "https://storage.example.com/files/test-data.csv",
+}
+
+
+def _make_store(tmp_path: Path) -> ConfigStore:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    store = ConfigStore(config_dir=config_dir)
+    config = AppConfig(
+        projects={
+            "test": ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            )
+        },
+    )
+    store.save(config)
+    return store
+
+
+def _make_service(store: ConfigStore, mock_client: MagicMock) -> StorageService:
+    return StorageService(
+        config_store=store,
+        client_factory=lambda url, token: mock_client,
+    )
+
+
+# ------------------------------------------------------------------
+# Service layer tests
+# ------------------------------------------------------------------
+
+
+class TestListFilesService:
+    """Tests for StorageService.list_files()."""
+
+    def test_list_files_basic(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.list_files.return_value = [SAMPLE_FILE]
+        service = _make_service(store, mock_client)
+
+        result = service.list_files(alias="test")
+
+        assert result["project_alias"] == "test"
+        assert result["count"] == 1
+        assert result["files"][0]["id"] == 12345
+        mock_client.list_files.assert_called_once_with(
+            limit=20, offset=0, tags=None, since_id=None, query=None, branch_id=None
+        )
+
+    def test_list_files_with_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.list_files.return_value = [SAMPLE_FILE]
+        service = _make_service(store, mock_client)
+
+        service.list_files(alias="test", tags=["report", "monthly"])
+
+        mock_client.list_files.assert_called_once_with(
+            limit=20,
+            offset=0,
+            tags=["report", "monthly"],
+            since_id=None,
+            query=None,
+            branch_id=None,
+        )
+
+    def test_list_files_empty(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.list_files.return_value = []
+        service = _make_service(store, mock_client)
+
+        result = service.list_files(alias="test")
+
+        assert result["count"] == 0
+        assert result["files"] == []
+
+
+class TestUploadFileService:
+    """Tests for StorageService.upload_file()."""
+
+    def test_upload_file_success(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.upload_file.return_value = {
+            "id": 99,
+            "name": "data.csv",
+            "sizeBytes": 512,
+            "tags": ["test"],
+            "isPermanent": False,
+            "created": "2026-04-12T10:00:00+0000",
+        }
+        service = _make_service(store, mock_client)
+
+        # Create a test file
+        test_file = tmp_path / "data.csv"
+        test_file.write_text("col1,col2\na,b\n")
+
+        result = service.upload_file(
+            alias="test",
+            file_path=str(test_file),
+            tags=["test"],
+        )
+
+        assert result["id"] == 99
+        assert result["project_alias"] == "test"
+        mock_client.upload_file.assert_called_once()
+
+    def test_upload_file_with_custom_name(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.upload_file.return_value = {
+            "id": 100,
+            "name": "custom-name.csv",
+            "sizeBytes": 512,
+            "tags": [],
+            "isPermanent": True,
+            "created": "2026-04-12T10:00:00+0000",
+        }
+        service = _make_service(store, mock_client)
+
+        test_file = tmp_path / "tmp.csv"
+        test_file.write_text("col1\na\n")
+
+        result = service.upload_file(
+            alias="test",
+            file_path=str(test_file),
+            name="custom-name.csv",
+            is_permanent=True,
+        )
+
+        assert result["id"] == 100
+        call_kwargs = mock_client.upload_file.call_args[1]
+        assert call_kwargs["name"] == "custom-name.csv"
+        assert call_kwargs["is_permanent"] is True
+
+
+class TestDownloadFileService:
+    """Tests for StorageService.download_file()."""
+
+    def test_download_by_id(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_file_info.return_value = {
+            **SAMPLE_FILE,
+            "isSliced": False,
+        }
+        mock_client.download_file.return_value = 1024
+        service = _make_service(store, mock_client)
+
+        result = service.download_file(
+            alias="test",
+            file_id=12345,
+            output_path=str(tmp_path / "out.csv"),
+        )
+
+        assert result["file_id"] == 12345
+        assert result["file_size_bytes"] == 1024
+        mock_client.download_file.assert_called_once()
+
+    def test_download_by_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.list_files.return_value = [SAMPLE_FILE]
+        mock_client.get_file_info.return_value = {
+            **SAMPLE_FILE,
+            "isSliced": False,
+        }
+        mock_client.download_file.return_value = 1024
+        service = _make_service(store, mock_client)
+
+        result = service.download_file(
+            alias="test",
+            tags=["report"],
+            output_path=str(tmp_path / "out.csv"),
+        )
+
+        assert result["file_id"] == 12345
+        mock_client.list_files.assert_called_once_with(limit=1, tags=["report"])
+
+    def test_download_by_tags_no_match(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.list_files.return_value = []
+        service = _make_service(store, mock_client)
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            service.download_file(alias="test", tags=["nonexistent"])
+
+        assert exc_info.value.error_code == "FILE_NOT_FOUND"
+
+    def test_download_sliced_file(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_file_info.return_value = {
+            **SAMPLE_FILE,
+            "isSliced": True,
+        }
+        mock_client.download_sliced_file.return_value = 2048
+        service = _make_service(store, mock_client)
+
+        result = service.download_file(
+            alias="test",
+            file_id=12345,
+            output_path=str(tmp_path / "out.csv"),
+        )
+
+        assert result["is_sliced"] is True
+        assert result["file_size_bytes"] == 2048
+        mock_client.download_sliced_file.assert_called_once()
+
+    def test_download_requires_id_or_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        with pytest.raises(ValueError, match="Either --file-id or --tag"):
+            service.download_file(alias="test")
+
+
+class TestGetFileInfoService:
+    """Tests for StorageService.get_file_info()."""
+
+    def test_get_file_info(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_file_info.return_value = SAMPLE_FILE.copy()
+        service = _make_service(store, mock_client)
+
+        result = service.get_file_info(alias="test", file_id=12345)
+
+        assert result["id"] == 12345
+        assert result["project_alias"] == "test"
+
+
+class TestDeleteFilesService:
+    """Tests for StorageService.delete_files()."""
+
+    def test_delete_single(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.delete_files(alias="test", file_ids=[12345])
+
+        assert result["deleted"] == [12345]
+        assert result["failed"] == []
+
+    def test_delete_dry_run(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.delete_files(alias="test", file_ids=[12345], dry_run=True)
+
+        assert result["would_delete"] == [12345]
+        assert result["deleted"] == []
+        mock_client.delete_file.assert_not_called()
+
+    def test_delete_partial_failure(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_file.side_effect = [
+            None,
+            KeboolaApiError("Not found", status_code=404, error_code="NOT_FOUND"),
+        ]
+        service = _make_service(store, mock_client)
+
+        result = service.delete_files(alias="test", file_ids=[100, 200])
+
+        assert result["deleted"] == [100]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["id"] == 200
+
+
+class TestTagFileService:
+    """Tests for StorageService.tag_file()."""
+
+    def test_add_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.tag_file(alias="test", file_id=12345, add_tags=["report", "2026"])
+
+        assert result["added"] == ["report", "2026"]
+        assert mock_client.tag_file.call_count == 2
+
+    def test_remove_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.tag_file(alias="test", file_id=12345, remove_tags=["draft"])
+
+        assert result["removed"] == ["draft"]
+        mock_client.untag_file.assert_called_once_with(12345, "draft")
+
+    def test_add_and_remove(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.tag_file(
+            alias="test",
+            file_id=12345,
+            add_tags=["final"],
+            remove_tags=["draft"],
+        )
+
+        assert result["added"] == ["final"]
+        assert result["removed"] == ["draft"]
+
+    def test_tag_error_accumulated(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.tag_file.side_effect = KeboolaApiError(
+            "Failed", status_code=400, error_code="BAD_REQUEST"
+        )
+        service = _make_service(store, mock_client)
+
+        result = service.tag_file(alias="test", file_id=12345, add_tags=["bad"])
+
+        assert result["added"] == []
+        assert len(result["errors"]) == 1
+
+
+class TestLoadFileToTableService:
+    """Tests for StorageService.load_file_to_table()."""
+
+    def test_load_success(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.import_table_async.return_value = {
+            "results": {"importedRowsCount": 100, "warnings": []},
+        }
+        service = _make_service(store, mock_client)
+
+        result = service.load_file_to_table(alias="test", file_id=12345, table_id="in.c-data.users")
+
+        assert result["imported_rows"] == 100
+        assert result["file_id"] == 12345
+        assert result["table_id"] == "in.c-data.users"
+        mock_client.import_table_async.assert_called_once_with(
+            table_id="in.c-data.users",
+            file_id=12345,
+            incremental=False,
+            delimiter=",",
+            enclosure='"',
+            branch_id=None,
+        )
+
+    def test_load_incremental(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.import_table_async.return_value = {
+            "results": {"importedRowsCount": 50, "warnings": []},
+        }
+        service = _make_service(store, mock_client)
+
+        result = service.load_file_to_table(
+            alias="test",
+            file_id=12345,
+            table_id="in.c-data.users",
+            incremental=True,
+        )
+
+        assert result["incremental"] is True
+        call_kwargs = mock_client.import_table_async.call_args[1]
+        assert call_kwargs["incremental"] is True
+
+
+class TestUnloadTableToFileService:
+    """Tests for StorageService.unload_table_to_file()."""
+
+    def test_unload_without_download(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 99}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 99,
+            "name": "export.csv.gz",
+            "sizeBytes": 2048,
+            "isSliced": False,
+            "tags": [],
+        }
+        service = _make_service(store, mock_client)
+
+        result = service.unload_table_to_file(alias="test", table_id="in.c-data.users")
+
+        assert result["file_id"] == 99
+        assert result["downloaded"] is False
+        mock_client.download_file.assert_not_called()
+
+    def test_unload_with_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 99}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 99,
+            "name": "export.csv.gz",
+            "sizeBytes": 2048,
+            "isSliced": False,
+            "tags": ["export", "daily"],
+        }
+        service = _make_service(store, mock_client)
+
+        service.unload_table_to_file(
+            alias="test",
+            table_id="in.c-data.users",
+            tags=["export", "daily"],
+        )
+
+        assert mock_client.tag_file.call_count == 2
+        mock_client.tag_file.assert_any_call(99, "export")
+        mock_client.tag_file.assert_any_call(99, "daily")
+
+    def test_unload_with_download(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 99}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 99,
+            "name": "export.csv.gz",
+            "sizeBytes": 2048,
+            "isSliced": False,
+            "tags": [],
+            "url": "https://storage.example.com/export.csv.gz",
+        }
+        mock_client.download_file.return_value = 2048
+        service = _make_service(store, mock_client)
+
+        result = service.unload_table_to_file(
+            alias="test",
+            table_id="in.c-data.users",
+            download=True,
+            output_path=str(tmp_path / "out.csv"),
+        )
+
+        assert result["downloaded"] is True
+        assert result["downloaded_bytes"] == 2048
+        mock_client.download_file.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Client layer tests
+# ------------------------------------------------------------------
+
+
+class TestClientListFiles:
+    """Tests for KeboolaClient.list_files()."""
+
+    def test_list_files_basic(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/files?limit=20&offset=0",
+            json=[SAMPLE_FILE],
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        result = client.list_files()
+        assert len(result) == 1
+        assert result[0]["id"] == 12345
+        client.close()
+
+    def test_list_files_with_tags(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(json=[SAMPLE_FILE])
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        result = client.list_files(tags=["report", "monthly"])
+        assert len(result) == 1
+
+        request = httpx_mock.get_requests()[0]
+        assert "tags%5B0%5D=report" in str(request.url)
+        assert "tags%5B1%5D=monthly" in str(request.url)
+        client.close()
+
+    def test_list_files_with_branch(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(json=[])
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.list_files(branch_id=42)
+        request = httpx_mock.get_requests()[0]
+        assert "/v2/storage/branch/42/files" in str(request.url)
+        client.close()
+
+
+class TestClientUploadFile:
+    """Tests for KeboolaClient.upload_file()."""
+
+    def test_upload_file_calls_prepare_and_cloud(self, tmp_path: Path) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("a,b\n1,2\n")
+
+        with (
+            patch.object(KeboolaClient, "prepare_file_upload") as mock_prepare,
+            patch.object(KeboolaClient, "_upload_to_cloud") as mock_upload,
+        ):
+            mock_prepare.return_value = {
+                "id": 55,
+                "name": "test.csv",
+                "tags": ["tag1"],
+                "isPermanent": False,
+                "created": "2026-04-12T10:00:00+0000",
+            }
+
+            client = KeboolaClient(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            )
+            result = client.upload_file(
+                file_path=str(test_file),
+                tags=["tag1"],
+            )
+
+            assert result["id"] == 55
+            mock_prepare.assert_called_once()
+            mock_upload.assert_called_once()
+            client.close()
+
+
+class TestClientDeleteFile:
+    """Tests for KeboolaClient.delete_file()."""
+
+    def test_delete_file(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/files/12345",
+            method="DELETE",
+            status_code=204,
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.delete_file(12345)
+        assert len(httpx_mock.get_requests()) == 1
+        client.close()
+
+
+class TestClientTagFile:
+    """Tests for KeboolaClient.tag_file() and untag_file()."""
+
+    def test_tag_file(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/files/12345/tags",
+            method="POST",
+            status_code=201,
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.tag_file(12345, "new-tag")
+        request = httpx_mock.get_requests()[0]
+        assert b"tag=new-tag" in request.content
+        client.close()
+
+    def test_untag_file(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(
+            url="https://connection.keboola.com/v2/storage/files/12345/tags/old-tag",
+            method="DELETE",
+            status_code=204,
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.untag_file(12345, "old-tag")
+        assert len(httpx_mock.get_requests()) == 1
+        client.close()
+
+
+# ------------------------------------------------------------------
+# CLI layer tests
+# ------------------------------------------------------------------
+
+
+class TestFileListCli:
+    """Tests for `kbagent storage file-list` command."""
+
+    def test_file_list_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_files.return_value = {
+                "project_alias": "test",
+                "files": [SAMPLE_FILE],
+                "count": 1,
+            }
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "file-list", "--project", "test"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["count"] == 1
+
+    def test_file_list_with_tags(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_files.return_value = {
+                "project_alias": "test",
+                "files": [SAMPLE_FILE],
+                "count": 1,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "file-list",
+                    "--project",
+                    "test",
+                    "--tag",
+                    "report",
+                    "--tag",
+                    "monthly",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = MockSvc.return_value.list_files.call_args[1]
+        assert call_kwargs["tags"] == ["report", "monthly"]
+
+    def test_file_list_empty_human(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_files.return_value = {
+                "project_alias": "test",
+                "files": [],
+                "count": 0,
+            }
+            result = runner.invoke(
+                app,
+                ["storage", "file-list", "--project", "test"],
+            )
+
+        assert result.exit_code == 0
+        assert "No files found" in result.output
+
+
+class TestFileUploadCli:
+    """Tests for `kbagent storage file-upload` command."""
+
+    def test_file_upload_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        test_file = tmp_path / "upload.csv"
+        test_file.write_text("a,b\n1,2\n")
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.upload_file.return_value = {
+                "id": 99,
+                "name": "upload.csv",
+                "file_size_bytes": 10,
+                "tags": ["test"],
+                "isPermanent": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "file-upload",
+                    "--project",
+                    "test",
+                    "--file",
+                    str(test_file),
+                    "--tag",
+                    "test",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["id"] == 99
+
+    def test_file_upload_missing_file(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "file-upload",
+                    "--project",
+                    "test",
+                    "--file",
+                    "/nonexistent/file.csv",
+                ],
+            )
+
+        assert result.exit_code == 2
+
+
+class TestFileDownloadCli:
+    """Tests for `kbagent storage file-download` command."""
+
+    def test_file_download_by_id_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.download_file.return_value = {
+                "project_alias": "test",
+                "file_id": 12345,
+                "file_name": "data.csv",
+                "output_path": "/tmp/data.csv",
+                "file_size_bytes": 1024,
+                "is_sliced": False,
+            }
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "file-download", "--project", "test", "--file-id", "12345"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["file_id"] == 12345
+
+    def test_file_download_no_id_no_tag(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "file-download", "--project", "test"],
+            )
+
+        assert result.exit_code == 2
+
+
+class TestFileInfoCli:
+    """Tests for `kbagent storage file-info` command."""
+
+    def test_file_info_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.get_file_info.return_value = SAMPLE_FILE.copy()
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "file-info", "--project", "test", "--file-id", "12345"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["id"] == 12345
+
+    def test_file_info_human(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.get_file_info.return_value = {
+                **SAMPLE_FILE,
+                "creatorToken": {"id": 1, "description": "My Token"},
+            }
+            result = runner.invoke(
+                app,
+                ["storage", "file-info", "--project", "test", "--file-id", "12345"],
+            )
+
+        assert result.exit_code == 0
+        assert "12345" in result.output
+        assert "test-data.csv" in result.output
+
+
+class TestFileDeleteCli:
+    """Tests for `kbagent storage file-delete` command."""
+
+    def test_file_delete_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.delete_files.return_value = {
+                "project_alias": "test",
+                "deleted": [12345],
+                "failed": [],
+                "dry_run": False,
+            }
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "file-delete", "--project", "test", "--file-id", "12345"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert 12345 in data["deleted"]
+
+
+class TestFileTagCli:
+    """Tests for `kbagent storage file-tag` command."""
+
+    def test_file_tag_add(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.tag_file.return_value = {
+                "project_alias": "test",
+                "file_id": 12345,
+                "added": ["new-tag"],
+                "removed": [],
+                "errors": [],
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "file-tag",
+                    "--project",
+                    "test",
+                    "--file-id",
+                    "12345",
+                    "--add",
+                    "new-tag",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert "new-tag" in data["added"]
+
+    def test_file_tag_no_add_no_remove(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with patch("keboola_agent_cli.cli.ConfigStore") as MockStore:
+            MockStore.return_value = store
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "file-tag", "--project", "test", "--file-id", "12345"],
+            )
+
+        assert result.exit_code == 2
+
+
+class TestLoadFileCli:
+    """Tests for `kbagent storage load-file` command."""
+
+    def test_load_file_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.load_file_to_table.return_value = {
+                "project_alias": "test",
+                "file_id": 12345,
+                "table_id": "in.c-data.users",
+                "incremental": False,
+                "imported_rows": 100,
+                "warnings": [],
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "load-file",
+                    "--project",
+                    "test",
+                    "--file-id",
+                    "12345",
+                    "--table-id",
+                    "in.c-data.users",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["imported_rows"] == 100
+
+
+class TestUnloadTableCli:
+    """Tests for `kbagent storage unload-table` command."""
+
+    def test_unload_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.unload_table_to_file.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+                "file_id": 99,
+                "file_name": "export.csv",
+                "file_size_bytes": 2048,
+                "is_sliced": False,
+                "tags": ["export"],
+                "downloaded": False,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "unload-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--tag",
+                    "export",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["file_id"] == 99
+        assert data["tags"] == ["export"]
+
+    def test_unload_with_download_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.unload_table_to_file.return_value = {
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+                "file_id": 99,
+                "file_name": "export.csv",
+                "file_size_bytes": 2048,
+                "is_sliced": False,
+                "tags": [],
+                "downloaded": True,
+                "output_path": "/tmp/users.csv",
+                "downloaded_bytes": 2048,
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "unload-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--download",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["downloaded"] is True
+
+
+# ------------------------------------------------------------------
+# Helper function tests
+# ------------------------------------------------------------------
+
+
+class TestFormatFileSize:
+    """Tests for _format_file_size helper."""
+
+    def test_none(self) -> None:
+        from keboola_agent_cli.commands.storage import _format_file_size
+
+        assert _format_file_size(None) == "unknown"
+
+    def test_bytes(self) -> None:
+        from keboola_agent_cli.commands.storage import _format_file_size
+
+        assert _format_file_size(512) == "512 B"
+
+    def test_kilobytes(self) -> None:
+        from keboola_agent_cli.commands.storage import _format_file_size
+
+        assert _format_file_size(2048) == "2.0 KB"
+
+    def test_megabytes(self) -> None:
+        from keboola_agent_cli.commands.storage import _format_file_size
+
+        assert _format_file_size(5 * 1024 * 1024) == "5.00 MB"
+
+    def test_gigabytes(self) -> None:
+        from keboola_agent_cli.commands.storage import _format_file_size
+
+        assert _format_file_size(2 * 1024 * 1024 * 1024) == "2.00 GB"

--- a/tests/test_storage_files.py
+++ b/tests/test_storage_files.py
@@ -1,6 +1,6 @@
 """Tests for Storage Files commands and service methods.
 
-Covers: file-list, file-upload, file-download, file-info,
+Covers: files, file-upload, file-download, file-detail,
 file-delete, file-tag, load-file, unload-table.
 """
 
@@ -634,7 +634,7 @@ class TestClientTagFile:
 
 
 class TestFileListCli:
-    """Tests for `kbagent storage file-list` command."""
+    """Tests for `kbagent storage files` command."""
 
     def test_file_list_json(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -650,7 +650,7 @@ class TestFileListCli:
             }
             result = runner.invoke(
                 app,
-                ["--json", "storage", "file-list", "--project", "test"],
+                ["--json", "storage", "files", "--project", "test"],
             )
 
         assert result.exit_code == 0
@@ -674,7 +674,7 @@ class TestFileListCli:
                 [
                     "--json",
                     "storage",
-                    "file-list",
+                    "files",
                     "--project",
                     "test",
                     "--tag",
@@ -702,7 +702,7 @@ class TestFileListCli:
             }
             result = runner.invoke(
                 app,
-                ["storage", "file-list", "--project", "test"],
+                ["storage", "files", "--project", "test"],
             )
 
         assert result.exit_code == 0
@@ -809,7 +809,7 @@ class TestFileDownloadCli:
 
 
 class TestFileInfoCli:
-    """Tests for `kbagent storage file-info` command."""
+    """Tests for `kbagent storage file-detail` command."""
 
     def test_file_info_json(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -821,7 +821,7 @@ class TestFileInfoCli:
             MockSvc.return_value.get_file_info.return_value = SAMPLE_FILE.copy()
             result = runner.invoke(
                 app,
-                ["--json", "storage", "file-info", "--project", "test", "--file-id", "12345"],
+                ["--json", "storage", "file-detail", "--project", "test", "--file-id", "12345"],
             )
 
         assert result.exit_code == 0
@@ -841,7 +841,7 @@ class TestFileInfoCli:
             }
             result = runner.invoke(
                 app,
-                ["storage", "file-info", "--project", "test", "--file-id", "12345"],
+                ["storage", "file-detail", "--project", "test", "--file-id", "12345"],
             )
 
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- Add 8 new CLI commands for direct Storage Files API access
- **file-list**: list files with tag filtering (AND logic), pagination, full-text search
- **file-upload**: upload any file with tags and `--permanent` flag
- **file-download**: download by file ID or by tags (latest matching file)
- **file-info**: show file metadata without downloading
- **file-delete**: batch delete with dry-run support
- **file-tag**: add/remove tags in a single operation
- **load-file**: import an already-uploaded Storage File into a table
- **unload-table**: export a table to a Storage File with optional tags and download

## Implementation

- **Client layer**: `list_files`, `upload_file`, `delete_file`, `tag_file`, `untag_file` + extended `prepare_file_upload` with tags/permanent params
- **Service layer**: 8 new methods in `StorageService` with standard project resolution and error handling
- **Command layer**: 8 Typer commands with dual output (JSON + Rich), branch support, permission registration
- **Tests**: 50 new tests covering client, service, and CLI layers
- Updated CLAUDE.md command list and plugin SKILL.md decision table

## Test plan

- [ ] Run `make check` (lint + format + tests) - all 1517 tests pass
- [ ] Integration test: `file-upload` + `file-list` + `file-download` + `file-tag` + `load-file` + `unload-table` + `file-delete` against all 3 providers (AWS, GCP, Azure)

Closes #134