### PR TITLE
chore: sync uv.lock with version 0.18.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
uv.lock had stale version 0.18.3 after the version bump in #144.