### PR TITLE
chore: bump version to 0.18.5

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.18.4"
+version = "0.18.5"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,14 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.18.5": [
+        "New: --hint client|service flag -- generate Python code for any CLI command (#153)",
+        "New: kbagent as Python SDK -- import KeboolaClient or service layer in your scripts",
+        "New: 47 commands with hint support (config, storage, job, branch, workspace, sharing, tool...)",
+        "Security: escape parameter values in generated code to prevent code injection (CWE-94)",
+        "UX: commands without hints show clear 'no hint available' message",
+        "Docs: programming-with-cli.md reference guide for SDK usage",
+    ],
     "0.18.4": [
         "New: Storage Files commands -- files, file-detail, file-upload, file-download, file-tag, file-delete (#134)",
         "New: load-file -- import an uploaded Storage File into a table (#134)",

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.18.4"
+version = "0.18.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bump version 0.18.4 -> 0.18.5
- Changelog entry for `--hint` feature (#153)

## What's new in 0.18.5

- `--hint client|service` flag -- generate Python code for any CLI command
- kbagent as Python SDK -- import KeboolaClient or service layer in scripts
- 47 commands with hint support
- CWE-94 code injection prevention in generated code
- `programming-with-cli.md` reference guide