### PR TITLE
feat: config update with --set, --merge, --dry-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ src/keboola_agent_cli/
   __main__.py           # python -m support
   cli.py                # Typer root app, global options, subcommand wiring
   constants.py          # Shared constants (retry params, timeouts, defaults)
+  json_utils.py         # Deep-merge, set_nested_value, compute_diff utilities
   http_base.py          # BaseHttpClient - shared HTTP foundation for both clients
   client.py             # LAYER 3: HTTP client (Storage API + Queue API)
   manage_client.py      # LAYER 3: HTTP client (Manage API, X-KBC-ManageApiToken)
@@ -115,6 +116,8 @@ tests/
   test_org_service.py      # Org service tests (slugify, setup, idempotency)
   test_workspace_service.py # Workspace service tests (CRUD, query, from-transformation)
   test_workspace_cli.py    # Workspace CLI tests via CliRunner
+  test_json_utils.py       # Deep-merge and nested-path utility tests
+  test_config_update.py    # Config update with configuration content (merge, set, dry-run)
   test_doctor_service.py   # Doctor service tests
   test_http_base.py        # BaseHttpClient tests
   test_helpers.py          # Command helpers tests
@@ -237,6 +240,7 @@ kbagent project refresh --all [--dry-run] [--force] [--yes] [--token-description
 kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]
 kbagent config detail --project NAME --component-id ID --config-id ID [--branch ID]
 kbagent config search --query PATTERN [--project NAME] [--component-type TYPE] [--ignore-case] [--regex] [--branch ID]
+kbagent config update --project NAME --component-id ID --config-id ID [--name N] [--description D] [--configuration JSON|@file|-] [--configuration-file PATH] [--set PATH=VALUE ...] [--merge] [--dry-run] [--branch ID]
 
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -67,7 +67,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | List configurations from connected projects | `kbagent config list` |
 | Show detailed information about a specific configuration | `kbagent config detail --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | Search through configuration bodies for a string or pattern | `kbagent config search --query QUERY` |
-| Update a configuration's name and/or description | `kbagent config update --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
+| Update a configuration's metadata and/or content | `kbagent config update --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | Delete a configuration from a project | `kbagent config delete --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
 | Generate boilerplate configuration files for a Keboola component | `kbagent config new --component-id COMPONENT-ID` |
 | List jobs from connected projects | `kbagent job list` |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -29,7 +29,7 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]` -- list configs across projects (branch-aware)
 - `config detail --project NAME --component-id ID --config-id ID [--branch ID]` -- full config with parameters and rows (branch-aware)
 - `config search --query PATTERN [--project NAME] [-i] [-r] [--branch ID]` -- search config bodies for string/regex (branch-aware)
-- `config update --project NAME --component-id ID --config-id ID [--name N] [--description D]` -- update name/description
+- `config update --project NAME --component-id ID --config-id ID [--name N] [--description D] [--configuration JSON|@file|-] [--configuration-file PATH] [--set PATH=VALUE ...] [--merge] [--dry-run] [--branch ID]` -- update metadata and/or configuration content. `--set` targets a nested key (e.g. `parameters.db.host=new-host`). `--merge` deep-merges into existing config (preserves sibling keys). `--dry-run` previews changes without applying. Paths are relative to the configuration root (unlike MCP's `update_config` which uses paths relative to `parameters`)
 - `config delete --project NAME --component-id ID --config-id ID [--branch ID]` -- delete a configuration
 - `config new --component-id ID [--project NAME] [--name NAME] [--output-dir DIR]` -- scaffold new config from component schema
 

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -85,6 +85,44 @@ kbagent looks for configuration in this order:
 
 Use `kbagent init` to create a local `.kbagent/` workspace for per-directory isolation.
 
+## config update vs MCP update_config
+
+For updating configuration content, prefer `kbagent config update` over MCP's `update_config` tool:
+
+| Feature | CLI `config update` | MCP `update_config` |
+|---------|--------------------|--------------------|
+| Path reference | Configuration root (`parameters.db.host`) | Relative to `parameters` (`db.host`) |
+| Deep merge | `--merge` preserves all sibling keys | Must use correct path or risk data loss |
+| Dry-run preview | `--dry-run` shows diff without applying | Not available |
+| Performance | ~1s (direct API call) | ~3-4s (MCP subprocess overhead) |
+| Input source | Inline JSON, `@file.json`, stdin (`-`) | Inline JSON only |
+
+**Key difference**: CLI paths start from the configuration root. MCP paths are relative to
+the `parameters` object. Using `path: "parameters.tables"` in MCP actually resolves to
+`parameters.parameters.tables` (double nesting), which causes confusing failures.
+
+**When to use MCP's `update_config`**: Only for `str_replace` and `list_append` operations
+which are not available in the CLI command. For `set` operations, always prefer CLI.
+
+**Examples:**
+```bash
+# Set a single nested value (--set implies merge)
+kbagent --json config update --project P --component-id C --config-id ID \
+  --set "parameters.db.host=new-host.example.com"
+
+# Deep-merge a partial JSON (preserves all siblings)
+kbagent --json config update --project P --component-id C --config-id ID \
+  --configuration '{"parameters": {"tables": {"new": "data"}}}' --merge
+
+# Preview changes before applying
+kbagent --json config update --project P --component-id C --config-id ID \
+  --set "parameters.config.debug=false" --dry-run
+
+# Update from a file
+kbagent --json config update --project P --component-id C --config-id ID \
+  --configuration-file updated-config.json --merge
+```
+
 ## Batch size limits for update_sql_transformation
 
 When using `update_sql_transformation` with `str_replace` operations, **limit batches

--- a/src/keboola_agent_cli/commands/config.py
+++ b/src/keboola_agent_cli/commands/config.py
@@ -324,6 +324,28 @@ def config_search(
         emit_project_warnings(formatter, result)
 
 
+def _parse_json_input(raw: str) -> dict:
+    """Parse JSON from inline string, ``@file``, or ``-`` (stdin)."""
+    import sys
+
+    if raw == "-":
+        return json.loads(sys.stdin.read())
+    if raw.startswith("@"):
+        file_path = Path(raw[1:])
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Input file not found: {file_path}")
+        return json.loads(file_path.read_text(encoding="utf-8"))
+    return json.loads(raw)
+
+
+def _parse_set_value(raw: str) -> object:
+    """Try to parse *raw* as JSON; fall back to plain string."""
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+
+
 @config_app.command("update")
 def config_update(
     ctx: typer.Context,
@@ -352,19 +374,117 @@ def config_update(
         "--description",
         help="New configuration description",
     ),
+    configuration: str | None = typer.Option(
+        None,
+        "--configuration",
+        help="Configuration JSON: inline, @file.json, or - for stdin",
+    ),
+    configuration_file: Path | None = typer.Option(
+        None,
+        "--configuration-file",
+        help="Path to a JSON file with configuration content",
+        exists=True,
+        readable=True,
+    ),
+    set_values: list[str] | None = typer.Option(
+        None,
+        "--set",
+        help="Set a nested value: PATH VALUE (e.g. --set 'parameters.db.host=new-host')",
+    ),
+    merge: bool = typer.Option(
+        False,
+        "--merge",
+        help="Deep-merge into existing config instead of replacing",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would change without applying",
+    ),
     branch: int | None = typer.Option(
         None,
         "--branch",
         help="Update in a specific dev branch ID (defaults to active branch)",
     ),
 ) -> None:
-    """Update a configuration's name and/or description.
+    """Update a configuration's metadata and/or content.
 
-    If a dev branch is active (via 'branch use'), the update targets
-    that branch. Use --branch to override.
+    \b
+    Metadata options (--name, --description) update display info.
+    Content options modify the configuration JSON itself:
+      --configuration / --configuration-file : provide a full JSON blob
+      --set PATH=VALUE : set a single nested key (repeatable)
+      --merge : deep-merge into existing config (preserves sibling keys)
+      --dry-run : preview changes without applying
+
+    \b
+    Examples:
+      # Update just the name
+      kbagent config update --project P --component-id C --config-id ID --name "New name"
+
+      # Replace entire configuration from a file
+      kbagent config update --project P --component-id C --config-id ID --configuration-file config.json
+
+      # Deep-merge a partial update (preserves sibling keys!)
+      kbagent config update --project P --component-id C --config-id ID \\
+        --configuration '{"parameters": {"tables": {"new": "data"}}}' --merge
+
+      # Set a single nested value
+      kbagent config update --project P --component-id C --config-id ID \\
+        --set 'parameters.db.host=new-host.example.com'
+
+      # Preview changes without applying
+      kbagent config update --project P --component-id C --config-id ID \\
+        --set 'parameters.db.host=new-host' --dry-run
     """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "config_service")
+
+    # --- Parse configuration content ------------------------------------------
+    config_dict: dict | None = None
+    if configuration and configuration_file:
+        formatter.error(
+            message="Cannot use both --configuration and --configuration-file.",
+            error_code="VALIDATION_ERROR",
+        )
+        raise typer.Exit(code=2) from None
+
+    if configuration:
+        try:
+            config_dict = _parse_json_input(configuration)
+        except (json.JSONDecodeError, FileNotFoundError) as exc:
+            formatter.error(
+                message=f"Invalid --configuration input: {exc}",
+                error_code="VALIDATION_ERROR",
+            )
+            raise typer.Exit(code=2) from None
+
+    if configuration_file:
+        try:
+            config_dict = json.loads(configuration_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            formatter.error(
+                message=f"Invalid JSON in {configuration_file}: {exc}",
+                error_code="VALIDATION_ERROR",
+            )
+            raise typer.Exit(code=2) from None
+
+    # --- Parse --set values ---------------------------------------------------
+    parsed_sets: list[tuple[str, object]] | None = None
+    if set_values:
+        parsed_sets = []
+        for item in set_values:
+            if "=" not in item:
+                formatter.error(
+                    message=f"Invalid --set format: '{item}'. Expected PATH=VALUE.",
+                    error_code="VALIDATION_ERROR",
+                )
+                raise typer.Exit(code=2) from None
+            path, _, raw_value = item.partition("=")
+            parsed_sets.append((path.strip(), _parse_set_value(raw_value.strip())))
+
+    # --set implies merge
+    effective_merge = merge or bool(parsed_sets)
 
     try:
         result = service.update_config(
@@ -373,6 +493,10 @@ def config_update(
             config_id=config_id,
             name=name,
             description=description,
+            configuration=config_dict,
+            set_paths=parsed_sets,
+            merge=effective_merge,
+            dry_run=dry_run,
             branch_id=branch,
         )
     except ConfigError as exc:
@@ -385,6 +509,21 @@ def config_update(
             retryable=exc.retryable,
         )
         raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    # --- Output ---------------------------------------------------------------
+    if result.get("dry_run"):
+        changes = result.get("changes", [])
+        if formatter.json_mode:
+            formatter.output(result)
+        else:
+            if not changes:
+                formatter.success("No changes detected.")
+            else:
+                formatter.console.print(f"\n[bold]Dry-run: {len(changes)} change(s)[/bold]\n")
+                for change in changes:
+                    formatter.console.print(f"  {change}")
+                formatter.console.print()
+        return
 
     if formatter.json_mode:
         formatter.output(result)

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -90,8 +90,11 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent config detail --project NAME --component-id ID --config-id ID [--branch ID]
     Full config detail including parameters and rows. Branch-aware.
 
-  kbagent config update --project NAME --component-id ID --config-id ID [--name N] [--description D] [--branch ID]
-    Update config name/description. Targets active dev branch if set.
+  kbagent config update --project NAME --component-id ID --config-id ID [--name N] [--description D] [--configuration JSON|@file|-] [--configuration-file PATH] [--set PATH=VALUE ...] [--merge] [--dry-run] [--branch ID]
+    Update config metadata and/or configuration content. --set targets a
+    nested key (e.g. parameters.db.host=new-host). --merge deep-merges into
+    existing config (preserves sibling keys). --dry-run previews changes.
+    Paths are always relative to the configuration root.
 
   kbagent config delete --project NAME --component-id ID --config-id ID [--branch ID]
     Delete a configuration. Branch-aware.

--- a/src/keboola_agent_cli/json_utils.py
+++ b/src/keboola_agent_cli/json_utils.py
@@ -1,0 +1,126 @@
+"""JSON deep-merge and nested-path utilities.
+
+Used by ``config update`` to patch configuration content without
+losing sibling keys -- the exact problem that MCP server's
+``update_config`` tool has (keboola/mcp-server#468).
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+
+def deep_merge(target: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *source* into *target* (non-mutating).
+
+    Rules:
+    * dict + dict → recursively merged
+    * anything else → *source* wins (including list replaces list)
+
+    Returns a new dict; neither *target* nor *source* is mutated.
+    """
+    result = copy.deepcopy(target)
+    for key, src_value in source.items():
+        if key in result and isinstance(result[key], dict) and isinstance(src_value, dict):
+            result[key] = deep_merge(result[key], src_value)
+        else:
+            result[key] = copy.deepcopy(src_value)
+    return result
+
+
+def get_nested_value(obj: Any, path: str) -> Any:
+    """Retrieve a value from a nested structure using a dot-separated path.
+
+    Supports integer segments for list indexing (e.g. ``"tables.0.name"``).
+
+    Raises ``KeyError`` or ``IndexError`` if the path does not exist.
+    """
+    for segment in path.split("."):
+        if isinstance(obj, dict):
+            obj = obj[segment]
+        elif isinstance(obj, list):
+            obj = obj[int(segment)]
+        else:
+            raise KeyError(f"Cannot traverse into {type(obj).__name__} with key '{segment}'")
+    return obj
+
+
+def set_nested_value(obj: dict[str, Any], path: str, value: Any) -> dict[str, Any]:
+    """Set a value at a dot-separated path, creating intermediate dicts.
+
+    Returns a deep-copied dict with the value set — *obj* is not mutated.
+
+    Supports integer segments for list indexing on **existing** lists
+    (new intermediate containers are always dicts).
+    """
+    result = copy.deepcopy(obj)
+    segments = path.split(".")
+    current: Any = result
+    for segment in segments[:-1]:
+        if isinstance(current, dict):
+            if segment not in current:
+                current[segment] = {}
+            current = current[segment]
+        elif isinstance(current, list):
+            current = current[int(segment)]
+        else:
+            raise KeyError(f"Cannot traverse into {type(current).__name__} with key '{segment}'")
+
+    last = segments[-1]
+    if isinstance(current, dict):
+        current[last] = copy.deepcopy(value)
+    elif isinstance(current, list):
+        current[int(last)] = copy.deepcopy(value)
+    else:
+        raise KeyError(f"Cannot set key '{last}' on {type(current).__name__}")
+    return result
+
+
+def compute_diff(
+    old: dict[str, Any],
+    new: dict[str, Any],
+    path: str = "",
+) -> list[str]:
+    """Produce a human-readable list of changes between two dicts.
+
+    Each entry looks like:
+        ``"parameters.tables.count: 5 -> 10"``
+        ``"parameters.newKey: (absent) -> 'hello'"``
+        ``"parameters.removed: 42 -> (absent)"``
+    """
+    changes: list[str] = []
+    all_keys = sorted(set(list(old.keys()) + list(new.keys())))
+
+    for key in all_keys:
+        full_path = f"{path}.{key}" if path else key
+        in_old = key in old
+        in_new = key in new
+
+        if in_old and in_new:
+            old_val = old[key]
+            new_val = new[key]
+            if isinstance(old_val, dict) and isinstance(new_val, dict):
+                changes.extend(compute_diff(old_val, new_val, full_path))
+            elif old_val != new_val:
+                changes.append(f"{full_path}: {_fmt(old_val)} -> {_fmt(new_val)}")
+        elif in_old and not in_new:
+            changes.append(f"{full_path}: {_fmt(old[key])} -> (absent)")
+        else:
+            changes.append(f"{full_path}: (absent) -> {_fmt(new[key])}")
+
+    return changes
+
+
+def _fmt(value: Any) -> str:
+    """Format a value for diff display — truncate long representations."""
+    if isinstance(value, str):
+        s = repr(value)
+    elif isinstance(value, dict):
+        s = f"{{...}} ({len(value)} keys)"
+    elif isinstance(value, list):
+        s = f"[...] ({len(value)} items)"
+    else:
+        s = repr(value)
+    max_len = 80
+    return s if len(s) <= max_len else s[: max_len - 3] + "..."

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -4,10 +4,12 @@ Orchestrates multi-project configuration retrieval in parallel, filtering,
 aggregation, and full-text search without knowing about CLI or HTTP details.
 """
 
+import json
 import re
 from typing import Any
 
 from ..errors import KeboolaApiError
+from ..json_utils import compute_diff, deep_merge, set_nested_value
 from ..models import ProjectConfig
 from .base import BaseService
 
@@ -242,9 +244,13 @@ class ConfigService(BaseService):
         config_id: str,
         name: str | None = None,
         description: str | None = None,
+        configuration: dict[str, Any] | None = None,
+        set_paths: list[tuple[str, Any]] | None = None,
+        merge: bool = False,
+        dry_run: bool = False,
         branch_id: int | None = None,
     ) -> dict[str, Any]:
-        """Update a configuration's name and/or description.
+        """Update a configuration's metadata and/or content.
 
         Args:
             alias: Project alias.
@@ -252,36 +258,89 @@ class ConfigService(BaseService):
             config_id: The configuration ID to update.
             name: New name (if None, not changed).
             description: New description (if None, not changed).
+            configuration: Full configuration dict to set/merge.
+            set_paths: List of (path, value) tuples for targeted updates
+                       (e.g. ``[("parameters.tables", {...})]``).
+            merge: If True, deep-merge *configuration* or *set_paths* into
+                   the existing config instead of replacing.  When using
+                   *set_paths* merge is always implied.
+            dry_run: If True, compute and return the diff without applying.
             branch_id: If set, update in a specific dev branch.
                        If None, uses the project's active branch (if any).
 
         Returns:
             Dict with the updated configuration from the API.
+            When *dry_run* is True the dict contains ``"dry_run": True``
+            and a ``"changes"`` list instead of the API response.
 
         Raises:
             ConfigError: If the alias is not found.
             KeboolaApiError: If the API call fails.
         """
-        if name is None and description is None:
+        has_content = configuration is not None or bool(set_paths)
+        has_metadata = name is not None or description is not None
+
+        if not has_content and not has_metadata:
             raise KeboolaApiError(
                 status_code=400,
                 error_code="VALIDATION_ERROR",
-                message="At least one of --name or --description must be provided.",
+                message=(
+                    "At least one of --name, --description, --configuration, "
+                    "--configuration-file, or --set must be provided."
+                ),
             )
 
         projects = self.resolve_projects([alias])
         project = projects[alias]
-
         effective_branch_id = branch_id or project.active_branch_id
 
         client = self._client_factory(project.stack_url, project.token)
         try:
+            final_config: dict[str, Any] | None = None
+
+            if has_content:
+                final_config = self._resolve_configuration(
+                    client=client,
+                    component_id=component_id,
+                    config_id=config_id,
+                    configuration=configuration,
+                    set_paths=set_paths,
+                    merge=merge,
+                    branch_id=effective_branch_id,
+                )
+
+            if dry_run:
+                current = client.get_config_detail(
+                    component_id, config_id, branch_id=effective_branch_id
+                )
+                old_cfg = current.get("configuration", {})
+                new_cfg = final_config if final_config is not None else old_cfg
+                changes = compute_diff(old_cfg, new_cfg)
+                return {
+                    "dry_run": True,
+                    "project_alias": alias,
+                    "component_id": component_id,
+                    "config_id": config_id,
+                    "branch_id": effective_branch_id,
+                    "changes": changes,
+                    "old_configuration": old_cfg,
+                    "new_configuration": new_cfg,
+                }
+
+            change_parts = []
+            if has_metadata:
+                change_parts.append("metadata")
+            if has_content:
+                change_parts.append("configuration")
+            change_desc = f"Updated {' + '.join(change_parts)} via kbagent config update"
+
             result = client.update_config(
                 component_id=component_id,
                 config_id=config_id,
                 name=name,
                 description=description,
-                change_description="Updated via kbagent config update",
+                configuration=final_config,
+                change_description=change_desc,
                 branch_id=effective_branch_id,
             )
         finally:
@@ -290,6 +349,46 @@ class ConfigService(BaseService):
         result["project_alias"] = alias
         result["branch_id"] = effective_branch_id
         return result
+
+    def _resolve_configuration(
+        self,
+        client: Any,
+        component_id: str,
+        config_id: str,
+        configuration: dict[str, Any] | None,
+        set_paths: list[tuple[str, Any]] | None,
+        merge: bool,
+        branch_id: int | None,
+    ) -> dict[str, Any]:
+        """Build the final configuration dict by merging/setting paths.
+
+        When *merge* is True or *set_paths* are given, the current
+        configuration is fetched from the API and changes are applied
+        on top of it (deep-merge for dicts, replace for scalars/lists).
+        """
+        needs_current = merge or bool(set_paths)
+
+        if needs_current:
+            current_detail = client.get_config_detail(component_id, config_id, branch_id=branch_id)
+            current_cfg: dict[str, Any] = current_detail.get("configuration", {})
+            if isinstance(current_cfg, str):
+                current_cfg = json.loads(current_cfg)
+        else:
+            current_cfg = {}
+
+        if set_paths:
+            result = current_cfg
+            for path, value in set_paths:
+                result = set_nested_value(result, path, value)
+            if configuration:
+                result = deep_merge(result, configuration)
+            return result
+
+        if merge and configuration:
+            return deep_merge(current_cfg, configuration)
+
+        # Full replace (no merge, no set_paths)
+        return configuration if configuration is not None else current_cfg
 
     def delete_config(
         self,

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -1,0 +1,459 @@
+"""Tests for config update with configuration content (merge, --set, dry-run).
+
+Covers ConfigService.update_config and the CLI command.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from helpers import setup_single_project
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.errors import KeboolaApiError
+from keboola_agent_cli.services.config_service import ConfigService
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_CONFIG_DETAIL = {
+    "id": "cfg-001",
+    "name": "My Config",
+    "description": "desc",
+    "configuration": {
+        "parameters": {
+            "user": "admin",
+            "project": "proj1",
+            "tables": {"old_table": {"columns": ["a", "b"]}},
+            "dimensions": ["dim1", "dim2"],
+        },
+        "storage": {"input": {"tables": []}},
+    },
+}
+
+
+def _make_service(tmp_config_dir: Path) -> tuple[ConfigService, MagicMock]:
+    """Create a ConfigService with a mock client."""
+    store = setup_single_project(tmp_config_dir)
+    mock_client = MagicMock()
+    mock_client.get_config_detail.return_value = SAMPLE_CONFIG_DETAIL
+    mock_client.update_config.return_value = {
+        "id": "cfg-001",
+        "name": "My Config",
+        "componentId": "keboola.ex-db-snowflake",
+    }
+    service = ConfigService(
+        config_store=store,
+        client_factory=lambda url, token: mock_client,
+    )
+    return service, mock_client
+
+
+# ---------------------------------------------------------------------------
+# Service-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigServiceUpdateConfiguration:
+    """Tests for ConfigService.update_config with configuration content."""
+
+    def test_full_replace(self, tmp_config_dir: Path) -> None:
+        """Without --merge, configuration is sent as-is (full replace)."""
+        service, client = _make_service(tmp_config_dir)
+        new_cfg = {"parameters": {"tables": {"brand_new": True}}}
+
+        service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            configuration=new_cfg,
+        )
+
+        client.update_config.assert_called_once()
+        call_kwargs = client.update_config.call_args.kwargs
+        assert call_kwargs["configuration"] == new_cfg
+        # Should NOT fetch current config for full replace
+        client.get_config_detail.assert_not_called()
+
+    def test_merge_preserves_siblings(self, tmp_config_dir: Path) -> None:
+        """With merge=True, sibling keys under 'parameters' are preserved."""
+        service, client = _make_service(tmp_config_dir)
+        partial = {"parameters": {"tables": {"new_table": {"columns": ["x"]}}}}
+
+        service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            configuration=partial,
+            merge=True,
+        )
+
+        call_kwargs = client.update_config.call_args.kwargs
+        merged = call_kwargs["configuration"]
+
+        # Sibling keys preserved
+        assert merged["parameters"]["user"] == "admin"
+        assert merged["parameters"]["project"] == "proj1"
+        assert merged["parameters"]["dimensions"] == ["dim1", "dim2"]
+        # deep_merge merges dict+dict: old table key preserved, new one added
+        assert merged["parameters"]["tables"]["new_table"] == {"columns": ["x"]}
+        assert merged["parameters"]["tables"]["old_table"] == {"columns": ["a", "b"]}
+        # Storage section preserved
+        assert "storage" in merged
+
+    def test_set_path_preserves_siblings(self, tmp_config_dir: Path) -> None:
+        """--set targets a specific key without touching siblings."""
+        service, client = _make_service(tmp_config_dir)
+
+        service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            set_paths=[("parameters.tables", {"replaced": True})],
+        )
+
+        call_kwargs = client.update_config.call_args.kwargs
+        cfg = call_kwargs["configuration"]
+        assert cfg["parameters"]["user"] == "admin"
+        assert cfg["parameters"]["project"] == "proj1"
+        assert cfg["parameters"]["tables"] == {"replaced": True}
+
+    def test_multiple_set_paths(self, tmp_config_dir: Path) -> None:
+        """Multiple --set values are applied sequentially."""
+        service, client = _make_service(tmp_config_dir)
+
+        service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            set_paths=[
+                ("parameters.user", "new-admin"),
+                ("parameters.project", "new-proj"),
+            ],
+        )
+
+        cfg = client.update_config.call_args.kwargs["configuration"]
+        assert cfg["parameters"]["user"] == "new-admin"
+        assert cfg["parameters"]["project"] == "new-proj"
+        # Untouched keys preserved
+        assert "tables" in cfg["parameters"]
+
+    def test_dry_run_returns_diff(self, tmp_config_dir: Path) -> None:
+        """dry_run=True returns changes without calling update_config."""
+        service, client = _make_service(tmp_config_dir)
+
+        result = service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            set_paths=[("parameters.user", "new-admin")],
+            dry_run=True,
+        )
+
+        assert result["dry_run"] is True
+        assert len(result["changes"]) >= 1
+        assert any("parameters.user" in c for c in result["changes"])
+        # Should NOT call update
+        client.update_config.assert_not_called()
+
+    def test_metadata_only_still_works(self, tmp_config_dir: Path) -> None:
+        """Name/description update without configuration still works."""
+        service, client = _make_service(tmp_config_dir)
+
+        service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            name="New Name",
+        )
+
+        call_kwargs = client.update_config.call_args.kwargs
+        assert call_kwargs["name"] == "New Name"
+        assert call_kwargs["configuration"] is None
+
+    def test_metadata_plus_configuration(self, tmp_config_dir: Path) -> None:
+        """Both metadata and configuration can be updated at once."""
+        service, client = _make_service(tmp_config_dir)
+
+        service.update_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            config_id="cfg-001",
+            name="New Name",
+            set_paths=[("parameters.user", "updated")],
+        )
+
+        call_kwargs = client.update_config.call_args.kwargs
+        assert call_kwargs["name"] == "New Name"
+        assert call_kwargs["configuration"]["parameters"]["user"] == "updated"
+
+    def test_validation_error_when_nothing_provided(self, tmp_config_dir: Path) -> None:
+        """Raise error if no metadata or configuration is given."""
+        service, _ = _make_service(tmp_config_dir)
+
+        with pytest.raises(KeboolaApiError, match="must be provided"):
+            service.update_config(
+                alias="prod",
+                component_id="keboola.ex-db-snowflake",
+                config_id="cfg-001",
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigUpdateCli:
+    """CLI-level tests for config update command."""
+
+    def _invoke(self, tmp_config_dir: Path, args: list[str]) -> object:
+        return runner.invoke(
+            app,
+            ["--json", "--config-dir", str(tmp_config_dir), "config", "update", *args],
+        )
+
+    def test_set_flag(self, tmp_config_dir: Path) -> None:
+        """--set flag parses PATH=VALUE and sends to service."""
+        store = setup_single_project(tmp_config_dir)
+
+        mock_client = MagicMock()
+        mock_client.get_config_detail.return_value = SAMPLE_CONFIG_DETAIL
+        mock_client.update_config.return_value = {
+            "id": "cfg-001",
+            "name": "My Config",
+            "componentId": "keboola.ex-db-snowflake",
+        }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "keboola_agent_cli.commands.config.get_service",
+                lambda ctx, name: ConfigService(
+                    config_store=store,
+                    client_factory=lambda url, token: mock_client,
+                ),
+            )
+
+            result = self._invoke(
+                tmp_config_dir,
+                [
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--config-id",
+                    "cfg-001",
+                    "--set",
+                    "parameters.user=new-admin",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        cfg = mock_client.update_config.call_args.kwargs["configuration"]
+        assert cfg["parameters"]["user"] == "new-admin"
+        assert cfg["parameters"]["project"] == "proj1"
+
+    def test_configuration_inline_json(self, tmp_config_dir: Path) -> None:
+        """--configuration accepts inline JSON."""
+        store = setup_single_project(tmp_config_dir)
+
+        mock_client = MagicMock()
+        mock_client.update_config.return_value = {
+            "id": "cfg-001",
+            "name": "My Config",
+        }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "keboola_agent_cli.commands.config.get_service",
+                lambda ctx, name: ConfigService(
+                    config_store=store,
+                    client_factory=lambda url, token: mock_client,
+                ),
+            )
+
+            new_cfg = {"parameters": {"key": "value"}}
+            result = self._invoke(
+                tmp_config_dir,
+                [
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "comp",
+                    "--config-id",
+                    "cfg-001",
+                    "--configuration",
+                    json.dumps(new_cfg),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.update_config.call_args.kwargs
+        assert call_kwargs["configuration"] == new_cfg
+
+    def test_configuration_file(self, tmp_config_dir: Path, tmp_path: Path) -> None:
+        """--configuration-file reads JSON from disk."""
+        store = setup_single_project(tmp_config_dir)
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({"parameters": {"from_file": True}}))
+
+        mock_client = MagicMock()
+        mock_client.update_config.return_value = {
+            "id": "cfg-001",
+            "name": "My Config",
+        }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "keboola_agent_cli.commands.config.get_service",
+                lambda ctx, name: ConfigService(
+                    config_store=store,
+                    client_factory=lambda url, token: mock_client,
+                ),
+            )
+
+            result = self._invoke(
+                tmp_config_dir,
+                [
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "comp",
+                    "--config-id",
+                    "cfg-001",
+                    "--configuration-file",
+                    str(cfg_file),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.update_config.call_args.kwargs
+        assert call_kwargs["configuration"]["parameters"]["from_file"] is True
+
+    def test_dry_run_output(self, tmp_config_dir: Path) -> None:
+        """--dry-run shows changes without applying."""
+        store = setup_single_project(tmp_config_dir)
+
+        mock_client = MagicMock()
+        mock_client.get_config_detail.return_value = SAMPLE_CONFIG_DETAIL
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "keboola_agent_cli.commands.config.get_service",
+                lambda ctx, name: ConfigService(
+                    config_store=store,
+                    client_factory=lambda url, token: mock_client,
+                ),
+            )
+
+            result = self._invoke(
+                tmp_config_dir,
+                [
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--config-id",
+                    "cfg-001",
+                    "--set",
+                    "parameters.user=changed",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        output = json.loads(result.output)
+        data = output["data"]
+        assert data["dry_run"] is True
+        assert any("parameters.user" in c for c in data["changes"])
+        mock_client.update_config.assert_not_called()
+
+    def test_invalid_set_format(self, tmp_config_dir: Path) -> None:
+        """--set without = sign gives validation error."""
+        setup_single_project(tmp_config_dir)
+
+        result = self._invoke(
+            tmp_config_dir,
+            [
+                "--project",
+                "prod",
+                "--component-id",
+                "comp",
+                "--config-id",
+                "cfg-001",
+                "--set",
+                "no-equals-sign",
+            ],
+        )
+
+        assert result.exit_code == 2
+
+    def test_both_configuration_and_file_rejected(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Cannot use --configuration and --configuration-file together."""
+        setup_single_project(tmp_config_dir)
+        cfg_file = tmp_path / "c.json"
+        cfg_file.write_text("{}")
+
+        result = self._invoke(
+            tmp_config_dir,
+            [
+                "--project",
+                "prod",
+                "--component-id",
+                "comp",
+                "--config-id",
+                "cfg-001",
+                "--configuration",
+                "{}",
+                "--configuration-file",
+                str(cfg_file),
+            ],
+        )
+
+        assert result.exit_code == 2
+
+    def test_set_json_value(self, tmp_config_dir: Path) -> None:
+        """--set with JSON value is parsed correctly."""
+        store = setup_single_project(tmp_config_dir)
+
+        mock_client = MagicMock()
+        mock_client.get_config_detail.return_value = SAMPLE_CONFIG_DETAIL
+        mock_client.update_config.return_value = {
+            "id": "cfg-001",
+            "name": "My Config",
+        }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "keboola_agent_cli.commands.config.get_service",
+                lambda ctx, name: ConfigService(
+                    config_store=store,
+                    client_factory=lambda url, token: mock_client,
+                ),
+            )
+
+            result = self._invoke(
+                tmp_config_dir,
+                [
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-db-snowflake",
+                    "--config-id",
+                    "cfg-001",
+                    "--set",
+                    'parameters.tables={"new": "table"}',
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        cfg = mock_client.update_config.call_args.kwargs["configuration"]
+        assert cfg["parameters"]["tables"] == {"new": "table"}

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,179 @@
+"""Tests for keboola_agent_cli.json_utils (deep_merge, set_nested_value, compute_diff)."""
+
+import pytest
+
+from keboola_agent_cli.json_utils import (
+    compute_diff,
+    deep_merge,
+    get_nested_value,
+    set_nested_value,
+)
+
+
+class TestDeepMerge:
+    """Tests for deep_merge()."""
+
+    def test_flat_merge(self) -> None:
+        target = {"a": 1, "b": 2}
+        source = {"b": 3, "c": 4}
+        result = deep_merge(target, source)
+        assert result == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge_preserves_siblings(self) -> None:
+        """The core scenario from keboola/mcp-server#468."""
+        target = {
+            "parameters": {
+                "user": "admin",
+                "project": "proj1",
+                "tables": {"old": "data"},
+                "dimensions": ["dim1"],
+            }
+        }
+        source = {"parameters": {"tables": {"new": "data"}}}
+        result = deep_merge(target, source)
+
+        assert result["parameters"]["user"] == "admin"
+        assert result["parameters"]["project"] == "proj1"
+        assert result["parameters"]["dimensions"] == ["dim1"]
+        # deep_merge merges dict+dict recursively, so both keys are present
+        assert result["parameters"]["tables"] == {"old": "data", "new": "data"}
+
+    def test_deeply_nested(self) -> None:
+        target = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        source = {"a": {"b": {"c": 99}}}
+        result = deep_merge(target, source)
+        assert result == {"a": {"b": {"c": 99, "d": 2}, "e": 3}}
+
+    def test_list_replaced_not_merged(self) -> None:
+        target = {"items": [1, 2, 3]}
+        source = {"items": [4, 5]}
+        result = deep_merge(target, source)
+        assert result["items"] == [4, 5]
+
+    def test_new_keys_added(self) -> None:
+        target = {"a": 1}
+        source = {"b": {"c": 2}}
+        result = deep_merge(target, source)
+        assert result == {"a": 1, "b": {"c": 2}}
+
+    def test_non_mutating(self) -> None:
+        target = {"a": {"b": 1}}
+        source = {"a": {"c": 2}}
+        original_target = {"a": {"b": 1}}
+        deep_merge(target, source)
+        assert target == original_target
+
+    def test_empty_source(self) -> None:
+        target = {"a": 1}
+        assert deep_merge(target, {}) == {"a": 1}
+
+    def test_empty_target(self) -> None:
+        source = {"a": 1}
+        assert deep_merge({}, source) == {"a": 1}
+
+    def test_scalar_overwrites_dict(self) -> None:
+        target = {"a": {"b": 1}}
+        source = {"a": "string"}
+        result = deep_merge(target, source)
+        assert result == {"a": "string"}
+
+    def test_dict_overwrites_scalar(self) -> None:
+        target = {"a": "string"}
+        source = {"a": {"b": 1}}
+        result = deep_merge(target, source)
+        assert result == {"a": {"b": 1}}
+
+
+class TestGetNestedValue:
+    """Tests for get_nested_value()."""
+
+    def test_simple_path(self) -> None:
+        obj = {"a": {"b": 42}}
+        assert get_nested_value(obj, "a.b") == 42
+
+    def test_top_level(self) -> None:
+        obj = {"key": "val"}
+        assert get_nested_value(obj, "key") == "val"
+
+    def test_list_index(self) -> None:
+        obj = {"items": [10, 20, 30]}
+        assert get_nested_value(obj, "items.1") == 20
+
+    def test_missing_key_raises(self) -> None:
+        with pytest.raises(KeyError):
+            get_nested_value({"a": 1}, "b")
+
+
+class TestSetNestedValue:
+    """Tests for set_nested_value()."""
+
+    def test_set_existing_key(self) -> None:
+        obj = {"a": {"b": 1, "c": 2}}
+        result = set_nested_value(obj, "a.b", 99)
+        assert result == {"a": {"b": 99, "c": 2}}
+
+    def test_create_intermediate_dicts(self) -> None:
+        result = set_nested_value({}, "a.b.c", "new")
+        assert result == {"a": {"b": {"c": "new"}}}
+
+    def test_preserves_siblings(self) -> None:
+        """Same scenario as MCP bug — set a nested key, siblings stay."""
+        obj = {
+            "parameters": {
+                "user": "admin",
+                "project": "p1",
+                "tables": {"old": "data"},
+            }
+        }
+        result = set_nested_value(obj, "parameters.tables", {"new": "data"})
+        assert result["parameters"]["user"] == "admin"
+        assert result["parameters"]["project"] == "p1"
+        assert result["parameters"]["tables"] == {"new": "data"}
+
+    def test_non_mutating(self) -> None:
+        obj = {"a": {"b": 1}}
+        set_nested_value(obj, "a.b", 2)
+        assert obj == {"a": {"b": 1}}
+
+    def test_set_list_element(self) -> None:
+        obj = {"items": [10, 20, 30]}
+        result = set_nested_value(obj, "items.1", 99)
+        assert result == {"items": [10, 99, 30]}
+
+
+class TestComputeDiff:
+    """Tests for compute_diff()."""
+
+    def test_no_changes(self) -> None:
+        d = {"a": 1, "b": {"c": 2}}
+        assert compute_diff(d, d) == []
+
+    def test_value_change(self) -> None:
+        old = {"host": "old.example.com"}
+        new = {"host": "new.example.com"}
+        changes = compute_diff(old, new)
+        assert len(changes) == 1
+        assert "host:" in changes[0]
+        assert "old.example.com" in changes[0]
+        assert "new.example.com" in changes[0]
+
+    def test_added_key(self) -> None:
+        old = {"a": 1}
+        new = {"a": 1, "b": 2}
+        changes = compute_diff(old, new)
+        assert len(changes) == 1
+        assert "(absent) -> 2" in changes[0]
+
+    def test_removed_key(self) -> None:
+        old = {"a": 1, "b": 2}
+        new = {"a": 1}
+        changes = compute_diff(old, new)
+        assert len(changes) == 1
+        assert "-> (absent)" in changes[0]
+
+    def test_nested_changes(self) -> None:
+        old = {"db": {"host": "old", "port": 5432}}
+        new = {"db": {"host": "new", "port": 5432}}
+        changes = compute_diff(old, new)
+        assert len(changes) == 1
+        assert "db.host:" in changes[0]


### PR DESCRIPTION
## Summary

- Extend `config update` to support updating configuration content (not just name/description)
- New options: `--configuration`, `--configuration-file`, `--set PATH=VALUE`, `--merge`, `--dry-run`
- Paths are always relative to the configuration root (avoids the MCP `update_config` confusion where paths are relative to `parameters`)
- Deep merge preserves sibling keys at every nesting level
- `--dry-run` returns structured diff without applying changes
- ~3-4x faster than MCP equivalent (direct API call, no subprocess overhead)

## New files

- `src/keboola_agent_cli/json_utils.py` -- deep_merge, set_nested_value, compute_diff utilities
- `tests/test_json_utils.py` -- 24 unit tests
- `tests/test_config_update.py` -- 15 service + CLI tests

## Benchmark (real project, keboola-ai)

| Scenario | CLI | MCP | Speedup |
|----------|----:|----:|:-------:|
| Scalar set | 1.0s | 3.8s | 3.8x |
| Deep merge | 1.3s | 3.5s | 2.7x |
| Dry-run | 0.7s | n/a | -- |

## Context

Triggered by #155 where MCP's `update_config` appeared to lose sibling keys. Root cause turned out to be ambiguous path semantics (paths relative to `parameters`, not config root). This native CLI implementation avoids that entire class of confusion.

## Test plan

- [x] 39 new tests (24 json_utils + 15 config_update)
- [x] Full suite: 1586 passed, 0 failed
- [x] Manual test on real project (keboola-ai, ex-generic-v2 config)
- [x] Round-trip verified: set value, read back, siblings preserved
- [x] Lint + format clean