### PR TITLE
chore: bump version to 0.18.6

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.18.5"
+version = "0.18.6"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,13 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.18.6": [
+        "New: config update --set PATH=VALUE -- set nested config keys without losing siblings (#156)",
+        "New: config update --merge -- deep-merge partial JSON into existing configuration (#156)",
+        "New: config update --dry-run -- preview changes before applying (#156)",
+        "New: config update --configuration / --configuration-file -- update full config content (#156)",
+        "Perf: 3-4x faster than MCP update_config (direct API, no subprocess overhead)",
+    ],
     "0.18.5": [
         "New: --hint client|service flag -- generate Python code for any CLI command (#153)",
         "New: kbagent as Python SDK -- import KeboolaClient or service layer in your scripts",


### PR DESCRIPTION
## Summary

- Bump version 0.18.5 -> 0.18.6
- Add changelog entries for config update feature (#156)

After merge, tag `v0.18.6` and create GitHub release.