### PR TITLE
feat: add storage delete-column command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,7 @@ kbagent storage create-table --project NAME --bucket-id ID --name NAME --column 
 kbagent storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]
 kbagent storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]
 kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
+kbagent storage delete-column --project NAME --table-id ID --column COL [--column ...] [--dry-run] [--yes] [--branch ID]
 kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
 kbagent storage files --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
 kbagent storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,22 +188,29 @@ When adding a new command (e.g., `kbagent storage create-foo`), you must update 
 - [ ] **Client method** in `client.py` (or `manage_client.py`) -- HTTP layer
 - [ ] **Service method** in `services/` -- business logic, validation, orchestration
 - [ ] **Command function** in `commands/` -- Typer options, formatter, error handling
-- [ ] **Hint definition** in `hints/definitions/` -- register a `CommandHint` for `--hint` code generation (see existing files for pattern)
-- [ ] **Hint short-circuit** in the command function -- add `if should_hint(ctx): emit_hint(...)` before service call
+- [ ] **`--hint` support** -- every command must support `--hint client` and `--hint service` code generation:
+  - [ ] **Hint definition** in `hints/definitions/` -- register a `CommandHint` with `ClientCall` + `ServiceCall` (see existing files for pattern)
+  - [ ] **Hint short-circuit** in the command function -- add `if should_hint(ctx): emit_hint(...)` **before** the service call
+  - [ ] **Verify** both modes produce valid Python: `kbagent --hint client <command> ...` and `kbagent --hint service <command> ...`
 - [ ] **Permission registration** in `permissions.py` (`OPERATION_REGISTRY` dict)
 - [ ] **Service wiring** in `cli.py` if adding a new service class
 
 ### Documentation changes (mandatory!)
 
-- [ ] **`kbagent context`** -- update `AGENT_CONTEXT` string in `commands/context.py` (this is the primary reference for AI agents)
+- [ ] **`kbagent context`** -- update `AGENT_CONTEXT` string in `commands/context.py` (this is the primary reference for AI agents; if it's missing there, AI agents won't know the command exists)
 - [ ] **SKILL.md** -- run `make skill-gen` to regenerate the decision table (CI has a freshness check that will fail if the generated output doesn't match). **Do not edit SKILL.md by hand** -- the table is auto-generated from CLI command metadata
 - [ ] **CLAUDE.md** -- add command signature to the `## All CLI Commands` section
+- [ ] **Plugin references** -- update `plugins/kbagent/skills/kbagent/references/`:
+  - [ ] **`commands-reference.md`** -- add the new command to the appropriate section (this is a hand-maintained file, NOT auto-generated)
+  - [ ] **New reference file** -- if the command introduces a new workflow or topic area (e.g. a new subcommand group), create a dedicated `<topic>-workflow.md` in the references directory. Existing examples: `workspace-workflow.md`, `branch-workflow.md`, `sync-workflow.md`, `storage-files-workflow.md`
+  - [ ] **`gotchas.md`** -- if the command has non-obvious behavior, response format quirks, or common mistakes, document them here
 - [ ] **`--help` text** -- Typer docstring and option help strings should be clear and complete
 
 ### Tests (mandatory!)
 
 - [ ] **Service-layer tests** -- mock the client, test business logic, edge cases, error propagation
 - [ ] **CLI-layer tests** -- use `CliRunner`, test JSON output, error exit codes
+- [ ] **E2E tests** -- add a test in `tests/test_e2e.py` that exercises the command against a real Keboola project (requires `E2E_API_TOKEN` + `E2E_URL`). Run `make test-e2e` to verify. Every CLI command must have E2E coverage
 - [ ] **Run `make check`** before committing (lint + format + full test suite)
 
 ### UX considerations

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -82,6 +82,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Upload a CSV file into a storage table | `kbagent storage upload-table --project PROJECT --table-id TABLE-ID --file FILE` |
 | Export a storage table to a local CSV file | `kbagent storage download-table --project PROJECT --table-id TABLE-ID` |
 | Delete one or more storage tables | `kbagent storage delete-table --project PROJECT --table-id TABLE-ID` |
+| Delete one or more columns from a storage table | `kbagent storage delete-column --project PROJECT --table-id TABLE-ID --column COLUMN` |
 | Delete one or more storage buckets | `kbagent storage delete-bucket --project PROJECT --bucket-id BUCKET-ID` |
 | List Storage Files with optional tag filtering | `kbagent storage files --project PROJECT` |
 | Show Storage File metadata (without downloading) | `kbagent storage file-detail --project PROJECT --file-id FILE-ID` |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -48,6 +48,7 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]` -- upload CSV (branch-aware)
 - `storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]` -- export table to CSV (branch-aware)
 - `storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]` -- delete tables (branch-aware)
+- `storage delete-column --project NAME --table-id ID --column COL [--column ...] [--dry-run] [--yes] [--branch ID]` -- delete columns from a table (branch-aware)
 - `storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete buckets (branch-aware)
 
 ## Data Lineage

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1128,6 +1128,21 @@ class KeboolaClient(BaseHttpClient):
         response = self._request("DELETE", f"{prefix}/tables/{safe_id}", params={"async": "true"})
         return self._wait_for_storage_job(response.json())
 
+    def delete_column(self, table_id: str, column_name: str, branch_id: int | None = None) -> None:
+        """Delete a column from a storage table.
+
+        This is a synchronous operation (no async job).
+
+        Args:
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+            column_name: Name of the column to delete.
+            branch_id: If set, target a specific dev branch.
+        """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        safe_table_id = quote(table_id, safe="")
+        safe_column = quote(column_name, safe="")
+        self._request("DELETE", f"{prefix}/tables/{safe_table_id}/columns/{safe_column}")
+
     def list_tables_with_metadata(self) -> list[dict[str, Any]]:
         """List all storage tables with columns and metadata.
 

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -151,6 +151,9 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
     Delete one or more tables. Batch: repeat --table-id. --dry-run to preview. Branch-aware.
 
+  kbagent storage delete-column --project NAME --table-id ID --column COL [--column ...] [--dry-run] [--yes] [--branch ID]
+    Delete one or more columns from a table. Batch: repeat --column. --dry-run to preview. Branch-aware.
+
   kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
     Delete one or more buckets. --force cascade-deletes tables. Linked/shared buckets protected. Branch-aware.
 

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -835,6 +835,118 @@ def storage_delete_table(
         raise typer.Exit(code=1)
 
 
+@storage_app.command("delete-column", rich_help_panel=_TABLES)
+def storage_delete_column(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    table_id: str = typer.Option(
+        ...,
+        "--table-id",
+        help="Table ID containing the column(s) (e.g. 'in.c-bucket.table')",
+    ),
+    column: list[str] = typer.Option(
+        ...,
+        "--column",
+        help="Column name to delete. Can be repeated.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be deleted without executing",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (defaults to active branch if set via 'branch use')",
+    ),
+) -> None:
+    """Delete one or more columns from a storage table.
+
+    Supports batch deletion with multiple --column flags.
+    """
+    if should_hint(ctx):
+        emit_hint(
+            ctx,
+            "storage.delete-column",
+            project=project,
+            table_id=table_id,
+            column=column,
+            dry_run=dry_run,
+            branch=branch,
+        )
+
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "storage_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    if dry_run:
+        try:
+            result = service.delete_columns(
+                alias=project,
+                table_id=table_id,
+                columns=column,
+                dry_run=True,
+                branch_id=effective_branch,
+            )
+        except ConfigError as exc:
+            formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+            raise typer.Exit(code=5) from None
+
+        if formatter.json_mode:
+            formatter.output(result)
+        else:
+            for col in result.get("would_delete", []):
+                formatter.console.print(
+                    f"[bold blue]Would delete:[/bold blue] {col} from {table_id}"
+                )
+        return
+
+    if (
+        not yes
+        and not formatter.json_mode
+        and not typer.confirm(
+            f"Delete {len(column)} column(s) from table '{table_id}' in project '{project}'?"
+        )
+    ):
+        formatter.console.print("Aborted.")
+        raise typer.Exit(code=0)
+
+    try:
+        result = service.delete_columns(
+            alias=project,
+            table_id=table_id,
+            columns=column,
+            branch_id=effective_branch,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        for col in result["deleted"]:
+            formatter.console.print(f"[bold green]Deleted:[/bold green] {col} from {table_id}")
+        for f_item in result["failed"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] {f_item['column']}: {f_item['error']}"
+            )
+
+    if result["failed"]:
+        raise typer.Exit(code=1)
+
+
 @storage_app.command("delete-bucket", rich_help_panel=_BUCKETS)
 def storage_delete_bucket(
     ctx: typer.Context,

--- a/src/keboola_agent_cli/hints/definitions/storage.py
+++ b/src/keboola_agent_cli/hints/definitions/storage.py
@@ -350,6 +350,45 @@ HintRegistry.register(
     )
 )
 
+# ── storage delete-column ─────────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="storage.delete-column",
+        description="Delete one or more columns from a table",
+        steps=[
+            HintStep(
+                comment="Delete column(s)",
+                client=ClientCall(
+                    method="delete_column",
+                    args={
+                        "table_id": "{table_id}",
+                        "column_name": "{column}",
+                        "branch_id": "{branch}",
+                    },
+                    result_var=None,
+                ),
+                service=ServiceCall(
+                    service_class="StorageService",
+                    service_module="storage_service",
+                    method="delete_columns",
+                    args={
+                        "alias": "{project}",
+                        "table_id": "{table_id}",
+                        "columns": "{column}",
+                        "dry_run": "{dry_run}",
+                        "branch_id": "{branch}",
+                    },
+                ),
+            ),
+        ],
+        notes=[
+            "Client layer deletes one column at a time. Loop for batch.",
+            "Synchronous API — no async job polling needed.",
+        ],
+    )
+)
+
 # ── storage files ──────��──────────────────────────────────���────────
 
 HintRegistry.register(

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -83,6 +83,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     "storage.unload-table": "read",
     # Storage destructive
     "storage.delete-table": "destructive",
+    "storage.delete-column": "destructive",
     "storage.delete-bucket": "destructive",
     "storage.file-delete": "destructive",
     # Encryption

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -695,6 +695,67 @@ class StorageService(BaseService):
             "project_alias": alias,
         }
 
+    def delete_columns(
+        self,
+        alias: str,
+        table_id: str,
+        columns: list[str],
+        dry_run: bool = False,
+        branch_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Delete one or more columns from a storage table.
+
+        Batch-tolerant: accumulates errors per column, one failure does not
+        stop other deletes.
+
+        Args:
+            alias: Project alias.
+            table_id: Full table ID (e.g. "in.c-bucket.table").
+            columns: List of column names to delete.
+            dry_run: If True, only report what would be deleted.
+            branch_id: If set, target a specific dev branch.
+
+        Returns:
+            Dict with 'deleted', 'failed', 'dry_run', 'project_alias',
+            'table_id', and optionally 'would_delete'.
+        """
+        from ..errors import KeboolaApiError
+
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        if dry_run:
+            return {
+                "deleted": [],
+                "failed": [],
+                "would_delete": list(columns),
+                "dry_run": True,
+                "project_alias": alias,
+                "table_id": table_id,
+            }
+
+        deleted: list[str] = []
+        failed: list[dict[str, str]] = []
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            for col in columns:
+                try:
+                    client.delete_column(table_id, col, branch_id=branch_id)
+                    deleted.append(col)
+                except KeboolaApiError as exc:
+                    failed.append({"column": col, "error": exc.message})
+        finally:
+            client.close()
+
+        return {
+            "deleted": deleted,
+            "failed": failed,
+            "dry_run": False,
+            "project_alias": alias,
+            "table_id": table_id,
+        }
+
     def delete_buckets(
         self,
         alias: str,

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -397,6 +397,229 @@ class TestDeleteBucketCLI:
 
 
 # ---------------------------------------------------------------------------
+# delete-column: service layer
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteColumnsService:
+    """Tests for StorageService.delete_columns()."""
+
+    def test_single_column_success(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_column.return_value = None
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(alias="test", table_id="in.c-data.users", columns=["age"])
+
+        assert result["deleted"] == ["age"]
+        assert result["failed"] == []
+        assert result["dry_run"] is False
+        assert result["table_id"] == "in.c-data.users"
+        mock_client.delete_column.assert_called_once_with("in.c-data.users", "age", branch_id=None)
+
+    def test_batch_multiple_columns(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_column.return_value = None
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(
+            alias="test", table_id="in.c-data.users", columns=["age", "email"]
+        )
+
+        assert result["deleted"] == ["age", "email"]
+        assert result["failed"] == []
+        assert mock_client.delete_column.call_count == 2
+
+    def test_batch_partial_failure(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_column.side_effect = [
+            None,
+            KeboolaApiError("Column not found", status_code=404, error_code="NOT_FOUND"),
+        ]
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(
+            alias="test", table_id="in.c-data.users", columns=["age", "missing"]
+        )
+
+        assert result["deleted"] == ["age"]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["column"] == "missing"
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(
+            alias="test", table_id="in.c-data.users", columns=["age"], dry_run=True
+        )
+
+        assert result["dry_run"] is True
+        assert result["would_delete"] == ["age"]
+        assert result["table_id"] == "in.c-data.users"
+        mock_client.delete_column.assert_not_called()
+
+    def test_unknown_project(self, tmp_path: Path) -> None:
+        from keboola_agent_cli.errors import ConfigError
+
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        service = _make_service(store, mock_client)
+
+        with pytest.raises(ConfigError):
+            service.delete_columns(alias="nonexistent", table_id="in.c-data.t", columns=["col"])
+
+
+# ---------------------------------------------------------------------------
+# delete-column: CLI layer
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteColumnCLI:
+    """CLI tests for `kbagent storage delete-column`."""
+
+    def test_delete_column_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_columns.return_value = {
+                "deleted": ["age"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-column",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--column",
+                    "age",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["deleted"] == ["age"]
+        assert data["table_id"] == "in.c-data.users"
+
+    def test_delete_column_dry_run(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_columns.return_value = {
+                "deleted": [],
+                "failed": [],
+                "would_delete": ["age"],
+                "dry_run": True,
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-column",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--column",
+                    "age",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_delete_column_multiple(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_columns.return_value = {
+                "deleted": ["age", "email"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-column",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--column",
+                    "age",
+                    "--column",
+                    "email",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["deleted"] == ["age", "email"]
+
+    def test_delete_column_exit_1_on_failure(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_columns.return_value = {
+                "deleted": [],
+                "failed": [{"column": "missing", "error": "not found"}],
+                "dry_run": False,
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-column",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--column",
+                    "missing",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
 # Branch support tests
 # ---------------------------------------------------------------------------
 
@@ -619,3 +842,58 @@ class TestStorageTablesBranch:
         assert result.exit_code == 0
         call_kwargs = svc.list_tables.call_args.kwargs
         assert call_kwargs["branch_id"] == 30
+
+
+class TestDeleteColumnBranch:
+    """Tests for --branch support in delete-column."""
+
+    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
+        """delete_columns passes branch_id to client.delete_column."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_column.return_value = None
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(
+            alias="test", table_id="in.c-data.users", columns=["age"], branch_id=42
+        )
+
+        assert result["deleted"] == ["age"]
+        mock_client.delete_column.assert_called_once_with("in.c-data.users", "age", branch_id=42)
+
+    def test_cli_branch_flag_json(self, tmp_path: Path) -> None:
+        """storage delete-column --branch 42 passes branch_id to service."""
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_columns.return_value = {
+                "deleted": ["age"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+                "table_id": "in.c-data.users",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-column",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--column",
+                    "age",
+                    "--branch",
+                    "42",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        call_kwargs = svc.delete_columns.call_args.kwargs
+        assert call_kwargs["branch_id"] == 42


### PR DESCRIPTION
## Summary

- Add `kbagent storage delete-column` command to delete one or more columns from a storage table
- Supports batch deletion (`--column` repeatable), `--dry-run` preview, `--yes` confirmation skip, `--branch` for dev branches
- Synchronous Storage API endpoint (`DELETE /v2/storage/tables/{tableId}/columns/{columnName}`)

## Changes

All 3 layers updated per CONTRIBUTING.md checklist:
- **Client**: `delete_column()` method in `client.py`
- **Service**: `delete_columns()` with batch-tolerant error accumulation in `storage_service.py`
- **Command**: thin Typer wrapper in `commands/storage.py`
- **Registrations**: permissions, hints, context, CLAUDE.md, SKILL.md
- **Tests**: 9 new tests (service layer, CLI layer, branch propagation)

## Usage

```bash
# Delete a single column
kbagent storage delete-column --project myproj --table-id in.c-bucket.table --column old_column

# Delete multiple columns
kbagent storage delete-column --project myproj --table-id in.c-bucket.table --column col1 --column col2

# Preview what would be deleted
kbagent storage delete-column --project myproj --table-id in.c-bucket.table --column col1 --dry-run

# Skip confirmation
kbagent storage delete-column --project myproj --table-id in.c-bucket.table --column col1 -y
```

## Test plan

- [x] Service-layer tests (single, batch, partial failure, dry-run, unknown project)
- [x] CLI-layer tests (JSON output, dry-run, multiple columns, exit code on failure)
- [x] Branch propagation tests (service + CLI)
- [x] Full test suite: 1597 passed, 0 failed

Closes #159