### PR TITLE
fix: branch-scoped file operations (#161)

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1197,18 +1197,20 @@ class KeboolaClient(BaseHttpClient):
         )
         return self._wait_for_storage_job(response.json(), max_wait=EXPORT_JOB_MAX_WAIT)
 
-    def get_file_info(self, file_id: int) -> dict[str, Any]:
+    def get_file_info(self, file_id: int, branch_id: int | None = None) -> dict[str, Any]:
         """Get file metadata including download URL.
 
         Args:
             file_id: Storage file ID (from export job results).
+            branch_id: If set, query file from a specific dev branch scope.
 
         Returns:
             File resource dict with 'url', 'isSliced', 'sizeBytes', etc.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         response = self._request(
             "GET",
-            f"/v2/storage/files/{file_id}",
+            f"{prefix}/files/{file_id}",
             params={"federationToken": "1"},
         )
         return response.json()
@@ -1292,32 +1294,38 @@ class KeboolaClient(BaseHttpClient):
             "created": upload_info.get("created"),
         }
 
-    def delete_file(self, file_id: int) -> None:
+    def delete_file(self, file_id: int, branch_id: int | None = None) -> None:
         """Delete a Storage File.
 
         Args:
             file_id: Storage file ID.
+            branch_id: If set, target a file in a specific dev branch scope.
         """
-        self._request("DELETE", f"/v2/storage/files/{file_id}")
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        self._request("DELETE", f"{prefix}/files/{file_id}")
 
-    def tag_file(self, file_id: int, tag: str) -> None:
+    def tag_file(self, file_id: int, tag: str, branch_id: int | None = None) -> None:
         """Add a tag to a Storage File.
 
         Args:
             file_id: Storage file ID.
             tag: Tag string to add.
+            branch_id: If set, target a file in a specific dev branch scope.
         """
-        self._request("POST", f"/v2/storage/files/{file_id}/tags", data={"tag": tag})
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        self._request("POST", f"{prefix}/files/{file_id}/tags", data={"tag": tag})
 
-    def untag_file(self, file_id: int, tag: str) -> None:
+    def untag_file(self, file_id: int, tag: str, branch_id: int | None = None) -> None:
         """Remove a tag from a Storage File.
 
         Args:
             file_id: Storage file ID.
             tag: Tag string to remove.
+            branch_id: If set, target a file in a specific dev branch scope.
         """
+        prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_tag = quote(tag, safe="")
-        self._request("DELETE", f"/v2/storage/files/{file_id}/tags/{safe_tag}")
+        self._request("DELETE", f"{prefix}/files/{file_id}/tags/{safe_tag}")
 
     def download_sliced_file(self, file_detail: dict[str, Any], output_path: str) -> int:
         """Download a sliced file by fetching manifest and concatenating slices.

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -600,8 +600,8 @@ class StorageService(BaseService):
                     retryable=False,
                 )
 
-            # Step 3: Get download URL
-            file_detail = client.get_file_info(file_id)
+            # Step 3: Get download URL (branch-scoped if exporting from dev branch)
+            file_detail = client.get_file_info(file_id, branch_id=branch_id)
             download_url = file_detail.get("url")
             if not download_url:
                 raise KeboolaApiError(
@@ -1193,12 +1193,12 @@ class StorageService(BaseService):
                     retryable=False,
                 )
 
-            # Step 3: Tag the exported file
+            # Step 3: Tag the exported file (branch-scoped if on dev branch)
             for tag in tags or []:
-                client.tag_file(file_id, tag)
+                client.tag_file(file_id, tag, branch_id=branch_id)
 
-            # Step 4: Get full file detail
-            file_detail = client.get_file_info(file_id)
+            # Step 4: Get full file detail (branch-scoped if on dev branch)
+            file_detail = client.get_file_info(file_id, branch_id=branch_id)
 
             result: dict[str, Any] = {
                 "project_alias": alias,

--- a/tests/test_storage_files.py
+++ b/tests/test_storage_files.py
@@ -449,8 +449,8 @@ class TestUnloadTableToFileService:
         )
 
         assert mock_client.tag_file.call_count == 2
-        mock_client.tag_file.assert_any_call(99, "export")
-        mock_client.tag_file.assert_any_call(99, "daily")
+        mock_client.tag_file.assert_any_call(99, "export", branch_id=None)
+        mock_client.tag_file.assert_any_call(99, "daily", branch_id=None)
 
     def test_unload_with_download(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -1071,3 +1071,121 @@ class TestFormatFileSize:
         from keboola_agent_cli.commands.storage import _format_file_size
 
         assert _format_file_size(2 * 1024 * 1024 * 1024) == "2.00 GB"
+
+
+# ------------------------------------------------------------------
+# Branch-scoped file operations (issue #161)
+# ------------------------------------------------------------------
+
+
+class TestClientGetFileInfoBranch:
+    """Verify get_file_info uses branch-scoped URL prefix."""
+
+    def test_get_file_info_without_branch(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(json=SAMPLE_FILE)
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.get_file_info(12345)
+        request = httpx_mock.get_requests()[0]
+        assert "/v2/storage/files/12345" in str(request.url)
+        assert "/branch/" not in str(request.url)
+        client.close()
+
+    def test_get_file_info_with_branch(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(json=SAMPLE_FILE)
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.get_file_info(12345, branch_id=42)
+        request = httpx_mock.get_requests()[0]
+        assert "/v2/storage/branch/42/files/12345" in str(request.url)
+        client.close()
+
+
+class TestClientDeleteFileBranch:
+    """Verify delete_file uses branch-scoped URL prefix."""
+
+    def test_delete_file_with_branch(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(method="DELETE", status_code=204)
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.delete_file(12345, branch_id=42)
+        request = httpx_mock.get_requests()[0]
+        assert "/v2/storage/branch/42/files/12345" in str(request.url)
+        client.close()
+
+
+class TestClientTagFileBranch:
+    """Verify tag_file and untag_file use branch-scoped URL prefix."""
+
+    def test_tag_file_with_branch(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(method="POST", status_code=201)
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.tag_file(12345, "my-tag", branch_id=42)
+        request = httpx_mock.get_requests()[0]
+        assert "/v2/storage/branch/42/files/12345/tags" in str(request.url)
+        client.close()
+
+    def test_untag_file_with_branch(self, httpx_mock) -> None:
+        from keboola_agent_cli.client import KeboolaClient
+
+        httpx_mock.add_response(method="DELETE", status_code=204)
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+        )
+        client.untag_file(12345, "old-tag", branch_id=42)
+        request = httpx_mock.get_requests()[0]
+        assert "/v2/storage/branch/42/files/12345/tags/old-tag" in str(request.url)
+        client.close()
+
+
+class TestUnloadTableToFileBranchService:
+    """Verify unload_table_to_file passes branch_id to file operations."""
+
+    def test_unload_with_branch_passes_branch_to_file_ops(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.export_table_async.return_value = {
+            "results": {"file": {"id": 99}},
+        }
+        mock_client.get_file_info.return_value = {
+            "id": 99,
+            "name": "export.csv.gz",
+            "sizeBytes": 2048,
+            "isSliced": False,
+            "tags": ["export"],
+        }
+        service = _make_service(store, mock_client)
+
+        service.unload_table_to_file(
+            alias="test",
+            table_id="in.c-data.users",
+            tags=["export"],
+            branch_id=33,
+        )
+
+        mock_client.export_table_async.assert_called_once_with(
+            table_id="in.c-data.users",
+            columns=None,
+            limit=None,
+            branch_id=33,
+        )
+        mock_client.tag_file.assert_called_once_with(99, "export", branch_id=33)
+        mock_client.get_file_info.assert_called_once_with(99, branch_id=33)

--- a/tests/test_storage_write.py
+++ b/tests/test_storage_write.py
@@ -1255,7 +1255,7 @@ class TestDownloadTableService:
             limit=None,
             branch_id=None,
         )
-        mock_client.get_file_info.assert_called_once_with(42)
+        mock_client.get_file_info.assert_called_once_with(42, branch_id=None)
         mock_client.close.assert_called_once()
 
     def test_with_columns_and_limit(self, tmp_path: Path) -> None:
@@ -1432,6 +1432,8 @@ class TestDownloadTableService:
             limit=None,
             branch_id=42,
         )
+        # Issue #161: get_file_info must also receive branch_id
+        mock_client.get_file_info.assert_called_once_with(7, branch_id=42)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `download-table` and `unload-table` failing with `NOT_FOUND` on dev branch tables
- Add `branch_id` parameter to `get_file_info`, `delete_file`, `tag_file`, `untag_file` in `client.py`
- Pass `branch_id` through from `download_table` and `unload_table_to_file` in the service layer

## Root cause

`export_table_async` correctly creates files in branch scope (`/v2/storage/branch/{id}/tables/.../export-async`), but the follow-up `get_file_info` call queried main scope (`/v2/storage/files/{id}`) — returning 404 because the file only exists in the branch scope.

## Test plan

- [x] Client-level tests verify branch URL prefix for all 4 file methods
- [x] Service-level test for `download_table` with `branch_id` asserts `get_file_info(file_id, branch_id=42)`
- [x] Service-level test for `unload_table_to_file` with `branch_id` asserts both `tag_file` and `get_file_info` receive `branch_id`
- [x] Full test suite passes (1592 tests)

Closes #161