### PR TITLE
fix: job run now respects active dev branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ kbagent config rename --project NAME --component-id ID --config-id ID --name "Ne
 
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID
-kbagent job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N]
+kbagent job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N] [--branch ID]
 
 kbagent storage buckets [--project NAME] [--branch ID]
 kbagent storage bucket-detail --project NAME --bucket-id ID [--branch ID]

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -37,7 +37,7 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 ## Job History
 - `job list [--project NAME] [--component-id ID] [--config-id ID] [--status STATUS] [--limit N]` -- list jobs (default 50, max 500)
 - `job detail --project NAME --job-id ID` -- full job detail with timing and result message
-- `job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N]` -- run a job, optionally wait for completion
+- `job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N] [--branch ID]` -- run a job, optionally wait for completion (branch-aware)
 
 ## Storage
 - `storage buckets [--project NAME] [--branch ID]` -- list buckets with sharing/linked info (branch-aware)

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1543,6 +1543,7 @@ class KeboolaClient(BaseHttpClient):
         config_data: dict[str, Any] | None = None,
         config_row_ids: list[str] | None = None,
         mode: str = "run",
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create and run a Queue API job.
 
@@ -1553,6 +1554,8 @@ class KeboolaClient(BaseHttpClient):
             config_row_ids: Optional list of config row IDs to run
                 (omit to run entire config).
             mode: Job mode (default: run).
+            branch_id: Optional dev branch ID. When set, the job runs
+                on that branch instead of the default (production) branch.
 
         Returns:
             Job dict from the Queue API.
@@ -1562,6 +1565,8 @@ class KeboolaClient(BaseHttpClient):
             "config": config_id,
             "mode": mode,
         }
+        if branch_id is not None:
+            body["branchId"] = str(branch_id)
         if config_data:
             body["configData"] = config_data
         if config_row_ids:

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -118,9 +118,9 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent job detail --project NAME --job-id ID
     Full job detail including result message and timing.
 
-  kbagent job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N]
+  kbagent job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N] [--branch ID]
     Run a Queue API job. --row-id selects specific config rows (repeatable; omit to run entire config).
-    --wait polls until job finishes. --timeout sets max wait in seconds (default 300).
+    --wait polls until job finishes. --timeout sets max wait in seconds (default 300). Branch-aware.
 
 ### Storage
 

--- a/src/keboola_agent_cli/commands/job.py
+++ b/src/keboola_agent_cli/commands/job.py
@@ -6,6 +6,7 @@ No business logic belongs here.
 
 import typer
 
+from ..config_store import ConfigStore
 from ..constants import DEFAULT_JOB_LIMIT, DEFAULT_JOB_RUN_TIMEOUT, MAX_JOB_LIMIT, VALID_STATUSES
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_job_detail, format_jobs_table
@@ -16,7 +17,9 @@ from ._helpers import (
     get_formatter,
     get_service,
     map_error_to_exit_code,
+    resolve_branch,
     should_hint,
+    validate_branch_requires_project,
 )
 
 job_app = typer.Typer(help="Browse job history and run jobs")
@@ -177,11 +180,19 @@ def job_run(
         "--timeout",
         help="Max seconds to wait when --wait is set",
     ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (overrides active branch)",
+    ),
 ) -> None:
     """Run a job for a component configuration.
 
     Creates a Queue API job and optionally waits for completion.
     Use --row-id to run specific configuration rows.
+
+    When a dev branch is active (via 'branch use'), the job automatically
+    runs on that branch. Use --branch to override.
     """
     if should_hint(ctx):
         emit_hint(
@@ -193,15 +204,22 @@ def job_run(
             row_id=row_id,
             wait=wait,
             timeout=timeout,
+            branch=branch,
         )
         return
     formatter = get_formatter(ctx)
     service = get_service(ctx, "job_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+
+    validate_branch_requires_project(formatter, branch, project)
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
 
     if not formatter.json_mode:
         msg = f"Running [cyan]{component_id}[/cyan] / [cyan]{config_id}[/cyan]"
         if row_id:
             msg += f" (rows: {', '.join(row_id)})"
+        if effective_branch is not None:
+            msg += f" on branch [cyan]{effective_branch}[/cyan]"
         if wait:
             msg += f" [dim](waiting up to {timeout:.0f}s)[/dim]"
         msg += "..."
@@ -215,6 +233,7 @@ def job_run(
             config_row_ids=row_id,
             wait=wait,
             timeout=timeout,
+            branch_id=effective_branch,
         )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")

--- a/src/keboola_agent_cli/services/job_service.py
+++ b/src/keboola_agent_cli/services/job_service.py
@@ -156,6 +156,7 @@ class JobService(BaseService):
         config_row_ids: list[str] | None = None,
         wait: bool = False,
         timeout: float = 300.0,
+        branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Create and optionally wait for a Queue API job.
 
@@ -166,6 +167,8 @@ class JobService(BaseService):
             config_row_ids: Optional row IDs (omit to run entire config).
             wait: If True, poll until job finishes or timeout.
             timeout: Max seconds to wait (only used when wait=True).
+            branch_id: Optional dev branch ID. When set, the job runs
+                on that branch instead of the default (production) branch.
 
         Returns:
             Job dict with project_alias. If wait=True, returns the
@@ -180,6 +183,7 @@ class JobService(BaseService):
                 component_id=component_id,
                 config_id=config_id,
                 config_row_ids=config_row_ids,
+                branch_id=branch_id,
             )
             job_id = str(job.get("id", ""))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2041,6 +2041,211 @@ class TestJobDetail:
         assert output["error"]["code"] == "NOT_FOUND"
 
 
+class TestJobRun:
+    """Tests for `kbagent job run` command - branch support."""
+
+    def test_job_run_with_branch_flag(self, tmp_path: Path) -> None:
+        """job run --branch 789 passes branch_id to service.run_job."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+
+            job_service = MagicMock()
+            job_service.run_job.return_value = {
+                "id": 555,
+                "status": "waiting",
+                "branchId": "789",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "run",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.snowflake-transformation",
+                    "--config-id",
+                    "100",
+                    "--branch",
+                    "789",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        job_service.run_job.assert_called_once()
+        call_kwargs = job_service.run_job.call_args
+        assert call_kwargs.kwargs.get("branch_id") == 789 or (
+            call_kwargs[1].get("branch_id") == 789 if call_kwargs[1] else False
+        )
+
+    def test_job_run_active_branch_resolved(self, tmp_path: Path) -> None:
+        """job run without --branch uses active_branch_id from config."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+        # Set active branch for the project
+        store.set_project_branch("prod", 456)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+
+            job_service = MagicMock()
+            job_service.run_job.return_value = {
+                "id": 556,
+                "status": "waiting",
+                "branchId": "456",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "run",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-http",
+                    "--config-id",
+                    "42",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        job_service.run_job.assert_called_once()
+        call_kwargs = job_service.run_job.call_args
+        assert call_kwargs.kwargs.get("branch_id") == 456 or (
+            call_kwargs[1].get("branch_id") == 456 if call_kwargs[1] else False
+        )
+
+    def test_job_run_no_branch_passes_none(self, tmp_path: Path) -> None:
+        """job run without --branch and no active branch passes branch_id=None."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+
+            job_service = MagicMock()
+            job_service.run_job.return_value = {
+                "id": 557,
+                "status": "waiting",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "run",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.ex-http",
+                    "--config-id",
+                    "42",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        job_service.run_job.assert_called_once()
+        call_kwargs = job_service.run_job.call_args
+        assert call_kwargs.kwargs.get("branch_id") is None or (
+            call_kwargs[1].get("branch_id") is None if call_kwargs[1] else True
+        )
+
+    def test_job_run_branch_requires_project(self, tmp_path: Path) -> None:
+        """job run --branch 123 without --project is rejected (but --project is required anyway)."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+            MockJobService.return_value = JobService(config_store=store)
+
+            # --project is required for job run, so missing it returns usage error
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "run",
+                    "--component-id",
+                    "keboola.ex-http",
+                    "--config-id",
+                    "42",
+                    "--branch",
+                    "123",
+                ],
+            )
+
+        # --project is required, so typer returns exit code 2 (usage error)
+        assert result.exit_code == 2
+
+
 # ---------------------------------------------------------------------------
 # Context command tests
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2128,3 +2128,82 @@ class TestUploadTableClient:
         ):
             client.upload_table(table_id="in.c-b.users", file_path=str(csv_file))
         assert exc_info.value.error_code == "UPLOAD_FAILED"
+
+
+class TestCreateJob:
+    """Tests for create_job() - Queue API job creation with branch support."""
+
+    def test_create_job_without_branch(self, httpx_mock) -> None:
+        """create_job() without branch_id does not include branchId in body."""
+        job_response = {"id": 555, "status": "waiting", "component": "keboola.ex-http"}
+        httpx_mock.add_response(
+            url="https://queue.keboola.com/jobs",
+            method="POST",
+            json=job_response,
+            status_code=201,
+        )
+
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.create_job(component_id="keboola.ex-http", config_id="42")
+
+        assert result["id"] == 555
+        request = httpx_mock.get_request()
+        import json
+
+        body = json.loads(request.content)
+        assert body["component"] == "keboola.ex-http"
+        assert body["config"] == "42"
+        assert "branchId" not in body
+
+    def test_create_job_with_branch(self, httpx_mock) -> None:
+        """create_job() with branch_id includes branchId in POST body."""
+        job_response = {"id": 556, "status": "waiting", "branchId": "789"}
+        httpx_mock.add_response(
+            url="https://queue.keboola.com/jobs",
+            method="POST",
+            json=job_response,
+            status_code=201,
+        )
+
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.create_job(
+                component_id="keboola.snowflake-transformation",
+                config_id="100",
+                branch_id=789,
+            )
+
+        assert result["id"] == 556
+        assert result["branchId"] == "789"
+        request = httpx_mock.get_request()
+        import json
+
+        body = json.loads(request.content)
+        assert body["branchId"] == "789"
+        assert body["component"] == "keboola.snowflake-transformation"
+        assert body["config"] == "100"
+
+    def test_create_job_with_branch_and_row_ids(self, httpx_mock) -> None:
+        """create_job() with branch_id and config_row_ids includes both in body."""
+        job_response = {"id": 557, "status": "waiting"}
+        httpx_mock.add_response(
+            url="https://queue.keboola.com/jobs",
+            method="POST",
+            json=job_response,
+            status_code=201,
+        )
+
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.create_job(
+                component_id="keboola.ex-http",
+                config_id="42",
+                branch_id=123,
+                config_row_ids=["row1", "row2"],
+            )
+
+        assert result["id"] == 557
+        request = httpx_mock.get_request()
+        import json
+
+        body = json.loads(request.content)
+        assert body["branchId"] == "123"
+        assert body["configRowIds"] == ["row1", "row2"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1749,6 +1749,28 @@ class TestFullE2E:
         data = self._run_ok("storage", "buckets", "--project", self.alias)
         assert data["data"]["errors"] == []
 
+        # job run should respect active branch (issue #170)
+        # Find any config to run a quick job (no --wait)
+        cfg_data = self._run_ok("config", "list", "--project", self.alias)
+        configs = cfg_data["data"]["configs"]
+        if configs:
+            test_cfg = configs[0]
+            job_data = self._run_ok(
+                "job",
+                "run",
+                "--project",
+                self.alias,
+                "--component-id",
+                test_cfg["component_id"],
+                "--config-id",
+                test_cfg["config_id"],
+            )
+            job = job_data["data"]
+            assert str(job.get("branchId")) == str(branch_id), (
+                f"job run with active branch: expected branchId={branch_id}, "
+                f"got {job.get('branchId')}"
+            )
+
         # branch reset -- deactivate the dev branch
         data = self._run_ok("branch", "reset", "--project", self.alias)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1719,6 +1719,137 @@ class TestJobServiceGetJobDetail:
         mock_client.close.assert_called_once()
 
 
+class TestJobServiceRunJob:
+    """Tests for JobService.run_job() - including branch_id support."""
+
+    def test_run_job_without_branch(self, tmp_config_dir: Path) -> None:
+        """run_job without branch_id calls create_job without branch_id."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-abc-defghijklmnopqrst",
+                project_name="Production",
+                project_id=1234,
+            ),
+        )
+
+        mock_client = MagicMock()
+        mock_client.create_job.return_value = {
+            "id": 555,
+            "status": "waiting",
+            "component": "keboola.ex-http",
+        }
+
+        service = JobService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.run_job(
+            alias="prod",
+            component_id="keboola.ex-http",
+            config_id="42",
+        )
+
+        assert result["id"] == 555
+        assert result["project_alias"] == "prod"
+        mock_client.create_job.assert_called_once_with(
+            component_id="keboola.ex-http",
+            config_id="42",
+            config_row_ids=None,
+            branch_id=None,
+        )
+        mock_client.close.assert_called_once()
+
+    def test_run_job_with_branch(self, tmp_config_dir: Path) -> None:
+        """run_job with branch_id forwards it to create_job."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "dev",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-abc-defghijklmnopqrst",
+                project_name="Dev",
+                project_id=5678,
+            ),
+        )
+
+        mock_client = MagicMock()
+        mock_client.create_job.return_value = {
+            "id": 556,
+            "status": "waiting",
+            "branchId": "789",
+        }
+
+        service = JobService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.run_job(
+            alias="dev",
+            component_id="keboola.snowflake-transformation",
+            config_id="100",
+            branch_id=789,
+        )
+
+        assert result["id"] == 556
+        assert result["project_alias"] == "dev"
+        mock_client.create_job.assert_called_once_with(
+            component_id="keboola.snowflake-transformation",
+            config_id="100",
+            config_row_ids=None,
+            branch_id=789,
+        )
+
+    def test_run_job_with_branch_and_wait(self, tmp_config_dir: Path) -> None:
+        """run_job with branch_id and wait=True polls until completion."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "dev",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="901-abc-defghijklmnopqrst",
+                project_name="Dev",
+                project_id=5678,
+            ),
+        )
+
+        mock_client = MagicMock()
+        mock_client.create_job.return_value = {"id": 557, "status": "waiting"}
+        mock_client.wait_for_queue_job.return_value = {
+            "id": 557,
+            "status": "success",
+            "isFinished": True,
+        }
+
+        service = JobService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = service.run_job(
+            alias="dev",
+            component_id="keboola.ex-http",
+            config_id="42",
+            branch_id=123,
+            wait=True,
+            timeout=60.0,
+        )
+
+        assert result["status"] == "success"
+        assert result["project_alias"] == "dev"
+        mock_client.create_job.assert_called_once_with(
+            component_id="keboola.ex-http",
+            config_id="42",
+            config_row_ids=None,
+            branch_id=123,
+        )
+        mock_client.wait_for_queue_job.assert_called_once_with("557", max_wait=60.0)
+
+
 # ---------------------------------------------------------------------------
 # Parallel-specific tests: deterministic ordering, unexpected exceptions
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `job run` always targeted the production branch because `create_job()` did not forward `branch_id` to the Queue API POST body. This caused silent false-positive results when testing changes on dev branches.
- Added `branch_id` parameter across all three layers (client, service, command) and `--branch` CLI flag with active branch auto-resolution via `resolve_branch()` helper -- same pattern as all other branch-aware commands.
- Updated `kbagent context`, CLAUDE.md command reference, and plugin commands-reference.md.

Closes #170

## Test plan

- [x] Unit tests: `TestCreateJob` (3 tests) -- verifies Queue API POST body with/without branchId
- [x] Unit tests: `TestJobServiceRunJob` (3 tests) -- verifies branch_id forwarding to client
- [x] Unit tests: `TestJobRun` (4 tests) -- verifies `--branch` flag, active branch resolve, no-branch=None, branch-requires-project
- [x] E2E test: `_test_branch_lifecycle` extended with job run branchId assertion
- [x] Manual E2E on real API (padak project): 4 scenarios all PASS (no branch, active branch resolve, explicit --branch override, after branch reset)
- [x] Full test suite: 1697 passed, lint clean (`make check`)