### PR TITLE
feat: add --force flag to storage delete-table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ kbagent storage create-bucket --project NAME --stage STAGE --name NAME [--descri
 kbagent storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]
 kbagent storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]
 kbagent storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]
-kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
+kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--force] [--dry-run] [--yes] [--branch ID]
 kbagent storage delete-column --project NAME --table-id ID --column COL [--column ...] [--force] [--dry-run] [--yes] [--branch ID]
 kbagent storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]
 kbagent storage files --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -48,7 +48,7 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]` -- create typed table (branch-aware)
 - `storage upload-table --project NAME --table-id ID --file PATH [--incremental] [--branch ID]` -- upload CSV (branch-aware)
 - `storage download-table --project NAME --table-id ID [--output FILE] [--columns COL ...] [--limit N] [--branch ID]` -- export table to CSV (branch-aware)
-- `storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]` -- delete tables (branch-aware)
+- `storage delete-table --project NAME --table-id ID [--table-id ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete tables, --force cascade-deletes aliased tables (branch-aware)
 - `storage delete-column --project NAME --table-id ID --column COL [--column ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete columns from a table (branch-aware)
 - `storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete buckets (branch-aware)
 

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1114,19 +1114,28 @@ class KeboolaClient(BaseHttpClient):
         )
         return job.get("results", {})
 
-    def delete_table(self, table_id: str, branch_id: int | None = None) -> dict[str, Any]:
+    def delete_table(
+        self,
+        table_id: str,
+        branch_id: int | None = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
         """Delete a storage table (async, waits for completion).
 
         Args:
             table_id: Full table ID (e.g. "in.c-bucket.table").
             branch_id: If set, target a specific dev branch.
+            force: If True, cascade-delete the table and all its aliases.
 
         Returns:
             Completed storage job dict.
         """
         prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
         safe_id = quote(table_id, safe="")
-        response = self._request("DELETE", f"{prefix}/tables/{safe_id}", params={"async": "true"})
+        params: dict[str, str] = {"async": "true"}
+        if force:
+            params["force"] = "true"
+        response = self._request("DELETE", f"{prefix}/tables/{safe_id}", params=params)
         return self._wait_for_storage_job(response.json())
 
     def delete_column(

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -153,8 +153,8 @@ Use `kbagent <command> --help` for full flag details and examples.
     Default filename: TABLE_NAME.csv. Use --columns to select columns (see table-detail for names).
     Use --limit to cap row count. Handles sliced files and gzip decompression transparently. Branch-aware.
 
-  kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--dry-run] [--yes] [--branch ID]
-    Delete one or more tables. Batch: repeat --table-id. --dry-run to preview. Branch-aware.
+  kbagent storage delete-table --project NAME --table-id ID [--table-id ...] [--force] [--dry-run] [--yes] [--branch ID]
+    Delete one or more tables. Batch: repeat --table-id. --force to cascade-delete aliased tables. --dry-run to preview. Branch-aware.
 
   kbagent storage delete-column --project NAME --table-id ID --column COL [--column ...] [--force] [--dry-run] [--yes] [--branch ID]
     Delete one or more columns from a table. Batch: repeat --column. --force when column is referenced by aliases. --dry-run to preview. Branch-aware.

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -747,6 +747,11 @@ def storage_delete_table(
         "--table-id",
         help="Table ID to delete (e.g. 'in.c-bucket.table'). Can be repeated.",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force-delete tables that have aliases in other projects (cascade).",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -768,6 +773,10 @@ def storage_delete_table(
 
     Supports batch deletion with multiple --table-id flags.
     All deletes are async and wait for completion.
+
+    Use --force to cascade-delete tables that have aliases linked
+    into other projects (shared buckets). Without --force, the API
+    rejects deletion of aliased tables.
     """
     if should_hint(ctx):
         emit_hint(
@@ -775,6 +784,7 @@ def storage_delete_table(
             "storage.delete-table",
             project=project,
             table_id=table_id,
+            force=force,
             dry_run=dry_run,
             branch=branch,
         )
@@ -803,11 +813,13 @@ def storage_delete_table(
                 formatter.console.print(f"[bold blue]Would delete:[/bold blue] {tid}")
         return
 
-    if (
-        not yes
-        and not formatter.json_mode
-        and not typer.confirm(f"Delete {len(table_id)} table(s) from project '{project}'?")
-    ):
+    confirm_msg = f"Delete {len(table_id)} table(s) from project '{project}'?"
+    if force:
+        confirm_msg = (
+            f"FORCE-delete {len(table_id)} table(s) from project '{project}'?"
+            " This will also delete all aliases in downstream projects."
+        )
+    if not yes and not formatter.json_mode and not typer.confirm(confirm_msg):
         formatter.console.print("Aborted.")
         raise typer.Exit(code=0)
 
@@ -815,6 +827,7 @@ def storage_delete_table(
         result = service.delete_tables(
             alias=project,
             table_ids=table_id,
+            force=force,
             branch_id=effective_branch,
         )
     except ConfigError as exc:

--- a/src/keboola_agent_cli/hints/definitions/storage.py
+++ b/src/keboola_agent_cli/hints/definitions/storage.py
@@ -330,7 +330,11 @@ HintRegistry.register(
                 comment="Delete table(s)",
                 client=ClientCall(
                     method="delete_table",
-                    args={"table_id": "{table_id}", "branch_id": "{branch}"},
+                    args={
+                        "table_id": "{table_id}",
+                        "branch_id": "{branch}",
+                        "force": "{force}",
+                    },
                     result_var="result",
                 ),
                 service=ServiceCall(
@@ -340,13 +344,17 @@ HintRegistry.register(
                     args={
                         "alias": "{project}",
                         "table_ids": "{table_id}",
+                        "force": "{force}",
                         "dry_run": "{dry_run}",
                         "branch_id": "{branch}",
                     },
                 ),
             ),
         ],
-        notes=["Client layer deletes one table at a time. Loop for batch."],
+        notes=[
+            "Client layer deletes one table at a time. Loop for batch.",
+            "Use force=True to cascade-delete aliased tables in downstream projects.",
+        ],
     )
 )
 

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -643,6 +643,7 @@ class StorageService(BaseService):
         alias: str,
         table_ids: list[str],
         dry_run: bool = False,
+        force: bool = False,
         branch_id: int | None = None,
     ) -> dict[str, Any]:
         """Delete one or more storage tables.
@@ -654,6 +655,7 @@ class StorageService(BaseService):
             alias: Project alias.
             table_ids: List of table IDs to delete.
             dry_run: If True, only report what would be deleted.
+            force: If True, cascade-delete tables and all their aliases.
             branch_id: If set, target a specific dev branch.
 
         Returns:
@@ -681,7 +683,7 @@ class StorageService(BaseService):
         try:
             for tid in table_ids:
                 try:
-                    client.delete_table(tid, branch_id=branch_id)
+                    client.delete_table(tid, branch_id=branch_id, force=force)
                     deleted.append(tid)
                 except KeboolaApiError as exc:
                     failed.append({"id": tid, "error": exc.message})

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -55,7 +55,23 @@ class TestDeleteTablesService:
         assert result["deleted"] == ["in.c-data.users"]
         assert result["failed"] == []
         assert result["dry_run"] is False
-        mock_client.delete_table.assert_called_once_with("in.c-data.users", branch_id=None)
+        mock_client.delete_table.assert_called_once_with(
+            "in.c-data.users", branch_id=None, force=False
+        )
+
+    def test_force_flag(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_table.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(alias="test", table_ids=["in.c-data.users"], force=True)
+
+        assert result["deleted"] == ["in.c-data.users"]
+        assert result["failed"] == []
+        mock_client.delete_table.assert_called_once_with(
+            "in.c-data.users", branch_id=None, force=True
+        )
 
     def test_batch_partial_failure(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -264,6 +280,44 @@ class TestDeleteTableCLI:
                 ],
             )
         assert result.exit_code == 0
+
+    def test_delete_table_force_json(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_tables.return_value = {
+                "deleted": ["out.c-shared.users"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "out.c-shared.users",
+                    "--force",
+                    "--yes",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["deleted"] == ["out.c-shared.users"]
+        svc.delete_tables.assert_called_once_with(
+            alias="test",
+            table_ids=["out.c-shared.users"],
+            force=True,
+            branch_id=None,
+        )
 
     def test_delete_table_exit_1_on_failure(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -639,7 +693,9 @@ class TestDeleteTableBranch:
         result = service.delete_tables(alias="test", table_ids=["in.c-data.users"], branch_id=42)
 
         assert result["deleted"] == ["in.c-data.users"]
-        mock_client.delete_table.assert_called_once_with("in.c-data.users", branch_id=42)
+        mock_client.delete_table.assert_called_once_with(
+            "in.c-data.users", branch_id=42, force=False
+        )
 
     def test_cli_branch_flag_json(self, tmp_path: Path) -> None:
         """storage delete-table --branch 42 passes branch_id to service."""


### PR DESCRIPTION
## Summary
- Adds `--force` flag to `storage delete-table` that sends `?force=1` to the Storage API, cascade-deleting tables with aliases in downstream projects
- Mirrors the existing `--force` behavior on `delete-column` and `delete-bucket`
- Propagated through all 3 layers: client (`force` param), service (`force` param), command (`--force` CLI flag)
- Enhanced confirmation prompt warns about cascade when `--force` is used

## Checklist (per CONTRIBUTING.md)
- [x] Client method (`client.py`)
- [x] Service method (`services/storage_service.py`)
- [x] Command function (`commands/storage.py`)
- [x] Hint definition (`hints/definitions/storage.py`)
- [x] Permission registration (already `destructive` -- unchanged)
- [x] `kbagent context` updated (`commands/context.py`)
- [x] SKILL.md regenerated (`make skill-gen`)
- [x] CLAUDE.md command signature updated
- [x] Plugin `commands-reference.md` updated
- [x] Service-layer tests (force flag, existing updated)
- [x] CLI-layer tests (--force JSON output)
- [x] `make check` passes (1699 passed)

Closes #174