### PR TITLE
feat: project description and branch metadata management (v0.21.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ kbagent project edit --project NAME [--url URL] [--token TOKEN]
 kbagent project status [--project NAME]
 kbagent project refresh --project ALIAS [--dry-run] [--force] [--yes] [--token-description DESC] [--token-expires-in N]
 kbagent project refresh --all [--dry-run] [--force] [--yes] [--token-description DESC] [--token-expires-in N]
+kbagent project description-get --project NAME
+kbagent project description-set --project NAME [--text STR | --file PATH | --stdin]
 
 kbagent config list [--project NAME] [--component-type TYPE] [--component-id ID] [--branch ID]
 kbagent config detail --project NAME --component-id ID --config-id ID [--branch ID]
@@ -297,6 +299,10 @@ kbagent branch use --project ALIAS --branch ID
 kbagent branch reset --project ALIAS
 kbagent branch delete --project ALIAS --branch ID
 kbagent branch merge --project ALIAS [--branch ID]
+kbagent branch metadata-list --project NAME [--branch ID|default]
+kbagent branch metadata-get --project NAME --key KEY [--branch ID|default]
+kbagent branch metadata-set --project NAME --key KEY [--text STR | --file PATH | --stdin] [--branch ID|default]
+kbagent branch metadata-delete --project NAME --metadata-id ID [--branch ID|default]
 
 kbagent workspace create --project ALIAS [--name NAME] [--backend TYPE] [--ui] [--read-only/--no-read-only]
 kbagent workspace list [--project NAME]

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -61,6 +61,8 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Edit an existing Keboola project connection | `kbagent project edit --project ALIAS` |
 | Test connectivity to connected Keboola projects | `kbagent project status` |
 | Refresh expired or invalid Storage API tokens | `kbagent project refresh` |
+| Get the Keboola dashboard project description | `kbagent project description-get --project PROJECT` |
+| Set the Keboola dashboard project description (markdown) | `kbagent project description-set --project PROJECT` |
 | Set up projects and register them in the kbagent config | `kbagent org setup --url URL` |
 | List available components from connected projects | `kbagent component list` |
 | Show detailed information about a specific component | `kbagent component detail --component-id COMPONENT-ID` |
@@ -113,6 +115,10 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | Reset the active branch back to main/production | `kbagent branch reset --project PROJECT` |
 | Delete a development branch | `kbagent branch delete --project PROJECT --branch BRANCH` |
 | Get the KBC UI merge URL for a development branch | `kbagent branch merge --project PROJECT` |
+| List all metadata entries on a branch | `kbagent branch metadata-list --project PROJECT` |
+| Read a single metadata value by key | `kbagent branch metadata-get --project PROJECT --key KEY` |
+| Set a metadata key/value on a branch | `kbagent branch metadata-set --project PROJECT --key KEY` |
+| Delete a branch metadata entry by its numeric ID | `kbagent branch metadata-delete --project PROJECT --metadata-id METADATA-ID` |
 | Create a new workspace | `kbagent workspace create --project PROJECT` |
 | List workspaces from connected projects | `kbagent workspace list` |
 | Show workspace details (password NOT included) | `kbagent workspace detail --project PROJECT --workspace-id WORKSPACE-ID` |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -16,6 +16,8 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `project remove --project NAME` -- disconnect a project
 - `project edit --project NAME [--url URL] [--token TOKEN]` -- update connection details
 - `project status [--project NAME]` -- test connectivity and response time
+- `project description-get --project NAME` -- read the dashboard project description (KBC.projectDescription on the default branch). Returns `{"description": ""}` if not set, not an error
+- `project description-set --project NAME [--text STR | --file PATH | --stdin]` -- set the dashboard project description (markdown). Pass exactly one of `--text`, `--file`, or `--stdin`. Writes to `KBC.projectDescription` on the default branch -- always the main branch, regardless of any active dev branch
 
 ## Organization
 - `org setup --org-id ID --url URL [--dry-run] [--yes]` -- bulk-onboard all projects from an org (org admin, needs `KBC_MANAGE_API_TOKEN`)
@@ -67,6 +69,10 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `branch reset --project ALIAS` -- reset to main/production
 - `branch delete --project ALIAS --branch ID` -- delete branch (resets if active)
 - `branch merge --project ALIAS [--branch ID]` -- get merge URL (does NOT merge via API)
+- `branch metadata-list --project NAME [--branch ID|default]` -- list all metadata entries on a branch (id, key, value, provider, timestamp). `--branch` defaults to `default` (main branch)
+- `branch metadata-get --project NAME --key KEY [--branch ID|default]` -- read a single metadata value by key. Exits with `NOT_FOUND` (exit 1) if absent
+- `branch metadata-set --project NAME --key KEY [--text STR | --file PATH | --stdin] [--branch ID|default]` -- set a key/value. Useful for `KBC.projectDescription` and similar dashboard-visible fields. Pass exactly one of `--text`, `--file`, or `--stdin`
+- `branch metadata-delete --project NAME --metadata-id ID [--branch ID|default]` -- delete a metadata entry by its numeric ID (from `metadata-list`)
 
 ## Workspaces (SQL Debugging)
 - `workspace create --project ALIAS [--name NAME] [--ui] [--read-only]` -- create workspace (headless ~1s, `--ui` ~15s)

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -323,3 +323,19 @@ See [docs/hint-mode.md](../../../../../docs/hint-mode.md) for full documentation
 - **Not saving workspace password**: only returned once on creation
 - **Putting SQL in _config.yml**: SQL transformations must use `transform.sql` with block markers (see above)
 - **Auto-running jobs after config update**: never start a job automatically after pushing config changes -- let the user decide when to run
+
+## Project description vs branch description
+
+The "description" shown on the Keboola project dashboard is **not** the same
+field as a branch's `description` attribute:
+
+- **Dashboard project description** = `KBC.projectDescription` metadata on the
+  **default (main) branch**. Set via `kbagent project description-set` (or
+  generically `kbagent branch metadata-set --key KBC.projectDescription --branch default`)
+- **Dev branch description** = the `description` field on a dev branch record.
+  Set via `kbagent branch create --description "..."`; visible in the branch
+  switcher and synced as `description.md` by the kbc CLI
+
+They live at different endpoints in the Storage API
+(`/v2/storage/branch/{id}/metadata` vs. `/v2/storage/dev-branches/{id}`),
+so setting a branch's description will **not** update the dashboard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.20.0"
+version = "0.21.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,11 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.21.0": [
+        "New: project description-get / description-set -- read/write the Keboola dashboard project description (markdown)",
+        "New: branch metadata-list / metadata-get / metadata-set / metadata-delete -- generic CRUD over branch metadata (KBC.* keys)",
+        "New: client helpers list/set/delete_branch_metadata + get_branch_metadata_value on KeboolaClient",
+    ],
     "0.20.0": [
         "New: lineage build -- column-level lineage graph from sync'd data (SQL tokenizer + AI)",
         "New: lineage show -- query upstream/downstream with --columns, -c trace, --format mermaid/html/er",

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -575,6 +575,96 @@ class KeboolaClient(BaseHttpClient):
         response = self._request("GET", "/v2/storage/dev-branches")
         return response.json()
 
+    def list_branch_metadata(self, branch_id: int | str = "default") -> list[dict[str, Any]]:
+        """List metadata entries on a branch.
+
+        GET /v2/storage/branch/{id}/metadata
+
+        Args:
+            branch_id: Branch ID or the literal "default" for the main branch.
+
+        Returns:
+            List of metadata dicts with keys: id, key, value, provider, timestamp.
+        """
+        response = self._request("GET", f"/v2/storage/branch/{branch_id}/metadata")
+        return response.json()
+
+    def set_branch_metadata(
+        self,
+        entries: list[tuple[str, str]],
+        branch_id: int | str = "default",
+    ) -> list[dict[str, Any]]:
+        """Bulk-set metadata key/value pairs on a branch.
+
+        POST /v2/storage/branch/{id}/metadata
+
+        Keboola's endpoint expects PHP-style array indices in the
+        form-urlencoded body, e.g.::
+
+            metadata[0][key]=KBC.projectDescription
+            metadata[0][value]=My project
+
+        httpx's ``data=`` accepts a mapping of str -> str and URL-encodes it.
+        Since each ``metadata[i][...]`` key is unique per index, a plain dict
+        preserves both ordering (Python 3.7+) and Keboola's expected shape.
+
+        Args:
+            entries: Ordered list of ``(key, value)`` metadata tuples.
+            branch_id: Branch ID or the literal "default" for the main branch.
+
+        Returns:
+            List of metadata dicts created/updated by the API.
+        """
+        form: dict[str, str] = {}
+        for i, (key, value) in enumerate(entries):
+            form[f"metadata[{i}][key]"] = key
+            form[f"metadata[{i}][value]"] = value
+        response = self._request(
+            "POST",
+            f"/v2/storage/branch/{branch_id}/metadata",
+            data=form,
+        )
+        return response.json()
+
+    def delete_branch_metadata(
+        self,
+        metadata_id: int | str,
+        branch_id: int | str = "default",
+    ) -> None:
+        """Delete a single metadata entry on a branch by its numeric ID.
+
+        DELETE /v2/storage/branch/{id}/metadata/{metadataId}
+
+        Args:
+            metadata_id: ID of the metadata entry (from ``list_branch_metadata``).
+            branch_id: Branch ID or the literal "default" for the main branch.
+        """
+        self._request(
+            "DELETE",
+            f"/v2/storage/branch/{branch_id}/metadata/{metadata_id}",
+        )
+
+    def get_branch_metadata_value(
+        self,
+        key: str,
+        branch_id: int | str = "default",
+    ) -> str | None:
+        """Return the value for a single metadata key on a branch, or None if absent.
+
+        Convenience wrapper around ``list_branch_metadata`` that filters by key.
+
+        Args:
+            key: Metadata key to look up (e.g. "KBC.projectDescription").
+            branch_id: Branch ID or the literal "default" for the main branch.
+
+        Returns:
+            The string value, or None if the key is not present.
+        """
+        for entry in self.list_branch_metadata(branch_id=branch_id):
+            if entry.get("key") == key:
+                return entry.get("value")
+        return None
+
     def list_buckets(
         self, include: str | None = None, branch_id: int | None = None
     ) -> list[dict[str, Any]]:

--- a/src/keboola_agent_cli/commands/_metadata_input.py
+++ b/src/keboola_agent_cli/commands/_metadata_input.py
@@ -1,0 +1,49 @@
+"""Helper for resolving text input from --text, --file, or --stdin.
+
+Shared by `branch metadata-set` and `project description-set`. Enforces
+mutual exclusivity so the CLI fails fast with a clear error instead of
+silently picking one source.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ..errors import ConfigError
+
+
+def resolve_text_input(
+    *,
+    text: str | None,
+    file: Path | None,
+    stdin: bool,
+) -> str:
+    """Resolve a single string value from exactly one of three sources.
+
+    Args:
+        text: Inline string value, or None.
+        file: Path to a file to read UTF-8 text from, or None.
+        stdin: If True, read the value from standard input.
+
+    Returns:
+        The resolved string.
+
+    Raises:
+        ConfigError: If zero or more than one source is provided, or if
+            the given file cannot be read.
+    """
+    sources = [text is not None, file is not None, stdin]
+    provided = sum(sources)
+    if provided == 0:
+        raise ConfigError("Specify exactly one of --text, --file, or --stdin.")
+    if provided > 1:
+        raise ConfigError("--text, --file, and --stdin are mutually exclusive.")
+
+    if text is not None:
+        return text
+    if file is not None:
+        if not file.is_file():
+            raise ConfigError(f"Input file not found: {file}")
+        return file.read_text(encoding="utf-8")
+    return sys.stdin.read()

--- a/src/keboola_agent_cli/commands/branch.py
+++ b/src/keboola_agent_cli/commands/branch.py
@@ -4,10 +4,12 @@ Thin CLI layer: parses arguments, calls BranchService, formats output.
 No business logic belongs here.
 """
 
+from pathlib import Path
+
 import typer
 
 from ..errors import ConfigError, KeboolaApiError
-from ..output import format_branches_table
+from ..output import format_branch_metadata_table, format_branches_table
 from ._helpers import (
     check_cli_permission,
     emit_hint,
@@ -17,6 +19,7 @@ from ._helpers import (
     map_error_to_exit_code,
     should_hint,
 )
+from ._metadata_input import resolve_text_input
 
 branch_app = typer.Typer(help="Manage development branches")
 
@@ -249,6 +252,194 @@ def branch_merge(
                 c.print(f"\n{d['message']}"),
             ),
         )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+
+# ── Branch metadata commands ──────────────────────────────────────────
+
+
+@branch_app.command("metadata-list")
+def branch_metadata_list(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias to query",
+    ),
+    branch: str = typer.Option(
+        "default",
+        "--branch",
+        help='Branch ID or "default" for the main branch',
+    ),
+) -> None:
+    """List all metadata entries on a branch.
+
+    Metadata lives on a branch (not on the project) and is keyed by
+    arbitrary strings like ``KBC.projectDescription``.
+    """
+    if should_hint(ctx):
+        emit_hint(ctx, "branch.metadata-list", project=project, branch=branch)
+        return
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "branch_service")
+
+    try:
+        result = service.list_branch_metadata(alias=project, branch_id=branch)
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=exit_code) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        format_branch_metadata_table(formatter.console, result)
+
+
+@branch_app.command("metadata-get")
+def branch_metadata_get(
+    ctx: typer.Context,
+    project: str = typer.Option(..., "--project", help="Project alias to query"),
+    key: str = typer.Option(..., "--key", help="Metadata key to read"),
+    branch: str = typer.Option(
+        "default",
+        "--branch",
+        help='Branch ID or "default" for the main branch',
+    ),
+) -> None:
+    """Read a single metadata value by key.
+
+    Exits with code 1 (NOT_FOUND) if the key is not present on the branch.
+    """
+    if should_hint(ctx):
+        emit_hint(ctx, "branch.metadata-get", project=project, key=key, branch=branch)
+        return
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "branch_service")
+
+    try:
+        result = service.get_branch_metadata(alias=project, key=key, branch_id=branch)
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=exit_code) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    formatter.output(
+        result,
+        lambda c, d: c.print(d["value"]),
+    )
+
+
+@branch_app.command("metadata-set")
+def branch_metadata_set(
+    ctx: typer.Context,
+    project: str = typer.Option(..., "--project", help="Project alias"),
+    key: str = typer.Option(..., "--key", help="Metadata key to set"),
+    text: str | None = typer.Option(None, "--text", help="Inline string value"),
+    file: Path | None = typer.Option(
+        None,
+        "--file",
+        help="Read value from a UTF-8 text file",
+        exists=False,  # validated in helper with a clearer error message
+    ),
+    stdin: bool = typer.Option(
+        False,
+        "--stdin",
+        help="Read value from standard input",
+    ),
+    branch: str = typer.Option(
+        "default",
+        "--branch",
+        help='Branch ID or "default" for the main branch',
+    ),
+) -> None:
+    """Set a metadata key/value on a branch.
+
+    The value is taken from exactly one of --text, --file, or --stdin.
+    """
+    formatter = get_formatter(ctx)
+
+    try:
+        value = resolve_text_input(text=text, file=file, stdin=stdin)
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="INVALID_ARGUMENT")
+        raise typer.Exit(code=2) from None
+
+    if should_hint(ctx):
+        emit_hint(
+            ctx,
+            "branch.metadata-set",
+            project=project,
+            key=key,
+            value=value,
+            branch=branch,
+        )
+        return
+    service = get_service(ctx, "branch_service")
+
+    try:
+        result = service.set_branch_metadata(alias=project, key=key, value=value, branch_id=branch)
+        formatter.output(
+            result,
+            lambda c, d: c.print(f"[bold green]Success:[/bold green] {d['message']}"),
+        )
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=exit_code) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+
+@branch_app.command("metadata-delete")
+def branch_metadata_delete(
+    ctx: typer.Context,
+    project: str = typer.Option(..., "--project", help="Project alias"),
+    metadata_id: int = typer.Option(
+        ...,
+        "--metadata-id",
+        help="Numeric ID of the metadata entry (from metadata-list)",
+    ),
+    branch: str = typer.Option(
+        "default",
+        "--branch",
+        help='Branch ID or "default" for the main branch',
+    ),
+) -> None:
+    """Delete a branch metadata entry by its numeric ID."""
+    if should_hint(ctx):
+        emit_hint(
+            ctx,
+            "branch.metadata-delete",
+            project=project,
+            metadata_id=metadata_id,
+            branch=branch,
+        )
+        return
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "branch_service")
+
+    try:
+        result = service.delete_branch_metadata(
+            alias=project, metadata_id=metadata_id, branch_id=branch
+        )
+        formatter.output(
+            result,
+            lambda c, d: c.print(f"[bold green]Success:[/bold green] {d['message']}"),
+        )
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=exit_code) from None
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")
         raise typer.Exit(code=5) from None

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -74,6 +74,15 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent project refresh --all [--dry-run] [--force] [--yes] [--token-description ...] [--token-expires-in N]
     Refresh project tokens via Manage API. --all refreshes all projects. --force replaces non-expiring tokens.
 
+  kbagent project description-get --project NAME
+    Read the Keboola dashboard project description (markdown). Backed by
+    the KBC.projectDescription metadata key on the default branch. Returns
+    an empty string if no description has been set.
+
+  kbagent project description-set --project NAME [--text STR | --file PATH | --stdin]
+    Set the dashboard project description. Pass exactly one of --text,
+    --file, or --stdin. Writes KBC.projectDescription to the default branch.
+
 ### Component Discovery
 
   kbagent component list [--project NAME] [--type TYPE] [--query "search"]
@@ -265,6 +274,19 @@ Use `kbagent <command> --help` for full flag details and examples.
 
   kbagent branch merge --project ALIAS [--branch ID]
     Get KBC UI merge URL (does NOT merge via API). Resets active branch.
+
+  kbagent branch metadata-list --project NAME [--branch ID|default]
+    List all metadata entries on a branch (id, key, value, provider, timestamp).
+
+  kbagent branch metadata-get --project NAME --key KEY [--branch ID|default]
+    Read a single metadata value by key. Exits with NOT_FOUND if absent.
+
+  kbagent branch metadata-set --project NAME --key KEY [--text STR | --file PATH | --stdin] [--branch ID|default]
+    Set a metadata key/value. Useful for KBC.projectDescription and similar
+    dashboard-visible fields. --branch defaults to "default" (main branch).
+
+  kbagent branch metadata-delete --project NAME --metadata-id ID [--branch ID|default]
+    Delete a metadata entry by its numeric ID (from metadata-list).
 
 ### Workspaces (SQL Debugging)
 

--- a/src/keboola_agent_cli/commands/project.py
+++ b/src/keboola_agent_cli/commands/project.py
@@ -5,6 +5,7 @@ No business logic belongs here.
 """
 
 import sys
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -20,11 +21,14 @@ from ..constants import (
 from ..errors import ConfigError, KeboolaApiError
 from ._helpers import (
     check_cli_permission,
+    emit_hint,
     get_formatter,
     get_service,
     map_error_to_exit_code,
     resolve_manage_token,
+    should_hint,
 )
+from ._metadata_input import resolve_text_input
 
 project_app = typer.Typer(help="Manage connected Keboola projects")
 
@@ -467,3 +471,101 @@ def project_refresh(
         raise typer.Exit(code=exit_code) from None
 
     formatter.output(result, _format_refresh_result)
+
+
+# ── Project description (dashboard KBC.projectDescription) ────────────
+
+
+@project_app.command("description-get")
+def project_description_get(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias to query",
+    ),
+) -> None:
+    """Get the Keboola dashboard project description.
+
+    Reads the ``KBC.projectDescription`` metadata value from the default
+    branch - this is what the Keboola UI shows on the project dashboard.
+    Returns an empty string if no description has been set.
+    """
+    if should_hint(ctx):
+        emit_hint(ctx, "project.description-get", project=project)
+        return
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "branch_service")
+
+    try:
+        result = service.get_project_description(alias=project)
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=exit_code) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+
+    formatter.output(
+        result,
+        lambda c, d: c.print(d["description"] or "[dim](no description set)[/dim]"),
+    )
+
+
+@project_app.command("description-set")
+def project_description_set(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias to update",
+    ),
+    text: str | None = typer.Option(None, "--text", help="Inline description string"),
+    file: Path | None = typer.Option(
+        None,
+        "--file",
+        help="Read description from a UTF-8 markdown file",
+    ),
+    stdin: bool = typer.Option(
+        False,
+        "--stdin",
+        help="Read description from standard input",
+    ),
+) -> None:
+    """Set the Keboola dashboard project description (markdown).
+
+    Writes to ``KBC.projectDescription`` on the default branch. Provide the
+    content via exactly one of --text, --file, or --stdin.
+    """
+    formatter = get_formatter(ctx)
+
+    try:
+        description = resolve_text_input(text=text, file=file, stdin=stdin)
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="INVALID_ARGUMENT")
+        raise typer.Exit(code=2) from None
+
+    if should_hint(ctx):
+        emit_hint(
+            ctx,
+            "project.description-set",
+            project=project,
+            description=description,
+        )
+        return
+    service = get_service(ctx, "branch_service")
+
+    try:
+        result = service.set_project_description(alias=project, description=description)
+        formatter.output(
+            result,
+            lambda c, d: c.print(f"[bold green]Success:[/bold green] {d['message']}"),
+        )
+    except KeboolaApiError as exc:
+        exit_code = map_error_to_exit_code(exc)
+        formatter.error(message=exc.message, error_code=exc.error_code, retryable=exc.retryable)
+        raise typer.Exit(code=exit_code) from None
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None

--- a/src/keboola_agent_cli/hints/definitions/__init__.py
+++ b/src/keboola_agent_cli/hints/definitions/__init__.py
@@ -9,6 +9,7 @@ from . import (
     kai,  # noqa: F401
     lineage,  # noqa: F401
     org,  # noqa: F401
+    project,  # noqa: F401
     sharing,  # noqa: F401
     storage,  # noqa: F401
     tool,  # noqa: F401

--- a/src/keboola_agent_cli/hints/definitions/branch.py
+++ b/src/keboola_agent_cli/hints/definitions/branch.py
@@ -85,3 +85,129 @@ HintRegistry.register(
         notes=["Service layer auto-resets active branch if the deleted branch was active."],
     )
 )
+
+# ── branch metadata-list ──────────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="branch.metadata-list",
+        description="List metadata entries on a branch",
+        steps=[
+            HintStep(
+                comment="List branch metadata",
+                client=ClientCall(
+                    method="list_branch_metadata",
+                    args={"branch_id": "{branch}"},
+                    result_var="metadata",
+                    result_hint="list[dict]",
+                ),
+                service=ServiceCall(
+                    service_class="BranchService",
+                    service_module="branch_service",
+                    method="list_branch_metadata",
+                    args={"alias": "{project}", "branch_id": "{branch}"},
+                ),
+            ),
+        ],
+    )
+)
+
+# ── branch metadata-get ───────────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="branch.metadata-get",
+        description="Read a single metadata value by key",
+        steps=[
+            HintStep(
+                comment="Get a branch metadata value by key",
+                client=ClientCall(
+                    method="get_branch_metadata_value",
+                    args={"key": "{key}", "branch_id": "{branch}"},
+                    result_var="value",
+                    result_hint="str | None",
+                ),
+                service=ServiceCall(
+                    service_class="BranchService",
+                    service_module="branch_service",
+                    method="get_branch_metadata",
+                    args={
+                        "alias": "{project}",
+                        "key": "{key}",
+                        "branch_id": "{branch}",
+                    },
+                ),
+            ),
+        ],
+        notes=["Client returns None when the key is absent; service raises KeboolaApiError."],
+    )
+)
+
+# ── branch metadata-set ───────────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="branch.metadata-set",
+        description="Set a metadata key/value on a branch",
+        steps=[
+            HintStep(
+                comment="Set branch metadata (bulk-capable; one entry here)",
+                client=ClientCall(
+                    method="set_branch_metadata",
+                    args={
+                        "entries": "[({key}, {value})]",
+                        "branch_id": "{branch}",
+                    },
+                    result_var="result",
+                    result_hint="list[dict]",
+                ),
+                service=ServiceCall(
+                    service_class="BranchService",
+                    service_module="branch_service",
+                    method="set_branch_metadata",
+                    args={
+                        "alias": "{project}",
+                        "key": "{key}",
+                        "value": "{value}",
+                        "branch_id": "{branch}",
+                    },
+                ),
+            ),
+        ],
+        notes=[
+            "Keboola's endpoint is bulk: pass multiple (key, value) tuples to set many at once.",
+        ],
+    )
+)
+
+# ── branch metadata-delete ────────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="branch.metadata-delete",
+        description="Delete a branch metadata entry by ID",
+        steps=[
+            HintStep(
+                comment="Delete a single metadata entry",
+                client=ClientCall(
+                    method="delete_branch_metadata",
+                    args={
+                        "metadata_id": "{metadata_id}",
+                        "branch_id": "{branch}",
+                    },
+                    result_var="result",
+                ),
+                service=ServiceCall(
+                    service_class="BranchService",
+                    service_module="branch_service",
+                    method="delete_branch_metadata",
+                    args={
+                        "alias": "{project}",
+                        "metadata_id": "{metadata_id}",
+                        "branch_id": "{branch}",
+                    },
+                ),
+            ),
+        ],
+    )
+)

--- a/src/keboola_agent_cli/hints/definitions/project.py
+++ b/src/keboola_agent_cli/hints/definitions/project.py
@@ -1,0 +1,73 @@
+"""Hint definitions for project-level commands (project description)."""
+
+from .. import HintRegistry
+from ..models import ClientCall, CommandHint, HintStep, ServiceCall
+
+# ── project description-get ───────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="project.description-get",
+        description="Read the Keboola dashboard project description",
+        steps=[
+            HintStep(
+                comment="Read KBC.projectDescription on the default branch",
+                client=ClientCall(
+                    method="get_branch_metadata_value",
+                    args={
+                        "key": '"KBC.projectDescription"',
+                        "branch_id": '"default"',
+                    },
+                    result_var="description",
+                    result_hint="str | None",
+                ),
+                service=ServiceCall(
+                    service_class="BranchService",
+                    service_module="branch_service",
+                    method="get_project_description",
+                    args={"alias": "{project}"},
+                ),
+            ),
+        ],
+        notes=[
+            "The dashboard reads project description from branch metadata, "
+            "not from the Manage API or the branch description field.",
+        ],
+    )
+)
+
+# ── project description-set ───────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="project.description-set",
+        description="Set the Keboola dashboard project description (markdown)",
+        steps=[
+            HintStep(
+                comment="Write KBC.projectDescription on the default branch",
+                client=ClientCall(
+                    method="set_branch_metadata",
+                    args={
+                        "entries": '[("KBC.projectDescription", {description})]',
+                        "branch_id": '"default"',
+                    },
+                    result_var="result",
+                    result_hint="list[dict]",
+                ),
+                service=ServiceCall(
+                    service_class="BranchService",
+                    service_module="branch_service",
+                    method="set_project_description",
+                    args={
+                        "alias": "{project}",
+                        "description": "{description}",
+                    },
+                ),
+            ),
+        ],
+        notes=[
+            "Writes to the default branch metadata - always the main branch, "
+            "regardless of any active dev branch.",
+        ],
+    )
+)

--- a/src/keboola_agent_cli/output.py
+++ b/src/keboola_agent_cli/output.py
@@ -772,6 +772,47 @@ def format_branches_table(console: Console, data: dict[str, Any]) -> None:
     console.print()
 
 
+def format_branch_metadata_table(console: Console, data: dict[str, Any]) -> None:
+    """Render branch metadata entries as a Rich table.
+
+    Args:
+        console: Rich Console instance.
+        data: Dict with project_alias, branch_id, and metadata (list of entries).
+    """
+    entries = data.get("metadata", [])
+    alias = data.get("project_alias", "unknown")
+    branch_id = data.get("branch_id", "default")
+
+    if not entries:
+        console.print(
+            f"No metadata on branch [bold]{branch_id}[/bold] of project "
+            f"[bold magenta]{alias}[/bold magenta]."
+        )
+        return
+
+    table = Table(title=f"Branch Metadata  -  project: {alias}  -  branch: {branch_id}")
+    table.add_column("ID", justify="right", style="dim")
+    table.add_column("Key", style="bold cyan")
+    table.add_column("Value", max_width=60)
+    table.add_column("Provider", style="dim")
+    table.add_column("Timestamp", style="dim")
+
+    for entry in entries:
+        value = str(entry.get("value", ""))
+        if "\n" in value:
+            first_line = value.splitlines()[0]
+            value = f"{first_line} [dim](+{len(value.splitlines()) - 1} more lines)[/dim]"
+        table.add_row(
+            str(entry.get("id", "")),
+            str(entry.get("key", "")),
+            value,
+            str(entry.get("provider", "")),
+            str(entry.get("timestamp", "")),
+        )
+
+    console.print(table)
+
+
 def format_doctor_panel(console: Console, data: dict[str, Any]) -> None:
     """Render doctor check results as a Rich panel with colored status indicators.
 

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -20,6 +20,8 @@ OPERATION_REGISTRY: dict[str, str] = {
     "project.edit": "admin",
     "project.status": "read",
     "project.refresh": "admin",
+    "project.description-get": "read",
+    "project.description-set": "write",
     # Config browsing & management
     "config.list": "read",
     "config.detail": "read",
@@ -53,6 +55,10 @@ OPERATION_REGISTRY: dict[str, str] = {
     "branch.reset": "write",
     "branch.delete": "destructive",
     "branch.merge": "write",
+    "branch.metadata-list": "read",
+    "branch.metadata-get": "read",
+    "branch.metadata-set": "write",
+    "branch.metadata-delete": "destructive",
     # Workspace lifecycle
     "workspace.create": "write",
     "workspace.list": "read",

--- a/src/keboola_agent_cli/services/branch_service.py
+++ b/src/keboola_agent_cli/services/branch_service.py
@@ -2,7 +2,9 @@
 
 Orchestrates multi-project branch retrieval in parallel, annotates with
 project alias, and aggregates results. Provides create, activate, reset,
-delete, and merge URL generation for development branches.
+delete, and merge URL generation for development branches. Also provides
+branch metadata CRUD and a "project description" convenience wrapper over
+the ``KBC.projectDescription`` metadata key on the default branch.
 """
 
 from typing import Any
@@ -10,6 +12,8 @@ from typing import Any
 from ..errors import ConfigError, KeboolaApiError
 from ..models import ProjectConfig
 from .base import BaseService
+
+PROJECT_DESCRIPTION_KEY = "KBC.projectDescription"
 
 
 class BranchService(BaseService):
@@ -336,3 +340,217 @@ class BranchService(BaseService):
                 f"in project '{alias}'. Active branch has been reset to main."
             ),
         }
+
+    # ── Branch metadata ────────────────────────────────────────────────
+
+    def list_branch_metadata(
+        self,
+        alias: str,
+        branch_id: int | str = "default",
+    ) -> dict[str, Any]:
+        """List all metadata entries on a branch for a single project.
+
+        Args:
+            alias: Project alias.
+            branch_id: Branch ID or "default" for the main branch.
+
+        Returns:
+            Dict with project_alias, branch_id, and a key-sorted metadata list.
+
+        Raises:
+            ConfigError: If the project alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            entries = client.list_branch_metadata(branch_id=branch_id)
+        finally:
+            client.close()
+        return {
+            "project_alias": alias,
+            "branch_id": branch_id,
+            "metadata": sorted(entries, key=lambda e: e.get("key", "")),
+        }
+
+    def get_branch_metadata(
+        self,
+        alias: str,
+        key: str,
+        branch_id: int | str = "default",
+    ) -> dict[str, Any]:
+        """Get a single metadata value by key.
+
+        Args:
+            alias: Project alias.
+            key: Metadata key (e.g. "KBC.projectDescription").
+            branch_id: Branch ID or "default" for the main branch.
+
+        Returns:
+            Dict with project_alias, branch_id, key, value.
+
+        Raises:
+            ConfigError: If the project alias is not found.
+            KeboolaApiError: If the key is not present or the API call fails.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            value = client.get_branch_metadata_value(key=key, branch_id=branch_id)
+        finally:
+            client.close()
+        if value is None:
+            raise KeboolaApiError(
+                message=(
+                    f"Metadata key '{key}' not found on branch '{branch_id}' of project '{alias}'."
+                ),
+                status_code=404,
+                error_code="NOT_FOUND",
+                retryable=False,
+            )
+        return {
+            "project_alias": alias,
+            "branch_id": branch_id,
+            "key": key,
+            "value": value,
+        }
+
+    def set_branch_metadata(
+        self,
+        alias: str,
+        key: str,
+        value: str,
+        branch_id: int | str = "default",
+    ) -> dict[str, Any]:
+        """Set a single metadata key/value on a branch.
+
+        Args:
+            alias: Project alias.
+            key: Metadata key to set.
+            value: Metadata value (plain string; e.g. markdown).
+            branch_id: Branch ID or "default" for the main branch.
+
+        Returns:
+            Dict with project_alias, branch_id, key, value, result, message.
+
+        Raises:
+            ConfigError: If the project alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            result = client.set_branch_metadata(entries=[(key, value)], branch_id=branch_id)
+        finally:
+            client.close()
+        return {
+            "project_alias": alias,
+            "branch_id": branch_id,
+            "key": key,
+            "value": value,
+            "result": result,
+            "message": (f"Metadata '{key}' set on branch '{branch_id}' of project '{alias}'."),
+        }
+
+    def delete_branch_metadata(
+        self,
+        alias: str,
+        metadata_id: int | str,
+        branch_id: int | str = "default",
+    ) -> dict[str, Any]:
+        """Delete a metadata entry by its numeric ID.
+
+        Args:
+            alias: Project alias.
+            metadata_id: Metadata entry ID (from ``list_branch_metadata``).
+            branch_id: Branch ID or "default" for the main branch.
+
+        Returns:
+            Dict confirming the deletion.
+
+        Raises:
+            ConfigError: If the project alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            client.delete_branch_metadata(metadata_id=metadata_id, branch_id=branch_id)
+        finally:
+            client.close()
+        return {
+            "project_alias": alias,
+            "branch_id": branch_id,
+            "metadata_id": metadata_id,
+            "message": (
+                f"Metadata ID {metadata_id} deleted from branch '{branch_id}' of project '{alias}'."
+            ),
+        }
+
+    # ── Project description (convenience wrappers) ─────────────────────
+
+    def get_project_description(self, alias: str) -> dict[str, Any]:
+        """Get the dashboard project description for a project.
+
+        Reads the ``KBC.projectDescription`` metadata value from the default
+        branch -- this is what the Keboola UI displays on the project
+        dashboard.
+
+        Returns an empty description (not an error) if the key is unset, so
+        callers don't need to special-case freshly-provisioned projects.
+
+        Args:
+            alias: Project alias.
+
+        Returns:
+            Dict with project_alias, key, description (str, possibly empty).
+
+        Raises:
+            ConfigError: If the project alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            value = client.get_branch_metadata_value(
+                key=PROJECT_DESCRIPTION_KEY, branch_id="default"
+            )
+        finally:
+            client.close()
+        return {
+            "project_alias": alias,
+            "key": PROJECT_DESCRIPTION_KEY,
+            "description": value or "",
+        }
+
+    def set_project_description(self, alias: str, description: str) -> dict[str, Any]:
+        """Set the dashboard project description for a project.
+
+        Writes to ``KBC.projectDescription`` on the default branch, which is
+        what the Keboola UI reads for the project dashboard description.
+
+        Args:
+            alias: Project alias.
+            description: Markdown content for the description.
+
+        Returns:
+            Dict with project_alias, key, description, result, message.
+
+        Raises:
+            ConfigError: If the project alias is not found.
+            KeboolaApiError: If the API call fails.
+        """
+        result = self.set_branch_metadata(
+            alias=alias,
+            key=PROJECT_DESCRIPTION_KEY,
+            value=description,
+            branch_id="default",
+        )
+        result["description"] = description
+        result["message"] = f"Project description updated for '{alias}' ({len(description)} chars)."
+        return result

--- a/tests/test_branch_metadata_cli.py
+++ b/tests/test_branch_metadata_cli.py
@@ -1,0 +1,439 @@
+"""CLI tests for `kbagent branch metadata-*` and `kbagent project description-*`.
+
+Uses CliRunner + patched BranchService following the existing CLI test pattern
+(see tests/test_workspace_cli.py). Verifies JSON mode, Rich mode, error
+mapping, and the --text / --file / --stdin input resolver.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.models import ProjectConfig
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+runner = CliRunner()
+
+
+def _setup_store(config_dir: Path) -> ConfigStore:
+    store = ConfigStore(config_dir=config_dir)
+    store.add_project(
+        "prod",
+        ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token=TEST_TOKEN,
+            project_name="Production",
+            project_id=258,
+        ),
+    )
+    return store
+
+
+def _run(
+    store: ConfigStore,
+    mock_svc: MagicMock,
+    args: list[str],
+    *,
+    input_text: str | None = None,
+) -> object:
+    """Invoke the CLI with a mocked BranchService while letting everything else construct normally."""
+    with (
+        patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+        patch("keboola_agent_cli.cli.BranchService") as MockBranchSvc,
+    ):
+        MockStore.return_value = store
+        MockBranchSvc.return_value = mock_svc
+        return runner.invoke(app, args, input=input_text)
+
+
+class TestBranchMetadataList:
+    def test_list_json(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.list_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "metadata": [{"id": 1, "key": "x", "value": "v", "provider": "user", "timestamp": "t"}],
+        }
+
+        result = _run(
+            store,
+            mock_svc,
+            ["--json", "branch", "metadata-list", "--project", "prod"],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "ok"
+        assert payload["data"]["metadata"][0]["key"] == "x"
+        mock_svc.list_branch_metadata.assert_called_once_with(alias="prod", branch_id="default")
+
+    def test_list_human_renders_table(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.list_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "metadata": [],
+        }
+        result = _run(
+            store,
+            mock_svc,
+            ["branch", "metadata-list", "--project", "prod"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "No metadata" in result.output
+
+    def test_list_api_error_maps_exit_code(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.list_branch_metadata.side_effect = KeboolaApiError(
+            message="bad", status_code=401, error_code="INVALID_TOKEN", retryable=False
+        )
+        result = _run(
+            store,
+            mock_svc,
+            ["--json", "branch", "metadata-list", "--project", "prod"],
+        )
+        assert result.exit_code == 3
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "INVALID_TOKEN"
+
+
+class TestBranchMetadataGet:
+    def test_get_json(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.get_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "key": "KBC.projectDescription",
+            "value": "# hi",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-get",
+                "--project",
+                "prod",
+                "--key",
+                "KBC.projectDescription",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["data"]["value"] == "# hi"
+
+    def test_get_not_found_returns_exit_1(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.get_branch_metadata.side_effect = KeboolaApiError(
+            message="nope", status_code=404, error_code="NOT_FOUND", retryable=False
+        )
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-get",
+                "--project",
+                "prod",
+                "--key",
+                "missing",
+            ],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "NOT_FOUND"
+
+
+class TestBranchMetadataSet:
+    def test_set_text(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.set_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "key": "k",
+            "value": "v",
+            "result": [],
+            "message": "Metadata 'k' set on branch 'default' of project 'prod'.",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-set",
+                "--project",
+                "prod",
+                "--key",
+                "k",
+                "--text",
+                "v",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_svc.set_branch_metadata.assert_called_once_with(
+            alias="prod", key="k", value="v", branch_id="default"
+        )
+
+    def test_set_file(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        payload_file = tmp_path / "content.md"
+        payload_file.write_text("# Hello from file", encoding="utf-8")
+        mock_svc = MagicMock()
+        mock_svc.set_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "key": "k",
+            "value": "# Hello from file",
+            "result": [],
+            "message": "ok",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-set",
+                "--project",
+                "prod",
+                "--key",
+                "k",
+                "--file",
+                str(payload_file),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_svc.set_branch_metadata.assert_called_once_with(
+            alias="prod", key="k", value="# Hello from file", branch_id="default"
+        )
+
+    def test_set_stdin(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.set_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "key": "k",
+            "value": "stdin-value",
+            "result": [],
+            "message": "ok",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-set",
+                "--project",
+                "prod",
+                "--key",
+                "k",
+                "--stdin",
+            ],
+            input_text="stdin-value",
+        )
+        assert result.exit_code == 0, result.output
+        mock_svc.set_branch_metadata.assert_called_once_with(
+            alias="prod", key="k", value="stdin-value", branch_id="default"
+        )
+
+    def test_set_no_source_errors(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-set",
+                "--project",
+                "prod",
+                "--key",
+                "k",
+            ],
+        )
+        assert result.exit_code == 2
+        mock_svc.set_branch_metadata.assert_not_called()
+
+    def test_set_multiple_sources_errors(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-set",
+                "--project",
+                "prod",
+                "--key",
+                "k",
+                "--text",
+                "a",
+                "--stdin",
+            ],
+        )
+        assert result.exit_code == 2
+        mock_svc.set_branch_metadata.assert_not_called()
+
+
+class TestBranchMetadataDelete:
+    def test_delete_json(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.delete_branch_metadata.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "metadata_id": 99,
+            "message": "Metadata ID 99 deleted from branch 'default' of project 'prod'.",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "branch",
+                "metadata-delete",
+                "--project",
+                "prod",
+                "--metadata-id",
+                "99",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_svc.delete_branch_metadata.assert_called_once_with(
+            alias="prod", metadata_id=99, branch_id="default"
+        )
+
+
+class TestProjectDescription:
+    def test_get_json_with_value(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.get_project_description.return_value = {
+            "project_alias": "prod",
+            "key": "KBC.projectDescription",
+            "description": "# My project",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            ["--json", "project", "description-get", "--project", "prod"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["data"]["description"] == "# My project"
+
+    def test_get_json_empty(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.get_project_description.return_value = {
+            "project_alias": "prod",
+            "key": "KBC.projectDescription",
+            "description": "",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            ["--json", "project", "description-get", "--project", "prod"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["data"]["description"] == ""
+
+    def test_set_via_text(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.set_project_description.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "key": "KBC.projectDescription",
+            "value": "# New",
+            "description": "# New",
+            "result": [],
+            "message": "Project description updated for 'prod' (5 chars).",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "project",
+                "description-set",
+                "--project",
+                "prod",
+                "--text",
+                "# New",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_svc.set_project_description.assert_called_once_with(alias="prod", description="# New")
+
+    def test_set_via_stdin(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.set_project_description.return_value = {
+            "project_alias": "prod",
+            "branch_id": "default",
+            "key": "KBC.projectDescription",
+            "value": "from stdin",
+            "description": "from stdin",
+            "result": [],
+            "message": "ok",
+        }
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "project",
+                "description-set",
+                "--project",
+                "prod",
+                "--stdin",
+            ],
+            input_text="from stdin",
+        )
+        assert result.exit_code == 0, result.output
+        mock_svc.set_project_description.assert_called_once_with(
+            alias="prod", description="from stdin"
+        )
+
+    def test_set_config_error(self, tmp_path: Path) -> None:
+        store = _setup_store(tmp_path)
+        mock_svc = MagicMock()
+        mock_svc.set_project_description.side_effect = ConfigError("Project 'nope' not found.")
+        result = _run(
+            store,
+            mock_svc,
+            [
+                "--json",
+                "project",
+                "description-set",
+                "--project",
+                "prod",
+                "--text",
+                "x",
+            ],
+        )
+        assert result.exit_code == 5
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "CONFIG_ERROR"

--- a/tests/test_branch_metadata_service.py
+++ b/tests/test_branch_metadata_service.py
@@ -1,0 +1,188 @@
+"""Tests for BranchService branch-metadata and project-description methods."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from helpers import setup_single_project
+from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.services.branch_service import (
+    PROJECT_DESCRIPTION_KEY,
+    BranchService,
+)
+
+SAMPLE_ENTRIES = [
+    {"id": 1, "key": "b-key", "value": "bv", "provider": "user"},
+    {"id": 2, "key": "a-key", "value": "av", "provider": "user"},
+    {"id": 3, "key": PROJECT_DESCRIPTION_KEY, "value": "# Hello", "provider": "user"},
+]
+
+
+class TestBranchMetadataList:
+    def test_list_returns_sorted_by_key(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.list_branch_metadata.return_value = SAMPLE_ENTRIES
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.list_branch_metadata(alias="prod")
+
+        assert result["project_alias"] == "prod"
+        assert result["branch_id"] == "default"
+        # Sorted lexicographically; uppercase "KBC." sorts before lowercase.
+        assert [e["key"] for e in result["metadata"]] == [
+            PROJECT_DESCRIPTION_KEY,
+            "a-key",
+            "b-key",
+        ]
+        mock_client.list_branch_metadata.assert_called_once_with(branch_id="default")
+        mock_client.close.assert_called_once()
+
+    def test_list_numeric_branch_id(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.list_branch_metadata.return_value = []
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        svc.list_branch_metadata(alias="prod", branch_id=456)
+
+        mock_client.list_branch_metadata.assert_called_once_with(branch_id=456)
+
+    def test_list_missing_alias_raises(self, tmp_config_dir: Path) -> None:
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: MagicMock(),
+        )
+        with pytest.raises(ConfigError):
+            svc.list_branch_metadata(alias="does-not-exist")
+
+
+class TestBranchMetadataGet:
+    def test_get_returns_value(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.get_branch_metadata_value.return_value = "# Hello"
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.get_branch_metadata(alias="prod", key=PROJECT_DESCRIPTION_KEY)
+
+        assert result["value"] == "# Hello"
+        assert result["key"] == PROJECT_DESCRIPTION_KEY
+        assert result["branch_id"] == "default"
+        mock_client.close.assert_called_once()
+
+    def test_get_missing_key_raises_not_found(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.get_branch_metadata_value.return_value = None
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            svc.get_branch_metadata(alias="prod", key="missing")
+
+        assert exc_info.value.error_code == "NOT_FOUND"
+        assert exc_info.value.status_code == 404
+        mock_client.close.assert_called_once()
+
+
+class TestBranchMetadataSet:
+    def test_set_forwards_entries(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.set_branch_metadata.return_value = [SAMPLE_ENTRIES[2]]
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.set_branch_metadata(alias="prod", key="k", value="v", branch_id="default")
+
+        mock_client.set_branch_metadata.assert_called_once_with(
+            entries=[("k", "v")], branch_id="default"
+        )
+        assert result["key"] == "k"
+        assert result["value"] == "v"
+        assert "set on branch" in result["message"]
+
+
+class TestBranchMetadataDelete:
+    def test_delete_forwards_metadata_id(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.delete_branch_metadata(alias="prod", metadata_id=99)
+
+        mock_client.delete_branch_metadata.assert_called_once_with(
+            metadata_id=99, branch_id="default"
+        )
+        assert result["metadata_id"] == 99
+        assert "deleted" in result["message"]
+
+
+class TestProjectDescription:
+    def test_get_returns_description(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.get_branch_metadata_value.return_value = "# My project"
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.get_project_description(alias="prod")
+
+        assert result["description"] == "# My project"
+        assert result["key"] == PROJECT_DESCRIPTION_KEY
+        mock_client.get_branch_metadata_value.assert_called_once_with(
+            key=PROJECT_DESCRIPTION_KEY, branch_id="default"
+        )
+
+    def test_get_returns_empty_when_unset(self, tmp_config_dir: Path) -> None:
+        """A missing project description returns '', not an error."""
+        mock_client = MagicMock()
+        mock_client.get_branch_metadata_value.return_value = None
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        result = svc.get_project_description(alias="prod")
+
+        assert result["description"] == ""
+
+    def test_set_forwards_to_set_branch_metadata(self, tmp_config_dir: Path) -> None:
+        mock_client = MagicMock()
+        mock_client.set_branch_metadata.return_value = [SAMPLE_ENTRIES[2]]
+        store = setup_single_project(tmp_config_dir)
+        svc = BranchService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        description = "# My new description"
+        result = svc.set_project_description(alias="prod", description=description)
+
+        mock_client.set_branch_metadata.assert_called_once_with(
+            entries=[(PROJECT_DESCRIPTION_KEY, description)], branch_id="default"
+        )
+        assert result["description"] == description
+        assert str(len(description)) in result["message"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2207,3 +2207,122 @@ class TestCreateJob:
         body = json.loads(request.content)
         assert body["branchId"] == "123"
         assert body["configRowIds"] == ["row1", "row2"]
+
+
+_BRANCH_METADATA_SAMPLE = [
+    {
+        "id": 1001,
+        "key": "KBC.projectDescription",
+        "value": "# My project",
+        "provider": "user",
+        "timestamp": "2026-04-16T10:00:00+0200",
+    },
+    {
+        "id": 1002,
+        "key": "something.else",
+        "value": "abc",
+        "provider": "user",
+        "timestamp": "2026-04-16T10:01:00+0200",
+    },
+]
+
+
+class TestBranchMetadata:
+    """Tests for branch metadata CRUD against /v2/storage/branch/{id}/metadata."""
+
+    def test_list_branch_metadata_default(self, httpx_mock) -> None:
+        """list_branch_metadata() hits /branch/default/metadata and returns entries."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/default/metadata",
+            method="GET",
+            json=_BRANCH_METADATA_SAMPLE,
+            status_code=200,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.list_branch_metadata()
+        assert result == _BRANCH_METADATA_SAMPLE
+
+    def test_list_branch_metadata_numeric(self, httpx_mock) -> None:
+        """list_branch_metadata(branch_id=123) hits /branch/123/metadata."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/123/metadata",
+            method="GET",
+            json=[],
+            status_code=200,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.list_branch_metadata(branch_id=123)
+        assert result == []
+
+    def test_set_branch_metadata_encodes_php_indices(self, httpx_mock) -> None:
+        """set_branch_metadata() URL-encodes PHP-style indices in the form body."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/default/metadata",
+            method="POST",
+            json=_BRANCH_METADATA_SAMPLE[:1],
+            status_code=201,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.set_branch_metadata(
+                entries=[("KBC.projectDescription", "# My project")]
+            )
+
+        assert result == _BRANCH_METADATA_SAMPLE[:1]
+        request = httpx_mock.get_request()
+        body = request.content.decode()
+        # httpx URL-encodes "[" and "]" as %5B / %5D; accept either form.
+        normalized = body.replace("%5B", "[").replace("%5D", "]")
+        assert "metadata[0][key]=KBC.projectDescription" in normalized
+        assert "metadata[0][value]=" in normalized
+        assert request.headers["content-type"].startswith("application/x-www-form-urlencoded")
+
+    def test_set_branch_metadata_bulk(self, httpx_mock) -> None:
+        """set_branch_metadata() encodes multiple entries with increasing indices."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/default/metadata",
+            method="POST",
+            json=_BRANCH_METADATA_SAMPLE,
+            status_code=201,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            client.set_branch_metadata(entries=[("a", "1"), ("b", "2"), ("c", "3")])
+        body = httpx_mock.get_request().content.decode()
+        normalized = body.replace("%5B", "[").replace("%5D", "]")
+        assert "metadata[0][key]=a" in normalized
+        assert "metadata[1][key]=b" in normalized
+        assert "metadata[2][key]=c" in normalized
+
+    def test_delete_branch_metadata(self, httpx_mock) -> None:
+        """delete_branch_metadata() issues DELETE on the right path."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/default/metadata/1001",
+            method="DELETE",
+            status_code=204,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            client.delete_branch_metadata(metadata_id=1001)
+        assert httpx_mock.get_request().method == "DELETE"
+
+    def test_get_branch_metadata_value_found(self, httpx_mock) -> None:
+        """get_branch_metadata_value() returns the matching entry's value."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/default/metadata",
+            method="GET",
+            json=_BRANCH_METADATA_SAMPLE,
+            status_code=200,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            value = client.get_branch_metadata_value(key="KBC.projectDescription")
+        assert value == "# My project"
+
+    def test_get_branch_metadata_value_missing(self, httpx_mock) -> None:
+        """get_branch_metadata_value() returns None when the key is absent."""
+        httpx_mock.add_response(
+            url=f"{_BASE}/v2/storage/branch/default/metadata",
+            method="GET",
+            json=[],
+            status_code=200,
+        )
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            value = client.get_branch_metadata_value(key="KBC.projectDescription")
+        assert value is None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -492,6 +492,13 @@ class TestFullE2E:
         _step(35, "branch lifecycle", "list / create / use / reset / merge / delete")
         self._test_branch_lifecycle()
 
+        _step(
+            35,
+            "project description + branch metadata",
+            "get/set description + generic metadata CRUD",
+        )
+        self._test_project_description_and_metadata()
+
         # ==============================================================
         # PHASE 11: Permissions
         # ==============================================================
@@ -1811,6 +1818,128 @@ class TestFullE2E:
         data = self._run_ok("branch", "list", "--project", self.alias)
         branch_ids = [b["id"] for b in data["data"]["branches"]]
         assert branch_id not in branch_ids
+
+    def _test_project_description_and_metadata(self) -> None:
+        """Test project description + branch metadata CRUD round-trip.
+
+        Uses the default branch so the dashboard reflects the change. Captures
+        the original description up-front and restores it at the end to avoid
+        polluting the shared E2E project.
+        """
+        # Capture original description so we can restore it
+        data = self._run_ok("project", "description-get", "--project", self.alias)
+        original_desc = data["data"]["description"]
+
+        marker = f"# E2E {RUN_ID}\n\nTemporary project description."
+
+        try:
+            # set via --text
+            data = self._run_ok(
+                "project",
+                "description-set",
+                "--project",
+                self.alias,
+                "--text",
+                marker,
+            )
+            assert "updated" in data["data"]["message"].lower()
+
+            # get roundtrip
+            data = self._run_ok("project", "description-get", "--project", self.alias)
+            assert data["data"]["description"] == marker
+
+            # generic branch metadata-list should include KBC.projectDescription
+            data = self._run_ok(
+                "branch",
+                "metadata-list",
+                "--project",
+                self.alias,
+                "--branch",
+                "default",
+            )
+            entries = data["data"]["metadata"]
+            match = next(
+                (e for e in entries if e.get("key") == "KBC.projectDescription"),
+                None,
+            )
+            assert match is not None, "KBC.projectDescription not in metadata list"
+            assert match["value"] == marker
+
+            # generic branch metadata-get by key
+            data = self._run_ok(
+                "branch",
+                "metadata-get",
+                "--project",
+                self.alias,
+                "--key",
+                "KBC.projectDescription",
+                "--branch",
+                "default",
+            )
+            assert data["data"]["value"] == marker
+
+            # set via branch metadata-set (custom key we can then delete by id)
+            custom_key = f"E2E.{RUN_ID}.custom"
+            data = self._run_ok(
+                "branch",
+                "metadata-set",
+                "--project",
+                self.alias,
+                "--key",
+                custom_key,
+                "--text",
+                "e2e-value",
+                "--branch",
+                "default",
+            )
+            assert data["data"]["key"] == custom_key
+
+            # find the new entry ID so we can delete it
+            data = self._run_ok(
+                "branch",
+                "metadata-list",
+                "--project",
+                self.alias,
+                "--branch",
+                "default",
+            )
+            custom_entry = next(e for e in data["data"]["metadata"] if e.get("key") == custom_key)
+            metadata_id = int(custom_entry["id"])
+
+            # delete by ID
+            data = self._run_ok(
+                "branch",
+                "metadata-delete",
+                "--project",
+                self.alias,
+                "--metadata-id",
+                str(metadata_id),
+                "--branch",
+                "default",
+            )
+            assert str(metadata_id) in data["data"]["message"]
+
+            # verify delete
+            data = self._run_ok(
+                "branch",
+                "metadata-list",
+                "--project",
+                self.alias,
+                "--branch",
+                "default",
+            )
+            keys_after = {e.get("key") for e in data["data"]["metadata"]}
+            assert custom_key not in keys_after
+        finally:
+            # Restore original description so we don't leave e2e markers behind
+            self._run_ok(
+                "project",
+                "description-set",
+                "--project",
+                self.alias,
+                "--text",
+                original_desc,
+            )
 
     def _test_permissions(self) -> None:
         """Test permissions list, show, and check commands."""

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds first-class CLI support for the Keboola dashboard project description,
backed by the Storage API branch-metadata endpoint. Also exposes the
underlying branch metadata CRUD as a generic command group.

### New commands

| Command | Purpose |
| --- | --- |
| `kbagent project description-get --project NAME` | Read the dashboard description (markdown) |
| `kbagent project description-set --project NAME [--text \| --file \| --stdin]` | Set the dashboard description |
| `kbagent branch metadata-list --project NAME [--branch ID\|default]` | List all metadata entries on a branch |
| `kbagent branch metadata-get --project NAME --key KEY` | Read one metadata value by key |
| `kbagent branch metadata-set --project NAME --key KEY [--text \| --file \| --stdin]` | Set a key/value |
| `kbagent branch metadata-delete --project NAME --metadata-id ID` | Delete an entry by ID |

### Why it matters

The project description shown on the Keboola dashboard lives at
`POST /v2/storage/branch/default/metadata` with key
`KBC.projectDescription` -- **not** on the Manage API and **not** the
`description` field of a dev branch. Before this PR there was no kbagent
command for it; users had to curl the Storage API directly. The distinction
between dashboard description vs. branch description is now called out
explicitly in `gotchas.md`.

## What's in each layer

- **Client** (`client.py`): four new methods
  (`list_branch_metadata`, `set_branch_metadata`, `delete_branch_metadata`,
  `get_branch_metadata_value`). `set_branch_metadata` takes a list of
  `(key, value)` tuples and encodes them as Keboola's required PHP-style
  form body (`metadata[0][key]=...&metadata[0][value]=...`).
- **Service** (`branch_service.py`): six methods -- four generic metadata
  ops plus `get_project_description` / `set_project_description`
  convenience wrappers pinned to `KBC.projectDescription` on the default
  branch. Missing description returns `""`, not an error.
- **Commands**: thin Typer wrappers following the existing pattern
  (formatter + service + error-to-exit-code). Input for `-set` commands
  comes from exactly one of `--text`, `--file`, or `--stdin`, resolved by
  a shared helper (`commands/_metadata_input.py`).
- **Permissions**: six new entries in `OPERATION_REGISTRY`
  (`project.description-get`: read, `project.description-set`: write,
  `branch.metadata-list/-get`: read, `branch.metadata-set`: write,
  `branch.metadata-delete`: destructive).
- **Hints**: six `CommandHint` definitions with both `ClientCall` and
  `ServiceCall` renderers, registered in `hints/definitions/branch.py`
  and a new `hints/definitions/project.py`.
- **Docs**: `AGENT_CONTEXT` (context.py), `CLAUDE.md`, `commands-reference.md`,
  a new "project description vs branch description" entry in
  `gotchas.md`, and a v0.21.0 changelog entry. `SKILL.md` and
  `plugin.json` regenerated via the usual scripts.

## Test plan

- [x] `uv run pytest tests/test_client.py::TestBranchMetadata tests/test_branch_metadata_service.py tests/test_branch_metadata_cli.py tests/test_branch_service.py` -- 55 tests pass (7 client, 10 service, 16 CLI incl. input-source mutual-exclusion edge cases, 22 existing branch-service tests untouched).
- [x] `uv run ruff check src/ tests/ scripts/` -- clean
- [x] `uv run ruff format . --check` -- clean
- [x] `uv run python scripts/generate_skill.py` -- SKILL.md regenerated and committed
- [x] `uv run python scripts/sync_version.py` -- plugin.json bumped to 0.21.0
- [x] `uv run kbagent --hint client branch metadata-set --project X --key K --text V` + `--hint service` variants -- both emit valid Python
- [x] `uv run kbagent branch --help` / `uv run kbagent project --help` -- all six new commands surface
- [x] **Live smoke test against a real Keboola project** (EU-GCP, project `99_Playground_Max` id 1143). Full round-trip in an isolated `--config-dir`:
  1. `project description-get` → `""` (empty)
  2. `project description-set --text "<timestamped marker>"` → 43 chars written
  3. `project description-get` → marker returned exactly (round-trip ✓)
  4. `branch metadata-list --branch default` → 4 entries incl. `KBC.projectDescription` with new marker
  5. `branch metadata-set --key E2E.smoke --text hello-from-kbagent` → id 119630
  6. `branch metadata-delete --metadata-id 119630` → OK
  7. `branch metadata-list` → `E2E.smoke` gone, 3 pre-existing entries intact
  8. `project description-set --text ""` → restored to original empty
  9. `project description-get` → `""` (clean teardown)

  No debris left in the project. Dashboard description restored, other pre-existing metadata entries untouched.

- [x] New `_test_project_description_and_metadata` step added to `tests/test_e2e.py::TestFullE2E` (step 35) for regression coverage in CI. It captures the original description up-front and restores it in a `finally` block so it is safe to re-run.

## Notes / scope

- **MCP tool exposure was considered and deferred.** Agents can already
  call these via either `kbagent --json project description-set ...` or
  `kbagent --hint service ...` (which emits a ready-to-run Python
  snippet using `BranchService`). A local-tools registry in `McpService`
  would have required intercepting `list_tools`/`call_tool`/transport
  dispatch and risks colliding with any future upstream tool of the
  same name. If there is demand, the cleanest path is a PR against
  `keboola/keboola-mcp-server` upstream, not a shim here.
- Uses `branch_id="default"` (the Keboola shortcut for the main branch)
  so callers never have to resolve the main branch ID manually. Numeric
  IDs are still accepted.
- Version bumped to 0.21.0. No changes to existing commands.