### PR TITLE
fix: resolve physical table ID for branch delete operations (#177)

### DIFF
--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.20.1": [
+        "Fix: storage delete-table/delete-column/delete-bucket on dev branches (#177)",
+        "Fix: --dry-run now validates table existence on branches before reporting success",
+    ],
     "0.20.0": [
         "New: lineage build -- column-level lineage graph from sync'd data (SQL tokenizer + AI)",
         "New: lineage show -- query upstream/downstream with --columns, -c trace, --format mermaid/html/er",

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -668,6 +668,28 @@ class StorageService(BaseService):
         project = projects[alias]
 
         if dry_run:
+            if branch_id:
+                # Validate tables exist on the branch (non-branch dry-run
+                # skips validation — out of scope for this fix).
+                client = self._client_factory(project.stack_url, project.token)
+                would_delete: list[str] = []
+                failed: list[dict[str, str]] = []
+                try:
+                    for tid in table_ids:
+                        try:
+                            client.get_table_detail(tid, branch_id=branch_id)
+                            would_delete.append(tid)
+                        except KeboolaApiError as exc:
+                            failed.append({"id": tid, "error": exc.message})
+                finally:
+                    client.close()
+                return {
+                    "deleted": [],
+                    "failed": failed,
+                    "would_delete": would_delete,
+                    "dry_run": True,
+                    "project_alias": alias,
+                }
             return {
                 "deleted": [],
                 "failed": [],
@@ -683,7 +705,15 @@ class StorageService(BaseService):
         try:
             for tid in table_ids:
                 try:
-                    client.delete_table(tid, branch_id=branch_id, force=force)
+                    if branch_id:
+                        # Resolve physical table ID first — the async DELETE
+                        # endpoint doesn't handle branch bucket resolution
+                        # (Keboola Storage API limitation).
+                        detail = client.get_table_detail(tid, branch_id=branch_id)
+                        physical_id = detail["id"]
+                        client.delete_table(physical_id, branch_id=None, force=force)
+                    else:
+                        client.delete_table(tid, branch_id=None, force=force)
                     deleted.append(tid)
                 except KeboolaApiError as exc:
                     failed.append({"id": tid, "error": exc.message})
@@ -743,9 +773,32 @@ class StorageService(BaseService):
 
         client = self._client_factory(project.stack_url, project.token)
         try:
+            # Resolve physical table ID once for branch operations — the async
+            # DELETE endpoint doesn't handle branch bucket resolution.
+            effective_table_id = table_id
+            effective_branch = branch_id
+            if branch_id:
+                try:
+                    detail = client.get_table_detail(table_id, branch_id=branch_id)
+                    effective_table_id = detail["id"]
+                    effective_branch = None
+                except KeboolaApiError as exc:
+                    # Table itself not found on branch — fail all columns
+                    for col in columns:
+                        failed.append({"column": col, "error": exc.message})
+                    return {
+                        "deleted": deleted,
+                        "failed": failed,
+                        "dry_run": False,
+                        "project_alias": alias,
+                        "table_id": table_id,
+                    }
+
             for col in columns:
                 try:
-                    client.delete_column(table_id, col, branch_id=branch_id, force=force)
+                    client.delete_column(
+                        effective_table_id, col, branch_id=effective_branch, force=force
+                    )
                     deleted.append(col)
                 except KeboolaApiError as exc:
                     failed.append({"column": col, "error": exc.message})
@@ -838,7 +891,12 @@ class StorageService(BaseService):
                     continue
 
                 try:
-                    client.delete_bucket(bid, force=force, branch_id=branch_id)
+                    # On branches, use the physical bucket ID from the detail
+                    # response and skip the branch prefix — same workaround
+                    # as delete_tables (async DELETE doesn't resolve branches).
+                    physical_bid = bucket.get("id", bid) if branch_id else bid
+                    effective_branch = None if branch_id else branch_id
+                    client.delete_bucket(physical_bid, force=force, branch_id=effective_branch)
                     deleted.append(bid)
                 except KeboolaApiError as exc:
                     failed.append({"id": bid, "error": exc.message})

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -681,20 +681,106 @@ class TestDeleteColumnCLI:
 
 
 class TestDeleteTableBranch:
-    """Tests for --branch support in delete-table."""
+    """Tests for --branch support in delete-table.
 
-    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
-        """delete_tables passes branch_id to client.delete_table."""
+    When branch_id is set, the service resolves the physical table ID via
+    get_table_detail (which handles branch bucket mapping) and then deletes
+    using the physical ID without the branch prefix.  This works around a
+    Keboola Storage API limitation where async DELETE doesn't resolve branch
+    bucket context.
+    """
+
+    def test_branch_resolves_physical_id(self, tmp_path: Path) -> None:
+        """On branch, resolve physical table ID then delete without branch prefix."""
         store = _make_store(tmp_path)
         mock_client = MagicMock()
+        mock_client.get_table_detail.return_value = {
+            "id": "in.c-42-data.users",
+            "name": "users",
+            "bucket": {"id": "in.c-42-data"},
+        }
         mock_client.delete_table.return_value = {"id": 1, "status": "success"}
         service = _make_service(store, mock_client)
 
         result = service.delete_tables(alias="test", table_ids=["in.c-data.users"], branch_id=42)
 
         assert result["deleted"] == ["in.c-data.users"]
+        mock_client.get_table_detail.assert_called_once_with("in.c-data.users", branch_id=42)
         mock_client.delete_table.assert_called_once_with(
-            "in.c-data.users", branch_id=42, force=False
+            "in.c-42-data.users", branch_id=None, force=False
+        )
+
+    def test_branch_resolution_failure(self, tmp_path: Path) -> None:
+        """When table doesn't exist on branch, report error in failed list."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_table_detail.side_effect = KeboolaApiError(
+            message="Table not found", status_code=404
+        )
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(alias="test", table_ids=["in.c-data.gone"], branch_id=42)
+
+        assert result["deleted"] == []
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["id"] == "in.c-data.gone"
+        mock_client.delete_table.assert_not_called()
+
+    def test_branch_batch_mixed(self, tmp_path: Path) -> None:
+        """Batch delete on branch: one succeeds, one fails resolution."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_table_detail.side_effect = [
+            {"id": "in.c-42-data.ok", "name": "ok"},
+            KeboolaApiError(message="Not found", status_code=404),
+        ]
+        mock_client.delete_table.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(
+            alias="test", table_ids=["in.c-data.ok", "in.c-data.gone"], branch_id=42
+        )
+
+        assert result["deleted"] == ["in.c-data.ok"]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["id"] == "in.c-data.gone"
+
+    def test_branch_dry_run_validates(self, tmp_path: Path) -> None:
+        """Dry-run on branch validates tables via get_table_detail."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_table_detail.side_effect = [
+            {"id": "in.c-42-data.ok", "name": "ok"},
+            KeboolaApiError(message="Not found", status_code=404),
+        ]
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(
+            alias="test",
+            table_ids=["in.c-data.ok", "in.c-data.gone"],
+            branch_id=42,
+            dry_run=True,
+        )
+
+        assert result["dry_run"] is True
+        assert result["would_delete"] == ["in.c-data.ok"]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["id"] == "in.c-data.gone"
+        mock_client.delete_table.assert_not_called()
+
+    def test_no_branch_unchanged(self, tmp_path: Path) -> None:
+        """Without branch_id, no get_table_detail call — direct delete."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.delete_table.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_tables(alias="test", table_ids=["in.c-data.users"])
+
+        assert result["deleted"] == ["in.c-data.users"]
+        mock_client.get_table_detail.assert_not_called()
+        mock_client.delete_table.assert_called_once_with(
+            "in.c-data.users", branch_id=None, force=False
         )
 
     def test_cli_branch_flag_json(self, tmp_path: Path) -> None:
@@ -735,11 +821,11 @@ class TestDeleteTableBranch:
 class TestDeleteBucketBranch:
     """Tests for --branch support in delete-bucket."""
 
-    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
-        """delete_buckets passes branch_id to client calls."""
+    def test_branch_uses_physical_bucket_id(self, tmp_path: Path) -> None:
+        """On branch, delete_buckets uses physical bucket ID without branch prefix."""
         store = _make_store(tmp_path)
         mock_client = MagicMock()
-        mock_client.get_bucket_detail.return_value = {"id": "in.c-data"}
+        mock_client.get_bucket_detail.return_value = {"id": "in.c-99-data"}
         mock_client.delete_bucket.return_value = {"id": 1, "status": "success"}
         service = _make_service(store, mock_client)
 
@@ -747,7 +833,22 @@ class TestDeleteBucketBranch:
 
         assert result["deleted"] == ["in.c-data"]
         mock_client.get_bucket_detail.assert_called_once_with("in.c-data", branch_id=99)
-        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=False, branch_id=99)
+        mock_client.delete_bucket.assert_called_once_with(
+            "in.c-99-data", force=False, branch_id=None
+        )
+
+    def test_no_branch_unchanged(self, tmp_path: Path) -> None:
+        """Without branch, delete_buckets uses original bucket ID."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_bucket_detail.return_value = {"id": "in.c-data"}
+        mock_client.delete_bucket.return_value = {"id": 1, "status": "success"}
+        service = _make_service(store, mock_client)
+
+        result = service.delete_buckets(alias="test", bucket_ids=["in.c-data"])
+
+        assert result["deleted"] == ["in.c-data"]
+        mock_client.delete_bucket.assert_called_once_with("in.c-data", force=False, branch_id=None)
 
     def test_cli_branch_flag_json(self, tmp_path: Path) -> None:
         """storage delete-bucket --branch 99 passes branch_id to service."""
@@ -903,22 +1004,69 @@ class TestStorageTablesBranch:
 
 
 class TestDeleteColumnBranch:
-    """Tests for --branch support in delete-column."""
+    """Tests for --branch support in delete-column.
 
-    def test_service_passes_branch_id(self, tmp_path: Path) -> None:
-        """delete_columns passes branch_id to client.delete_column."""
+    Same resolve-then-delete pattern as delete_tables: on branches, the
+    physical table ID is resolved once and used for all column deletes.
+    """
+
+    def test_branch_resolves_physical_id(self, tmp_path: Path) -> None:
+        """On branch, resolve physical table ID then delete columns without branch prefix."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_table_detail.return_value = {
+            "id": "in.c-42-data.users",
+            "name": "users",
+        }
+        mock_client.delete_column.return_value = None
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(
+            alias="test", table_id="in.c-data.users", columns=["age", "name"], branch_id=42
+        )
+
+        assert result["deleted"] == ["age", "name"]
+        # get_table_detail called once (not per column)
+        mock_client.get_table_detail.assert_called_once_with("in.c-data.users", branch_id=42)
+        # delete_column uses physical ID without branch
+        assert mock_client.delete_column.call_count == 2
+        mock_client.delete_column.assert_any_call(
+            "in.c-42-data.users", "age", branch_id=None, force=False
+        )
+        mock_client.delete_column.assert_any_call(
+            "in.c-42-data.users", "name", branch_id=None, force=False
+        )
+
+    def test_branch_resolution_failure_fails_all_columns(self, tmp_path: Path) -> None:
+        """When table not found on branch, all columns are reported as failed."""
+        store = _make_store(tmp_path)
+        mock_client = MagicMock()
+        mock_client.get_table_detail.side_effect = KeboolaApiError(
+            message="Table not found", status_code=404
+        )
+        service = _make_service(store, mock_client)
+
+        result = service.delete_columns(
+            alias="test", table_id="in.c-data.gone", columns=["a", "b"], branch_id=42
+        )
+
+        assert result["deleted"] == []
+        assert len(result["failed"]) == 2
+        mock_client.delete_column.assert_not_called()
+
+    def test_no_branch_unchanged(self, tmp_path: Path) -> None:
+        """Without branch_id, no get_table_detail call — direct delete."""
         store = _make_store(tmp_path)
         mock_client = MagicMock()
         mock_client.delete_column.return_value = None
         service = _make_service(store, mock_client)
 
-        result = service.delete_columns(
-            alias="test", table_id="in.c-data.users", columns=["age"], branch_id=42
-        )
+        result = service.delete_columns(alias="test", table_id="in.c-data.users", columns=["age"])
 
         assert result["deleted"] == ["age"]
+        mock_client.get_table_detail.assert_not_called()
         mock_client.delete_column.assert_called_once_with(
-            "in.c-data.users", "age", branch_id=42, force=False
+            "in.c-data.users", "age", branch_id=None, force=False
         )
 
     def test_cli_branch_flag_json(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Fix `storage delete-table`, `delete-column`, and `delete-bucket` failing on dev branches with "bucket not found" error
- Work around Keboola Storage API limitation where async DELETE doesn't resolve branch bucket context
- Resolve physical table/bucket ID via GET first, then delete using physical ID without branch URL prefix
- Fix `--dry-run` on branches to validate table existence before reporting success

## Root Cause

The Storage API async DELETE endpoint (`/v2/storage/branch/{id}/tables/{table_id}?async=true`) doesn't properly resolve branch bucket mapping. The same URL pattern works for GET but not for async DELETE. The service layer now resolves the physical ID first (via `get_table_detail`/`get_bucket_detail`) and deletes using it.

## Test plan

- [x] 45 storage delete tests pass (including 11 new branch-specific tests)
- [x] Full test suite passes (1737 passed)
- [x] Lint + format checks pass
- [ ] E2E: create branch, create table, delete-table --branch, verify success

Closes #177