### PR TITLE
fix: review fixes for branch metadata commands

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.21.0",
+  "version": "0.20.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.21.0"
+version = "0.20.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
-    "0.21.0": [
+    "0.20.1": [
         "New: project description-get / description-set -- read/write the Keboola dashboard project description (markdown)",
         "New: branch metadata-list / metadata-get / metadata-set / metadata-delete -- generic CRUD over branch metadata (KBC.* keys)",
         "New: client helpers list/set/delete_branch_metadata + get_branch_metadata_value on KeboolaClient",

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -26,6 +26,7 @@ from .constants import (
     FILE_DOWNLOAD_TIMEOUT,
     FILE_UPLOAD_TIMEOUT,
     IMPORT_JOB_MAX_WAIT,
+    METADATA_NOT_FOUND,
     QUERY_JOB_MAX_WAIT,
     QUERY_JOB_POLL_INTERVAL,
     STORAGE_JOB_MAX_WAIT,
@@ -658,12 +659,13 @@ class KeboolaClient(BaseHttpClient):
             branch_id: Branch ID or the literal "default" for the main branch.
 
         Returns:
-            The string value, or None if the key is not present.
+            The string value if the key exists (may be None if the API stored null),
+            or ``METADATA_NOT_FOUND`` sentinel if the key is not present.
         """
         for entry in self.list_branch_metadata(branch_id=branch_id):
             if entry.get("key") == key:
                 return entry.get("value")
-        return None
+        return METADATA_NOT_FOUND
 
     def list_buckets(
         self, include: str | None = None, branch_id: int | None = None

--- a/src/keboola_agent_cli/commands/branch.py
+++ b/src/keboola_agent_cli/commands/branch.py
@@ -409,6 +409,12 @@ def branch_metadata_delete(
         "--metadata-id",
         help="Numeric ID of the metadata entry (from metadata-list)",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
     branch: str = typer.Option(
         "default",
         "--branch",
@@ -427,6 +433,14 @@ def branch_metadata_delete(
         return
     formatter = get_formatter(ctx)
     service = get_service(ctx, "branch_service")
+
+    if (
+        not yes
+        and not formatter.json_mode
+        and not typer.confirm(f"Delete metadata entry {metadata_id} from project '{project}'?")
+    ):
+        formatter.console.print("Aborted.")
+        raise typer.Exit(code=0)
 
     try:
         result = service.delete_branch_metadata(

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -7,6 +7,10 @@ and ensure consistency across the codebase.
 
 import httpx
 
+# --- Sentinel for missing metadata keys ---
+# Distinguishes "key absent" from "value is None/null" in branch metadata lookups.
+METADATA_NOT_FOUND = object()
+
 # --- HTTP Retry Constants ---
 RETRYABLE_STATUS_CODES: set[int] = {429, 500, 502, 503, 504}
 MAX_RETRIES: int = 3

--- a/src/keboola_agent_cli/services/branch_service.py
+++ b/src/keboola_agent_cli/services/branch_service.py
@@ -9,6 +9,7 @@ the ``KBC.projectDescription`` metadata key on the default branch.
 
 from typing import Any
 
+from ..constants import METADATA_NOT_FOUND
 from ..errors import ConfigError, KeboolaApiError
 from ..models import ProjectConfig
 from .base import BaseService
@@ -401,7 +402,7 @@ class BranchService(BaseService):
             value = client.get_branch_metadata_value(key=key, branch_id=branch_id)
         finally:
             client.close()
-        if value is None:
+        if value is METADATA_NOT_FOUND:
             raise KeboolaApiError(
                 message=(
                     f"Metadata key '{key}' not found on branch '{branch_id}' of project '{alias}'."
@@ -525,7 +526,7 @@ class BranchService(BaseService):
         return {
             "project_alias": alias,
             "key": PROJECT_DESCRIPTION_KEY,
-            "description": value or "",
+            "description": "" if value is METADATA_NOT_FOUND else (value or ""),
         }
 
     def set_project_description(self, alias: str, description: str) -> dict[str, Any]:
@@ -545,12 +546,16 @@ class BranchService(BaseService):
             ConfigError: If the project alias is not found.
             KeboolaApiError: If the API call fails.
         """
-        result = self.set_branch_metadata(
+        raw = self.set_branch_metadata(
             alias=alias,
             key=PROJECT_DESCRIPTION_KEY,
             value=description,
             branch_id="default",
         )
-        result["description"] = description
-        result["message"] = f"Project description updated for '{alias}' ({len(description)} chars)."
-        return result
+        return {
+            "project_alias": alias,
+            "key": PROJECT_DESCRIPTION_KEY,
+            "description": description,
+            "result": raw["result"],
+            "message": f"Project description updated for '{alias}' ({len(description)} chars).",
+        }

--- a/tests/test_branch_metadata_cli.py
+++ b/tests/test_branch_metadata_cli.py
@@ -364,9 +364,7 @@ class TestProjectDescription:
         mock_svc = MagicMock()
         mock_svc.set_project_description.return_value = {
             "project_alias": "prod",
-            "branch_id": "default",
             "key": "KBC.projectDescription",
-            "value": "# New",
             "description": "# New",
             "result": [],
             "message": "Project description updated for 'prod' (5 chars).",
@@ -392,9 +390,7 @@ class TestProjectDescription:
         mock_svc = MagicMock()
         mock_svc.set_project_description.return_value = {
             "project_alias": "prod",
-            "branch_id": "default",
             "key": "KBC.projectDescription",
-            "value": "from stdin",
             "description": "from stdin",
             "result": [],
             "message": "ok",

--- a/tests/test_branch_metadata_service.py
+++ b/tests/test_branch_metadata_service.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from helpers import setup_single_project
+from keboola_agent_cli.constants import METADATA_NOT_FOUND
 from keboola_agent_cli.errors import ConfigError, KeboolaApiError
 from keboola_agent_cli.services.branch_service import (
     PROJECT_DESCRIPTION_KEY,
@@ -84,7 +85,7 @@ class TestBranchMetadataGet:
 
     def test_get_missing_key_raises_not_found(self, tmp_config_dir: Path) -> None:
         mock_client = MagicMock()
-        mock_client.get_branch_metadata_value.return_value = None
+        mock_client.get_branch_metadata_value.return_value = METADATA_NOT_FOUND
         store = setup_single_project(tmp_config_dir)
         svc = BranchService(
             config_store=store,
@@ -158,7 +159,7 @@ class TestProjectDescription:
     def test_get_returns_empty_when_unset(self, tmp_config_dir: Path) -> None:
         """A missing project description returns '', not an error."""
         mock_client = MagicMock()
-        mock_client.get_branch_metadata_value.return_value = None
+        mock_client.get_branch_metadata_value.return_value = METADATA_NOT_FOUND
         store = setup_single_project(tmp_config_dir)
         svc = BranchService(
             config_store=store,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2316,7 +2316,9 @@ class TestBranchMetadata:
         assert value == "# My project"
 
     def test_get_branch_metadata_value_missing(self, httpx_mock) -> None:
-        """get_branch_metadata_value() returns None when the key is absent."""
+        """get_branch_metadata_value() returns sentinel when the key is absent."""
+        from keboola_agent_cli.constants import METADATA_NOT_FOUND
+
         httpx_mock.add_response(
             url=f"{_BASE}/v2/storage/branch/default/metadata",
             method="GET",
@@ -2325,4 +2327,4 @@ class TestBranchMetadata:
         )
         with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
             value = client.get_branch_metadata_value(key="KBC.projectDescription")
-        assert value is None
+        assert value is METADATA_NOT_FOUND

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -493,7 +493,7 @@ class TestFullE2E:
         self._test_branch_lifecycle()
 
         _step(
-            35,
+            36,
             "project description + branch metadata",
             "get/set description + generic metadata CRUD",
         )


### PR DESCRIPTION
## Summary

Post-merge review fixes for PR #176 (branch metadata & project description).
The original PR was merged but the review fix commit got lost during merge resolution.

- Add `--yes` flag to `metadata-delete` — registered as `destructive` in permissions but was missing confirmation prompt (required by CONTRIBUTING.md)
- Use `METADATA_NOT_FOUND` sentinel in `constants.py` — `get_branch_metadata_value` now distinguishes "key absent" from "value is null" (was ambiguous, both returned `None`)
- Clean `set_project_description` response — removed redundant `value`/`branch_id` fields that leaked from the inner `set_branch_metadata` call
- Fix duplicate E2E step number 35 -> 36

## Test plan

- [x] `make check` — 1732 passed, 0 failed
- [x] E2E round-trip on `padak-2-0`: get/set description, metadata CRUD, delete with cleanup — all OK