### PR TITLE
feat: job terminate command for killing Queue API jobs (#181)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,7 @@ kbagent config rename --project NAME --component-id ID --config-id ID --name "Ne
 kbagent job list [--project NAME] [--component-id ID] [--status STATUS] [--limit N]
 kbagent job detail --project NAME --job-id ID
 kbagent job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N] [--branch ID]
+kbagent job terminate --project NAME (--job-id ID [--job-id ID ...] | --status any|created|waiting|processing [--component-id ID] [--config-id ID] [--branch ID] [--limit N]) [--dry-run] [--yes]
 
 kbagent storage buckets [--project NAME] [--branch ID]
 kbagent storage bucket-detail --project NAME --bucket-id ID [--branch ID]

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.21.0",
+  "version": "0.20.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -20,7 +20,10 @@ description: >
   input mapping migration, remove input mapping, Snowflake paths,
   MULTI_STATEMENT_COUNT, statement count error, SQL transformation migration,
   keboola encrypt, encrypt secrets, encrypt credentials, encrypt password,
-  keboola encryption API, #password, #api_token, KBC::ProjectSecure.
+  keboola encryption API, #password, #api_token, KBC::ProjectSecure,
+  safe config write, dry-run preview, fresh fetch before edit,
+  stale local config file, config version overwrite,
+  local workspace, project directory, kbagent init.
 ---
 
 # kbagent -- Keboola Agent CLI
@@ -42,6 +45,23 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 4. **Write commands need `--project`**: specify the target project alias
 5. **Tokens are always masked** in output -- this is expected, not an error
 6. **Use `--hint` for Python code generation**: `kbagent --hint client <command>` generates Python code using `KeboolaClient` (direct API), `kbagent --hint service <command>` generates code using the service layer with CLI config. See [programming-with-cli.md](references/programming-with-cli.md) for details.
+7. **Always fetch fresh before write**: configs change between commands and across users. Re-fetch from the API immediately before any update; never reuse a config dump from earlier in the session. Stale local files are how `vN+1` silently overwrites someone else's `vN` changes.
+8. **Always `--dry-run` first** for destructive operations (`config update`, `config delete`, `storage delete-*`, `branch delete`, `sync push`). Show the user the diff and get explicit confirmation before applying.
+9. **Prefer CLI commands over MCP tools** where both exist (`config update` over `update_config`, `config detail` over `get_configs`). Lower latency, native dry-run/diff support, consistent JSON shape, and fewer parameter-shape footguns. Use MCP only for operations the CLI does not cover (e.g. `str_replace`, `list_append`, `run_component`).
+10. **Never auto-run jobs after config changes**. `config update` (or `sync push`) and `job run` are always two separate steps. Wait for the user to confirm before triggering a run -- do not chain them.
+
+## Safe write workflow
+
+For any operation that modifies a Keboola config or storage object, follow this order. See [safe-write-workflow](references/safe-write-workflow.md) for the detailed runbook with examples and anti-patterns.
+
+1. **Fetch fresh** from the API (e.g. `kbagent --json config detail ...`) -- never reuse a local file from earlier in the session.
+2. **Compute the change** in memory or via `jq`/Python. Keep the diff small and targeted; prefer `--set path=value` or `--merge` over full-config replacement.
+3. **Preview with `--dry-run`** (e.g. `kbagent --json config update ... --dry-run`). Show the user what will change.
+4. **Get user confirmation** before re-running the same command without `--dry-run`.
+5. **Verify** by re-fetching the config and inspecting the new version.
+6. **Stop**. Do NOT auto-trigger `job run`, transformation execution, or any side-effecting follow-up. The user decides when to run.
+
+When working inside a git repository or project directory, run `kbagent init` (or `kbagent init --from-global`) once to create a local `.kbagent/` workspace. After that, kbagent works from any subdirectory of the project -- no need to `cd ~` first.
 
 ## Choosing the right approach
 
@@ -175,6 +195,7 @@ For detailed response parsing rules and common pitfalls, see [gotchas](reference
 | Workflow | Reference |
 |----------|-----------|
 | All commands cheat sheet | [commands-reference](references/commands-reference.md) |
+| **Safe config write workflow** (fetch → dry-run → confirm → push) | [safe-write-workflow](references/safe-write-workflow.md) |
 | Creating new configurations | [scaffold-workflow](references/scaffold-workflow.md) |
 | MCP tools (multi-project read/write) | [mcp-workflow](references/mcp-workflow.md) |
 | Workspace SQL debugging | [workspace-workflow](references/workspace-workflow.md) |

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -76,6 +76,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 | List jobs from connected projects | `kbagent job list` |
 | Show detailed information about a specific job | `kbagent job detail --project PROJECT --job-id JOB-ID` |
 | Run a job for a component configuration | `kbagent job run --project PROJECT --component-id COMPONENT-ID --config-id CONFIG-ID` |
+| Terminate one or more Queue API jobs (use to stop runaway or stuck jobs) | `kbagent job terminate --project PROJECT` |
 | List storage buckets with sharing/linked bucket information | `kbagent storage buckets` |
 | Show detailed bucket info including Snowflake direct access paths | `kbagent storage bucket-detail --project PROJECT --bucket-id BUCKET-ID` |
 | List storage tables from a project | `kbagent storage tables --project PROJECT` |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -40,6 +40,7 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `job list [--project NAME] [--component-id ID] [--config-id ID] [--status STATUS] [--limit N]` -- list jobs (default 50, max 500)
 - `job detail --project NAME --job-id ID` -- full job detail with timing and result message
 - `job run --project NAME --component-id ID --config-id ID [--row-id ID ...] [--wait] [--timeout N] [--branch ID]` -- run a job, optionally wait for completion (branch-aware)
+- `job terminate --project NAME (--job-id ID [--job-id ...] | --status any|created|waiting|processing [--component-id ID] [--config-id ID] [--branch ID] [--limit N]) [--dry-run] [--yes]` -- kill running Queue API jobs. Use to stop runaway loops or clean up pile-ups from repeated `job run` calls. Two modes: by ID (single/batch) or by filter (`--status any` catches every killable state). Response partitions IDs into `killed / already_finished / not_found / failed`; safe to re-run idempotently. Kill is async -- poll `job detail` for `isFinished=true`.
 
 ## Storage
 - `storage buckets [--project NAME] [--branch ID]` -- list buckets with sharing/linked info (branch-aware)

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -17,6 +17,7 @@ Not all commands return data the same way. Key differences:
 | `config search` | `{"matches": [...], "errors": [...], "stats": {...}}` |
 | `storage table-detail` | `{"table_id": ..., "columns": [...], "column_details": [...]}` |
 | `storage download-table` | `{"table_id": ..., "output_path": ..., "file_size_bytes": N}` |
+| `job terminate` | `{"killed": [...], "already_finished": [...], "not_found": [...], "failed": [...]}` -- four-way partition, NOT a simple success/failure. Always inspect each bucket |
 
 Always check the actual response structure rather than assuming a pattern.
 
@@ -339,3 +340,35 @@ field as a branch's `description` attribute:
 They live at different endpoints in the Storage API
 (`/v2/storage/branch/{id}/metadata` vs. `/v2/storage/dev-branches/{id}`),
 so setting a branch's description will **not** update the dashboard.
+
+## `job terminate` quirks
+
+Queue API's kill endpoint (`POST /jobs/{id}/kill`) has a few non-obvious behaviors the
+CLI hides via its four-bucket response, but they matter when interpreting results:
+
+- **Kill is asynchronous.** A successful `killed` entry has
+  `desiredStatus=terminating` but the actual `status` does not change immediately.
+  The job transitions to `cancelled` (if it was `waiting`) or `terminated`
+  (if it was `processing`) within a few seconds. Poll `job detail` for
+  `isFinished=true` before assuming it's done.
+- **`processing` is transient in the middle of termination.** Between the
+  accepted kill and the terminal state, you may briefly observe
+  `status=terminating` -- still `isFinished=false`. Don't treat it as an error.
+- **Re-terminating a finished job is safe.** Queue API returns HTTP 400 for
+  already-terminal jobs; the CLI reports them in `already_finished` rather than
+  `failed`. This also covers race conditions where a job finishes between
+  `list` and `terminate`.
+- **Bogus or already-`success`/`error` IDs hit an inconsistency:** Queue API
+  returns HTTP 500 with body `code=404`. The CLI verifies via GET: if the job
+  exists and is finished, it lands in `already_finished`; if GET returns 404,
+  it lands in `not_found`.
+- **`--status` filter is client-side for branches.** Queue API's `/search/jobs`
+  does not accept a branch parameter, so `--branch ID` is applied by filtering
+  the listed jobs on `branchId`. If you need pristine branch scoping, consider
+  using the IDs returned from `job list --status processing` and passing them
+  explicitly with `--job-id`.
+- **`--status any` is the right default for runaway cleanup.** It fetches all
+  recent jobs (no status filter) and keeps only `created`/`waiting`/`processing`
+  client-side. Picking a single status misses the other killable states -- e.g.
+  a runaway loop often piles up `waiting` jobs while you're typing
+  `--status processing`.

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -219,19 +219,37 @@ SELECT * FROM sapi_1507."in.c-keboola-ex-db-mysql"."orders"
 This applies to linked bucket paths (`sapi_NNNN`), native bucket paths, and
 any identifier containing dots, hyphens, or lowercase letters.
 
-## SQL migration: do NOT use global text replace
+## SQL editing: do NOT use global text replace on identifiers
 
-When migrating SQL transformations (e.g. removing input mapping and replacing
-aliases with direct Snowflake paths), **never use global find & replace**.
-A table name like `"orders"` also appears as a **column name** in many places.
+This applies to ANY operation that rewrites a table or column name in SQL:
 
-Global replace will corrupt:
+- **Renaming** -- changing a table name (`"orders"` → `"objednavky"`)
+- **Migration** -- removing input mapping, replacing aliases with direct
+  Snowflake paths (`"orders"` → `"sapi_1507"."in.c-db"."orders"`)
+- **Refactoring** -- consolidating duplicate workspace tables, changing
+  prefixes (`"tmp.X"` → `"stg.X"`)
+
+In all of these, **never use global find & replace**. A table name like
+`"orders"` almost always also appears as a **column name** somewhere
+(FK reference in `JOIN ON`, aggregation alias in `SELECT`, `WHERE` clause).
+
+Global replace corrupts every scenario:
 
 ```sql
--- BEFORE: "orders" is a column name in SELECT
+-- BEFORE: rename table "orders" → "objednavky"
+SELECT SUM(a."orders") AS "orders" FROM "orders" a
+
+-- AFTER global replace (WRONG!):
+SELECT SUM(a."objednavky") AS "objednavky" FROM "objednavky" a
+-- The column reference and the SELECT alias were renamed too --
+-- only the FROM table should have changed.
+```
+
+```sql
+-- BEFORE: migrate "orders" alias to Snowflake path
 SUM(a."orders") AS "orders"
 
--- AFTER global replace: column becomes a table path (WRONG!)
+-- AFTER global replace (WRONG!): column becomes a table path
 SUM(a."tmp.orders") AS "tmp.orders"  -- no such column
 ```
 
@@ -239,23 +257,37 @@ SUM(a."tmp.orders") AS "tmp.orders"  -- no such column
 -- BEFORE: "country_locality" is a FK column in JOIN ON
 ON pcl."country_locality" = cl."id"
 
--- AFTER global replace: FK column becomes full path (WRONG!)
+-- AFTER global replace (WRONG!): FK column becomes full path
 ON pcl."sapi_1507"."in.c-keboola-ex-db-mysql"."country_locality" = cl."id"
 ```
 
-**Safe migration approach:**
-1. Build a complete destination→source map from `storage.input.tables`
-2. Replace ONLY in `FROM` and `JOIN` table-reference positions (not columns)
-3. After migration, verify with these regex checks:
-   - `alias\."sapi_\d+"` → FK column incorrectly expanded (e.g. `a."sapi_1507"...`)
-   - `ON.*=\s*"sapi_\d+"` → bare FK in JOIN ON replaced with path
-   - `"tmp\.\w+"` used as column name (not after FROM/JOIN)
-4. Verify ALL destination aliases were replaced (none should remain in SQL)
-5. Workspace tables created by earlier code blocks (e.g. `"tmp.orders"`) must
-   NOT be replaced -- they are runtime artifacts, not input mapping aliases
+**Safe approach (for any rename, migration, or refactor):**
 
-See [sql-migration-workflow](sql-migration-workflow.md) for the complete
-step-by-step procedure.
+1. Replace ONLY in **table-reference positions**:
+   - After `FROM` keyword
+   - After `JOIN` keyword
+   - In `CREATE ... TABLE "name"` declarations
+   - In `INSERT INTO "name"` / `UPDATE "name"` / `DELETE FROM "name"`
+2. Do NOT replace in:
+   - Column references: `a."orders"`, `SUM("orders")`, `"orders" AS "orders"`
+   - `JOIN ON` conditions: `ON a."col_name" = b."id"`
+   - `WHERE` conditions, string literals (`'... orders ...'`)
+3. **Context detection heuristic:**
+   - Preceded by a dot (`alias."name"`) → column, skip
+   - Preceded by `FROM` / `JOIN` keyword → table, replace
+   - Inside `SELECT` list (between commas, no FROM yet) → column, skip
+4. After editing, verify with regex:
+   - **Rename**: search for the new name in column positions
+     (`alias\."newname"`, `SUM\("newname"\)`) -- must be zero hits
+   - **Migration**: `alias\."sapi_\d+"`, `ON.*=\s*"sapi_\d+"`,
+     `"tmp\.\w+"` used as column
+   - Verify all old occurrences in table positions are gone
+5. Workspace tables created by earlier code blocks (e.g. `"tmp.orders"`)
+   must NOT be replaced -- they are runtime artifacts, not aliases.
+
+For input mapping migration specifically, see
+[sql-migration-workflow](sql-migration-workflow.md) for the full
+step-by-step procedure including building the destination→source map.
 
 ## Workspace table name conflicts
 

--- a/plugins/kbagent/skills/kbagent/references/safe-write-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/safe-write-workflow.md
@@ -230,3 +230,18 @@ for workspace table name conflicts before pushing:
 This isn't covered by `--dry-run` -- you have to spot it during step 2
 (compute the change). See `gotchas.md` "Workspace table name conflicts" for
 detail.
+
+## Renaming SQL identifiers in transformations
+
+When renaming a table inside a SQL transformation (e.g. `"orders"` →
+`"objednavky"`), do NOT use global find & replace. The same name almost
+always also appears as a **column** somewhere -- FK in `JOIN ON`,
+aggregation alias in `SELECT`, `WHERE` condition. Global replace will
+rename the column too and break the SQL silently.
+
+Replace only in **table-reference positions**: after `FROM`, after `JOIN`,
+in `CREATE ... TABLE` declarations. The same rule applies when migrating
+to direct Snowflake paths or changing table prefixes.
+
+See `gotchas.md` "SQL editing: do NOT use global text replace on
+identifiers" for the full pattern, examples, and verification regexes.

--- a/plugins/kbagent/skills/kbagent/references/safe-write-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/safe-write-workflow.md
@@ -1,0 +1,232 @@
+# Safe Config Write Workflow
+
+## Why this exists
+
+Two recurring incidents motivate this workflow:
+
+1. **Stale-file overwrite.** Edit a config based on a local file from earlier
+   in the session, push it back, and silently overwrite changes someone (or
+   you) made in between. The classic case: `v106` was built from a local
+   dump captured before `v105` landed, so the push of `v106` reverted the
+   `v105` improvements.
+2. **Blind push.** Apply a JSON edit without seeing the diff, discover only
+   after the fact that you accidentally rewrote unrelated keys (storage input
+   tables, parameters siblings, etc.). Without a `--dry-run` step, push is
+   fire-and-forget.
+
+The cycle below prevents both.
+
+## The six-step cycle
+
+Apply this for every write to a Keboola config, storage object, or branch.
+
+### 1. Fetch fresh
+
+Always re-read from the API right before you write. Never reuse a JSON dump
+from a few commands back -- the version may already have moved.
+
+```bash
+kbagent --json config detail \
+  --project prod \
+  --component-id keboola.snowflake-transformation \
+  --config-id 12345 > /tmp/config.fresh.json
+```
+
+If you fetched a config 10 minutes ago and want to write now, fetch again.
+The cost of one extra GET is negligible compared to recovering from a
+silently overwritten version.
+
+### 2. Compute the change
+
+Edit in memory (Python, `jq`) or in your head. Keep the change minimal: only
+the fields you actually want to modify. Avoid sending the whole config
+object back -- that maximizes the blast radius if any sibling key drifted.
+
+For nested updates, prefer:
+- `--set path=value` -- single key, shallow set
+- `--configuration '{...}' --merge` -- partial JSON, deep-merged into existing
+
+over:
+- `--configuration '{...}'` (without `--merge`) -- replaces the entire
+  configuration object with what you sent
+
+### 3. Preview with `--dry-run`
+
+```bash
+kbagent --json config update \
+  --project prod \
+  --component-id keboola.snowflake-transformation \
+  --config-id 12345 \
+  --set "parameters.query=SELECT 1" \
+  --dry-run
+```
+
+The dry-run output shows the diff between the current and proposed config
+without applying it. Read it, render the relevant changes back to the user,
+and pause.
+
+### 4. Get user confirmation
+
+Show the diff. Wait for an explicit "yes" before re-running the command
+without `--dry-run`. This catches mistakes before they hit the API.
+
+```bash
+# After user confirms:
+kbagent --json config update \
+  --project prod \
+  --component-id keboola.snowflake-transformation \
+  --config-id 12345 \
+  --set "parameters.query=SELECT 1"
+```
+
+### 5. Verify
+
+Re-fetch the config and check the new version number and the field you
+changed. Confirm to the user that the write landed.
+
+```bash
+kbagent --json config detail \
+  --project prod \
+  --component-id keboola.snowflake-transformation \
+  --config-id 12345 | jq '{version, query: .configuration.parameters.query}'
+```
+
+### 6. Stop -- do not auto-run
+
+Pushing a config and running the resulting transformation are always two
+separate steps. Reasons:
+
+- A previous job may still be running. Auto-triggering a second job stacks
+  them and burns credits.
+- The user may want to inspect the new config in the UI first.
+- The user may want to schedule the run for off-hours.
+
+Wait for an explicit user instruction before calling `job run` or any other
+execution endpoint.
+
+## Working from a git repository
+
+By default, kbagent reads its config from `~/.config/keboola-agent-cli/`.
+When you want a per-project setup (e.g. a git repo with its own Keboola
+project list), initialize a local workspace:
+
+```bash
+cd /path/to/project
+kbagent init                # create empty .kbagent/ in current dir
+# or
+kbagent init --from-global  # copy global config into local .kbagent/
+```
+
+After that, kbagent automatically uses `.kbagent/` whenever you run from
+this directory or any subdirectory. The lookup order is:
+
+1. `--config-dir` flag
+2. `KBAGENT_CONFIG_DIR` env var
+3. `.kbagent/` in current or parent directories
+4. `~/.config/keboola-agent-cli/` (global fallback)
+
+This eliminates the "kbagent only works from home directory" friction --
+once `.kbagent/` exists, you can run from any subdirectory of the repo.
+
+## Anti-patterns
+
+### Reusing a local file across edits
+
+```bash
+# BAD: fetched once at v105, edited and pushed multiple times
+kbagent config detail ... > /tmp/config.json
+# ... 10 minutes of editing ...
+# meanwhile someone (or you) pushed v106
+kbagent config update --configuration @/tmp/config.json
+# Result: v107 is built from v105 + your edits, silently discarding v106.
+```
+
+```bash
+# GOOD: re-fetch immediately before each push
+kbagent config detail ... > /tmp/config.json   # fresh
+# ... edit ...
+kbagent config update --configuration @/tmp/config.json --merge --dry-run
+# preview, confirm, then push without --dry-run
+```
+
+### Sending the whole configuration when changing one field
+
+```bash
+# BAD: replaces the entire .configuration with what you sent
+kbagent config update ... --configuration "$(cat /tmp/full-config.json)"
+# Result: any drift in storage.input.tables or parameters siblings is wiped.
+```
+
+```bash
+# GOOD: targeted change, deep-merged
+kbagent config update ... --set "parameters.query=SELECT 1"
+
+# GOOD: partial JSON merged into existing
+kbagent config update ... --configuration '{"parameters":{"query":"SELECT 1"}}' --merge
+```
+
+### Pushing then immediately running
+
+```bash
+# BAD
+kbagent config update ...
+kbagent job run ...   # do NOT chain
+```
+
+```bash
+# GOOD: push, report to user, wait for "yes, run it"
+kbagent config update ... --dry-run     # preview
+kbagent config update ...               # after user confirms
+# stop here; tell user the new version is in. Wait for explicit run instruction.
+```
+
+### Editing transformation SQL via full-config update
+
+For SQL transformations, only update the specific `script` arrays inside
+`parameters.blocks[N].codes[M]`, not the whole config. Sending the whole
+config can wipe `storage.input.tables` / `storage.output.tables`. See
+[sql-migration-workflow](sql-migration-workflow.md) for the safe pattern,
+including the use of MCP `update_sql_transformation` with `str_replace`
+operations (one of the few cases where MCP beats the CLI).
+
+## Multi-user / multi-session teams
+
+When several people (or several Claude sessions) edit the same project:
+
+- Always fetch fresh just before write -- the version may have advanced.
+- Capture the `version` field from `config detail` and report it back to the
+  user. If the version doesn't match what you expect (e.g. you fetched
+  `v105` and now see `v107`), stop and re-evaluate before writing.
+- For coordinated changes across multiple commits, prefer the
+  [sync workflow](sync-workflow.md) (per-branch local checkout with
+  explicit `pull` / `diff` / `push`) over ad-hoc `config update`.
+
+## When dry-run is not available
+
+A few destructive operations don't (yet) have `--dry-run`:
+
+- `kbagent tool call` for MCP write tools (`update_config`,
+  `update_sql_transformation`, `create_config`, etc.)
+- some `branch` operations
+
+For these, **describe the intended change to the user in plain English
+first** and get confirmation before invoking. The verbal preview replaces
+`--dry-run`. Better still: when an equivalent CLI command exists (e.g.
+`kbagent config update` instead of MCP `update_config`), use the CLI for
+its built-in `--dry-run`.
+
+## Workspace table conflicts in transformations
+
+When editing a SQL transformation that has multiple code blocks, also check
+for workspace table name conflicts before pushing:
+
+- Scan all `CREATE OR REPLACE TABLE "tmp.X"` statements across blocks.
+- If the same `"tmp.X"` is created in two different blocks with different
+  schemas, downstream blocks reading the original schema will fail at
+  runtime with `invalid identifier '"column_name"'`.
+- Fix: rename the secondary table (e.g. `"tmp.X2"`) and update its
+  references within that block.
+
+This isn't covered by `--dry-run` -- you have to spot it during step 2
+(compute the change). See `gotchas.md` "Workspace table name conflicts" for
+detail.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.21.0"
+version = "0.20.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.20.1"
+version = "0.21.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
-    "0.21.0": [
+    "0.20.2": [
         "New: job terminate -- kill Queue API jobs with --job-id or bulk --status filter (#181)",
         "New: --status any filter for terminating all killable jobs (created+waiting+processing)",
         "New: client helper kill_job + service terminate_jobs with partition response (killed/already_finished/not_found/failed)",

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.21.0": [
+        "New: job terminate -- kill Queue API jobs with --job-id or bulk --status filter (#181)",
+        "New: --status any filter for terminating all killable jobs (created+waiting+processing)",
+        "New: client helper kill_job + service terminate_jobs with partition response (killed/already_finished/not_found/failed)",
+        "New: job.terminate permission (destructive class) for policy-based gating",
+    ],
     "0.20.1": [
         "New: project description-get / description-set -- read/write the Keboola dashboard project description (markdown)",
         "New: branch metadata-list / metadata-get / metadata-set / metadata-delete -- generic CRUD over branch metadata (KBC.* keys)",

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -1675,6 +1675,24 @@ class KeboolaClient(BaseHttpClient):
         response = self._queue_request("POST", "/jobs", json=body)
         return response.json()
 
+    def kill_job(self, job_id: str) -> dict[str, Any]:
+        """Request termination of a running Queue API job.
+
+        Sets the job's desiredStatus to "terminating"; the executor transitions
+        the actual status asynchronously (waiting -> cancelled, processing ->
+        terminating -> terminated). Poll get_job_detail until isFinished=True
+        to observe the terminal state.
+
+        Killable states per Queue API: created, waiting, processing. Calling
+        kill on any other state returns HTTP 400 with a "not in one of killable
+        states" message; callers that want idempotent behavior (e.g. bulk
+        terminate after list_jobs under race conditions) should translate that
+        into a no-op success at the service layer.
+        """
+        safe_job_id = quote(job_id, safe="")
+        response = self._queue_request("POST", f"/jobs/{safe_job_id}/kill")
+        return response.json()
+
     def wait_for_queue_job(
         self, job_id: str, max_wait: float = STORAGE_JOB_MAX_WAIT
     ) -> dict[str, Any]:

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -131,6 +131,12 @@ Use `kbagent <command> --help` for full flag details and examples.
     Run a Queue API job. --row-id selects specific config rows (repeatable; omit to run entire config).
     --wait polls until job finishes. --timeout sets max wait in seconds (default 300). Branch-aware.
 
+  kbagent job terminate --project NAME (--job-id ID [--job-id ID ...] | --status any|created|waiting|processing [--component-id ID] [--config-id ID] [--branch ID] [--limit N]) [--dry-run] [--yes]
+    Kill running jobs via Queue API (POST /jobs/{id}/kill). Use to stop runaway loops or pile-ups.
+    Two modes: single/batch by --job-id, or bulk by --status. --status any covers all killable states
+    (created+waiting+processing). Response partitions into killed / already_finished / not_found / failed.
+    Idempotent: re-running on terminal jobs reports them as already_finished rather than failing.
+
 ### Storage
 
   kbagent storage buckets [--project NAME] [--branch ID]

--- a/src/keboola_agent_cli/commands/job.py
+++ b/src/keboola_agent_cli/commands/job.py
@@ -7,7 +7,13 @@ No business logic belongs here.
 import typer
 
 from ..config_store import ConfigStore
-from ..constants import DEFAULT_JOB_LIMIT, DEFAULT_JOB_RUN_TIMEOUT, MAX_JOB_LIMIT, VALID_STATUSES
+from ..constants import (
+    DEFAULT_JOB_LIMIT,
+    DEFAULT_JOB_RUN_TIMEOUT,
+    KILLABLE_JOB_STATUSES,
+    MAX_JOB_LIMIT,
+    VALID_STATUSES,
+)
 from ..errors import ConfigError, KeboolaApiError
 from ..output import format_job_detail, format_jobs_table
 from ._helpers import (
@@ -270,3 +276,256 @@ def job_run(
                     "  Use --wait to poll until completion, "
                     f"or: kbagent job detail --project {project} --job-id {job_id}"
                 )
+
+
+@job_app.command("terminate")
+def job_terminate(
+    ctx: typer.Context,
+    project: str = typer.Option(
+        ...,
+        "--project",
+        help="Project alias",
+    ),
+    job_id: list[str] | None = typer.Option(
+        None,
+        "--job-id",
+        help="Job ID to terminate. Can be repeated. Mutually exclusive with --status.",
+    ),
+    status: str | None = typer.Option(
+        None,
+        "--status",
+        help=(
+            "Bulk-terminate jobs matching status. "
+            f"Single killable: {', '.join(sorted(KILLABLE_JOB_STATUSES))}. "
+            "Use 'any' to match all killable states at once (typical for runaway cleanup). "
+            "Recommend scoping with --component-id / --config-id / --branch."
+        ),
+    ),
+    component_id: str | None = typer.Option(
+        None,
+        "--component-id",
+        help="Filter bulk terminate by component ID",
+    ),
+    config_id: str | None = typer.Option(
+        None,
+        "--config-id",
+        help="Filter bulk terminate by configuration ID (requires --component-id)",
+    ),
+    limit: int = typer.Option(
+        DEFAULT_JOB_LIMIT,
+        "--limit",
+        help=f"Max jobs to consider when using --status (1-{MAX_JOB_LIMIT})",
+    ),
+    branch: int | None = typer.Option(
+        None,
+        "--branch",
+        help="Dev branch ID (filters jobs client-side; defaults to active branch if set via 'branch use')",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be terminated without executing",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Terminate one or more Queue API jobs (use to stop runaway or stuck jobs).
+
+    Two modes:
+
+    - Single/multiple by ID: --job-id ID [--job-id ID ...]
+    - Bulk by filter: --status processing [--component-id ID] [--config-id ID] [--branch ID]
+
+    Queue API kill is asynchronous: the job's desiredStatus becomes 'terminating'
+    and the actual status transitions to 'cancelled' (if waiting) or 'terminated'
+    (if processing) within a few seconds. Poll with 'kbagent job detail' to
+    observe the terminal state.
+
+    Jobs already in a terminal state (success/error/terminated/cancelled) are
+    counted as 'already_finished' — safe to re-run this command idempotently
+    for cleanup purposes.
+    """
+    if should_hint(ctx):
+        emit_hint(
+            ctx,
+            "job.terminate",
+            project=project,
+            job_id=job_id,
+            status=status,
+            component_id=component_id,
+            config_id=config_id,
+            limit=limit,
+            branch=branch,
+            dry_run=dry_run,
+        )
+        return
+
+    formatter = get_formatter(ctx)
+    service = get_service(ctx, "job_service")
+    config_store: ConfigStore = ctx.obj["config_store"]
+
+    if bool(job_id) == bool(status):
+        formatter.error(
+            message="Provide either --job-id (one or more) or --status, but not both.",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    if status and status != "any" and status not in KILLABLE_JOB_STATUSES:
+        formatter.error(
+            message=(
+                f"Invalid --status '{status}'. Use one of: "
+                f"{', '.join(sorted(KILLABLE_JOB_STATUSES))} or 'any'."
+            ),
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    if config_id and not component_id:
+        formatter.error(
+            message="--config-id requires --component-id.",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    if limit < 1 or limit > MAX_JOB_LIMIT:
+        formatter.error(
+            message=f"Invalid --limit {limit}. Must be between 1 and {MAX_JOB_LIMIT}.",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    validate_branch_requires_project(formatter, branch, project)
+    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+
+    # Resolve job IDs
+    resolved_ids: list[str]
+    filter_context: dict[str, object | None] | None = None
+    if job_id:
+        resolved_ids = list(job_id)
+    else:
+        # "any" means: list without status filter, then keep only killable states client-side
+        list_status = None if status == "any" else status
+        try:
+            matched = service.resolve_job_ids_by_filter(
+                alias=project,
+                status=list_status,
+                component_id=component_id,
+                config_id=config_id,
+                branch_id=effective_branch,
+                limit=limit,
+            )
+            if status == "any":
+                matched = service.filter_killable(matched)
+        except ConfigError as exc:
+            formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+            raise typer.Exit(code=5) from None
+        except KeboolaApiError as exc:
+            formatter.error(
+                message=exc.message,
+                error_code=exc.error_code,
+                project=project,
+                retryable=exc.retryable,
+            )
+            raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+        resolved_ids = [str(j.get("id")) for j in matched if j.get("id")]
+        filter_context = {
+            "status": status,
+            "component_id": component_id,
+            "config_id": config_id,
+            "branch_id": effective_branch,
+            "matched_count": len(resolved_ids),
+        }
+
+    if not resolved_ids:
+        empty_result = {
+            "killed": [],
+            "already_finished": [],
+            "not_found": [],
+            "failed": [],
+            "dry_run": dry_run,
+            "project_alias": project,
+            "filter": filter_context,
+        }
+        if formatter.json_mode:
+            formatter.output(empty_result)
+        else:
+            formatter.console.print("[bold blue]No jobs matched.[/bold blue]")
+        return
+
+    # Dry-run: report without killing
+    if dry_run:
+        try:
+            result = service.terminate_jobs(
+                alias=project,
+                job_ids=resolved_ids,
+                dry_run=True,
+            )
+        except ConfigError as exc:
+            formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+            raise typer.Exit(code=5) from None
+
+        if filter_context is not None:
+            result["filter"] = filter_context
+        if formatter.json_mode:
+            formatter.output(result)
+        else:
+            formatter.console.print(
+                f"[bold blue]Would terminate {len(resolved_ids)} job(s):[/bold blue]"
+            )
+            for jid in resolved_ids:
+                formatter.console.print(f"  - {jid}")
+        return
+
+    # Confirmation prompt (interactive only)
+    confirm_msg = f"Terminate {len(resolved_ids)} job(s) in project '{project}'?"
+    if not yes and not formatter.json_mode and not typer.confirm(confirm_msg):
+        formatter.console.print("Aborted.")
+        raise typer.Exit(code=0)
+
+    try:
+        result = service.terminate_jobs(
+            alias=project,
+            job_ids=resolved_ids,
+        )
+    except ConfigError as exc:
+        formatter.error(message=exc.message, error_code="CONFIG_ERROR")
+        raise typer.Exit(code=5) from None
+    except KeboolaApiError as exc:
+        formatter.error(
+            message=exc.message,
+            error_code=exc.error_code,
+            project=project,
+            retryable=exc.retryable,
+        )
+        raise typer.Exit(code=map_error_to_exit_code(exc)) from None
+
+    if filter_context is not None:
+        result["filter"] = filter_context
+
+    if formatter.json_mode:
+        formatter.output(result)
+    else:
+        for entry in result["killed"]:
+            formatter.console.print(
+                f"[bold green]Killed:[/bold green] {entry['id']} "
+                f"(status={entry.get('status')}, desiredStatus={entry.get('desiredStatus')})"
+            )
+        for entry in result["already_finished"]:
+            formatter.console.print(
+                f"[yellow]Already finished:[/yellow] {entry['id']} ({entry.get('reason')})"
+            )
+        for jid in result["not_found"]:
+            formatter.console.print(f"[bold red]Not found:[/bold red] {jid}")
+        for f_item in result["failed"]:
+            formatter.console.print(
+                f"[bold red]Failed:[/bold red] {f_item['id']}: {f_item['error']}"
+            )
+
+    if result["failed"]:
+        raise typer.Exit(code=1)

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -120,6 +120,10 @@ SECRET_PLACEHOLDER: str = "<YOUR_SECRET>"
 # --- Job Run ---
 DEFAULT_JOB_RUN_TIMEOUT: float = 300.0  # 5 min default for --wait polling
 
+# --- Job Terminate ---
+# States where POST /jobs/{id}/kill returns HTTP 200; any other state yields 400.
+KILLABLE_JOB_STATUSES: frozenset[str] = frozenset({"created", "waiting", "processing"})
+
 # --- Permission Exit Code ---
 EXIT_PERMISSION_DENIED: int = 6
 

--- a/src/keboola_agent_cli/hints/definitions/job.py
+++ b/src/keboola_agent_cli/hints/definitions/job.py
@@ -120,3 +120,40 @@ HintRegistry.register(
         ],
     )
 )
+
+# ── job terminate ──────────────────────────────────────────────────
+
+HintRegistry.register(
+    CommandHint(
+        cli_command="job.terminate",
+        description="Request termination of one or more Queue API jobs",
+        steps=[
+            HintStep(
+                comment="Kill a single job (async: sets desiredStatus=terminating)",
+                client=ClientCall(
+                    method="kill_job",
+                    args={"job_id": "{job_id}"},
+                    result_var="job",
+                    result_hint="dict",
+                ),
+                service=ServiceCall(
+                    service_class="JobService",
+                    service_module="job_service",
+                    method="terminate_jobs",
+                    args={
+                        "alias": "{project}",
+                        "job_ids": "{job_id}",
+                        "dry_run": "{dry_run}",
+                    },
+                ),
+            ),
+        ],
+        notes=[
+            "Uses the Queue API (queue.keboola.com) - POST /jobs/{id}/kill.",
+            "Killable states: created, waiting, processing. Others return HTTP 400.",
+            "Transition is async - poll get_job_detail for isFinished=True.",
+            "Service partitions results into killed / already_finished / not_found / failed.",
+            "For bulk mode, resolve job IDs first via list_jobs, then call terminate_jobs.",
+        ],
+    )
+)

--- a/src/keboola_agent_cli/permissions.py
+++ b/src/keboola_agent_cli/permissions.py
@@ -34,6 +34,7 @@ OPERATION_REGISTRY: dict[str, str] = {
     "job.list": "read",
     "job.detail": "read",
     "job.run": "write",
+    "job.terminate": "destructive",
     # Lineage
     "lineage.build": "read",
     "lineage.info": "read",

--- a/src/keboola_agent_cli/services/job_service.py
+++ b/src/keboola_agent_cli/services/job_service.py
@@ -6,7 +6,7 @@ and aggregation without knowing about CLI or HTTP details.
 
 from typing import Any
 
-from ..constants import DEFAULT_JOB_LIMIT
+from ..constants import DEFAULT_JOB_LIMIT, KILLABLE_JOB_STATUSES
 from ..errors import KeboolaApiError
 from ..models import ProjectConfig
 from .base import BaseService
@@ -194,3 +194,147 @@ class JobService(BaseService):
 
         job["project_alias"] = alias
         return job
+
+    def resolve_job_ids_by_filter(
+        self,
+        alias: str,
+        status: str | None = None,
+        component_id: str | None = None,
+        config_id: str | None = None,
+        branch_id: int | None = None,
+        limit: int = DEFAULT_JOB_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """Resolve a set of jobs via filters for bulk operations (e.g. terminate).
+
+        Returns the full job dicts (not just IDs) so callers can display context
+        in dry-run output. branch_id is applied client-side because the Queue
+        API /search/jobs endpoint does not accept a branch filter.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            jobs = client.list_jobs(
+                component_id=component_id,
+                config_id=config_id,
+                status=status,
+                limit=limit,
+            )
+        finally:
+            client.close()
+
+        if branch_id is not None:
+            jobs = [j for j in jobs if str(j.get("branchId")) == str(branch_id)]
+
+        return jobs
+
+    def terminate_jobs(
+        self,
+        alias: str,
+        job_ids: list[str],
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Terminate one or more Queue API jobs.
+
+        Partitions results into four buckets based on Queue API behavior:
+        - killed: HTTP 200 from POST /jobs/{id}/kill (transition to terminating)
+        - already_finished: HTTP 400 "not in one of killable states" (race condition
+          between list and kill) OR HTTP 500 with body code=404 + GET confirms
+          isFinished=True (Queue API inconsistency for terminal jobs)
+        - not_found: HTTP 500 + body code=404 + GET returns 404
+        - failed: anything else (auth, network, genuine server errors)
+
+        Batch-tolerant: accumulates errors per job, one failure does not stop
+        other kills.
+
+        Args:
+            alias: Project alias.
+            job_ids: List of job IDs to terminate.
+            dry_run: If True, only report what would be terminated.
+
+        Returns:
+            Dict with 'killed', 'already_finished', 'not_found', 'failed',
+            'dry_run', 'project_alias', and optionally 'would_terminate'.
+        """
+        projects = self.resolve_projects([alias])
+        project = projects[alias]
+
+        if dry_run:
+            return {
+                "killed": [],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [],
+                "would_terminate": list(job_ids),
+                "dry_run": True,
+                "project_alias": alias,
+            }
+
+        killed: list[dict[str, Any]] = []
+        already_finished: list[dict[str, Any]] = []
+        not_found: list[str] = []
+        failed: list[dict[str, str]] = []
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            for jid in job_ids:
+                try:
+                    result = client.kill_job(jid)
+                    killed.append(
+                        {
+                            "id": jid,
+                            "status": result.get("status"),
+                            "desiredStatus": result.get("desiredStatus"),
+                        }
+                    )
+                except KeboolaApiError as exc:
+                    disposition = self._classify_kill_error(client, jid, exc)
+                    if disposition["bucket"] == "already_finished":
+                        already_finished.append({"id": jid, "reason": disposition["reason"]})
+                    elif disposition["bucket"] == "not_found":
+                        not_found.append(jid)
+                    else:
+                        failed.append({"id": jid, "error": exc.message})
+        finally:
+            client.close()
+
+        return {
+            "killed": killed,
+            "already_finished": already_finished,
+            "not_found": not_found,
+            "failed": failed,
+            "dry_run": False,
+            "project_alias": alias,
+        }
+
+    def _classify_kill_error(
+        self, client: Any, job_id: str, exc: KeboolaApiError
+    ) -> dict[str, str]:
+        """Map a kill_job error into one of {already_finished, not_found, failed}.
+
+        Queue API returns HTTP 400 with "not in one of killable states" when the
+        job is already terminal; for success/error/bogus IDs it returns HTTP 500
+        with body code=404 (inconsistent), so we fall back to GET /jobs/{id} to
+        distinguish "already done" from "really missing".
+        """
+        # Killable-state race: job transitioned to terminal between list and kill
+        if exc.status_code == 400 and "killable states" in exc.message.lower():
+            return {"bucket": "already_finished", "reason": "not_killable"}
+
+        # 500/404 inconsistency: verify via GET
+        if exc.status_code == 500 or exc.status_code == 404:
+            try:
+                job = client.get_job_detail(job_id)
+                if job.get("isFinished"):
+                    return {"bucket": "already_finished", "reason": "terminal_state"}
+            except KeboolaApiError as get_exc:
+                if get_exc.status_code == 404:
+                    return {"bucket": "not_found", "reason": "missing"}
+
+        return {"bucket": "failed", "reason": "error"}
+
+    @staticmethod
+    def filter_killable(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Keep only jobs whose current status is killable per Queue API contract."""
+        return [j for j in jobs if j.get("status") in KILLABLE_JOB_STATUSES]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2246,6 +2246,385 @@ class TestJobRun:
         assert result.exit_code == 2
 
 
+class TestJobTerminate:
+    """Tests for `kbagent job terminate` command."""
+
+    def _setup(self, tmp_path: Path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = _setup_config_test(
+            config_dir,
+            {
+                "prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"},
+            },
+        )
+        return store
+
+    def test_terminate_single_job_by_id(self, tmp_path: Path) -> None:
+        """--job-id variant calls service.terminate_jobs with the exact list."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.terminate_jobs.return_value = {
+                "killed": [{"id": "111", "status": "processing", "desiredStatus": "terminating"}],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "prod",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--job-id",
+                    "111",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        job_service.terminate_jobs.assert_called_once()
+        call_kwargs = job_service.terminate_jobs.call_args.kwargs
+        assert call_kwargs["alias"] == "prod"
+        assert call_kwargs["job_ids"] == ["111"]
+
+    def test_terminate_multiple_job_ids(self, tmp_path: Path) -> None:
+        """--job-id repeated flags accumulate into a single batch call."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.terminate_jobs.return_value = {
+                "killed": [],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "prod",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--job-id",
+                    "a",
+                    "--job-id",
+                    "b",
+                    "--job-id",
+                    "c",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert job_service.terminate_jobs.call_args.kwargs["job_ids"] == ["a", "b", "c"]
+
+    def test_terminate_requires_job_id_or_status(self, tmp_path: Path) -> None:
+        """Providing neither --job-id nor --status is a usage error."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+            MockJobService.return_value = JobService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                ["--json", "job", "terminate", "--project", "prod", "--yes"],
+            )
+
+        assert result.exit_code == 2
+
+    def test_terminate_rejects_both_job_id_and_status(self, tmp_path: Path) -> None:
+        """--job-id and --status are mutually exclusive."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+            MockJobService.return_value = JobService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--job-id",
+                    "1",
+                    "--status",
+                    "processing",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 2
+
+    def test_terminate_rejects_invalid_status(self, tmp_path: Path) -> None:
+        """--status success (terminal) is rejected as not killable."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+            MockJobService.return_value = JobService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--status",
+                    "success",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 2
+
+    def test_terminate_bulk_by_status(self, tmp_path: Path) -> None:
+        """--status triggers resolve_job_ids_by_filter + terminate_jobs with resolved IDs."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.resolve_job_ids_by_filter.return_value = [
+                {"id": "1", "status": "processing"},
+                {"id": "2", "status": "processing"},
+            ]
+            job_service.terminate_jobs.return_value = {
+                "killed": [
+                    {"id": "1", "status": "processing", "desiredStatus": "terminating"},
+                    {"id": "2", "status": "processing", "desiredStatus": "terminating"},
+                ],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "prod",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--status",
+                    "processing",
+                    "--component-id",
+                    "keboola.python-transformation-v2",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        job_service.resolve_job_ids_by_filter.assert_called_once()
+        job_service.terminate_jobs.assert_called_once_with(alias="prod", job_ids=["1", "2"])
+
+    def test_terminate_status_any_fetches_all_and_filters_client_side(self, tmp_path: Path) -> None:
+        """--status any passes status=None to list_jobs and applies filter_killable()."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.resolve_job_ids_by_filter.return_value = [
+                {"id": "1", "status": "processing"},
+                {"id": "2", "status": "success"},  # should be filtered out
+                {"id": "3", "status": "waiting"},
+            ]
+            job_service.filter_killable.return_value = [
+                {"id": "1", "status": "processing"},
+                {"id": "3", "status": "waiting"},
+            ]
+            job_service.terminate_jobs.return_value = {
+                "killed": [],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "prod",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--status",
+                    "any",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # list call should pass status=None (not "any")
+        assert job_service.resolve_job_ids_by_filter.call_args.kwargs["status"] is None
+        job_service.filter_killable.assert_called_once()
+        # terminate_jobs receives only the two killable IDs
+        assert job_service.terminate_jobs.call_args.kwargs["job_ids"] == ["1", "3"]
+
+    def test_terminate_dry_run_reports_without_kill(self, tmp_path: Path) -> None:
+        """--dry-run short-circuits and forwards dry_run=True to service."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.terminate_jobs.return_value = {
+                "killed": [],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [],
+                "would_terminate": ["1", "2"],
+                "dry_run": True,
+                "project_alias": "prod",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--job-id",
+                    "1",
+                    "--job-id",
+                    "2",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert job_service.terminate_jobs.call_args.kwargs["dry_run"] is True
+
+    def test_terminate_exit_code_1_on_failures(self, tmp_path: Path) -> None:
+        """Non-empty failed bucket yields exit code 1."""
+        store = self._setup(tmp_path)
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.terminate_jobs.return_value = {
+                "killed": [],
+                "already_finished": [],
+                "not_found": [],
+                "failed": [{"id": "1", "error": "timeout"}],
+                "dry_run": False,
+                "project_alias": "prod",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "terminate",
+                    "--project",
+                    "prod",
+                    "--job-id",
+                    "1",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 1
+
+
 # ---------------------------------------------------------------------------
 # Context command tests
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2209,6 +2209,88 @@ class TestCreateJob:
         assert body["configRowIds"] == ["row1", "row2"]
 
 
+class TestKillJob:
+    """Tests for kill_job() - Queue API POST /jobs/{id}/kill."""
+
+    def test_kill_job_success(self, httpx_mock) -> None:
+        """kill_job() returns full job dict with desiredStatus=terminating on 200."""
+        job_response = {
+            "id": "1234",
+            "status": "processing",
+            "desiredStatus": "terminating",
+            "isFinished": False,
+        }
+        httpx_mock.add_response(
+            url="https://queue.keboola.com/jobs/1234/kill",
+            method="POST",
+            json=job_response,
+            status_code=200,
+        )
+
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            result = client.kill_job("1234")
+
+        assert result["id"] == "1234"
+        assert result["desiredStatus"] == "terminating"
+
+    def test_kill_job_400_not_killable(self, httpx_mock) -> None:
+        """kill_job() raises KeboolaApiError(400) on terminal-state jobs."""
+        httpx_mock.add_response(
+            url="https://queue.keboola.com/jobs/9999/kill",
+            method="POST",
+            json={
+                "error": 'Job id "9999" is not in one of killable states (created,waiting,processing).',
+                "code": 400,
+            },
+            status_code=400,
+        )
+
+        with (
+            KeboolaClient(stack_url=_BASE, token=_TOKEN) as client,
+            pytest.raises(KeboolaApiError) as exc_info,
+        ):
+            client.kill_job("9999")
+
+        assert exc_info.value.status_code == 400
+        assert "killable states" in exc_info.value.message.lower()
+
+    def test_kill_job_500_404_mismatch(self, httpx_mock) -> None:
+        """kill_job() surfaces Queue API's 500/404 inconsistency for bogus/success jobs.
+
+        Queue API returns HTTP 500 with body code=404 for already-finished or
+        missing jobs. Client passes the error through; service layer distinguishes
+        the two cases via a follow-up GET.
+        """
+        # HTTP 500 triggers retry path (MAX_RETRIES total attempts); stub each.
+        for _ in range(MAX_RETRIES):
+            httpx_mock.add_response(
+                url="https://queue.keboola.com/jobs/1/kill",
+                method="POST",
+                json={"error": "Internal Server Error occurred.", "code": 404},
+                status_code=500,
+            )
+
+        with (
+            KeboolaClient(stack_url=_BASE, token=_TOKEN) as client,
+            pytest.raises(KeboolaApiError) as exc_info,
+        ):
+            client.kill_job("1")
+
+        assert exc_info.value.status_code == 500
+
+    def test_kill_job_url_encodes_job_id(self, httpx_mock) -> None:
+        """kill_job() URL-encodes the job ID to prevent path injection."""
+        httpx_mock.add_response(
+            url="https://queue.keboola.com/jobs/ab%2Fcd/kill",
+            method="POST",
+            json={"id": "ab/cd", "status": "processing", "desiredStatus": "terminating"},
+            status_code=200,
+        )
+
+        with KeboolaClient(stack_url=_BASE, token=_TOKEN) as client:
+            client.kill_job("ab/cd")
+
+
 _BRANCH_METADATA_SAMPLE = [
     {
         "id": 1001,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -472,6 +472,17 @@ class TestFullE2E:
         self._test_transformation_cleanup(out_bucket_id, transform_config_id)
 
         # ==============================================================
+        # PHASE 7.5: Job terminate (kill long-running / runaway jobs)
+        # ==============================================================
+
+        _step(
+            32.5,
+            "job terminate",
+            "spawn sleep job, kill it, verify idempotency",
+        )
+        self._test_job_terminate()
+
+        # ==============================================================
         # PHASE 8: File operations
         # ==============================================================
 
@@ -1530,6 +1541,132 @@ class TestFullE2E:
                 f"Row id={row['id']}: value={value}, "
                 f"expected doubled_value={value * 2}, got {doubled}"
             )
+
+    def _test_job_terminate(self) -> None:
+        """End-to-end coverage for `kbagent job terminate`.
+
+        Spawns a python-transformation-v2 job that would sleep for 10 minutes,
+        terminates it via CLI, confirms the buckets behave as documented:
+          - killed (200)
+          - already_finished on re-terminate (400 "not in killable states")
+          - not_found on a bogus ID (500/body-404 disambiguated via GET)
+
+        Any leftover config is cleaned up at the end.
+        """
+        # Sleep transformation - long enough that we always catch it in a killable state
+        kill_config_body = self.api.create_config(
+            component_id="keboola.python-transformation-v2",
+            name=f"{RUN_ID} kill-test",
+            configuration={
+                "parameters": {
+                    "blocks": [
+                        {
+                            "name": "Block 1",
+                            "codes": [
+                                {
+                                    "name": "sleep",
+                                    "script": ["import time", "time.sleep(600)"],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            },
+            description="E2E: spawned only to be terminated",
+        )
+        kill_config_id = str(kill_config_body["id"])
+        self._created_config_ids.append(("keboola.python-transformation-v2", kill_config_id))
+
+        # Spawn without --wait (we want it still alive to kill)
+        data = self._run_ok(
+            "job",
+            "run",
+            "--project",
+            self.alias,
+            "--component-id",
+            "keboola.python-transformation-v2",
+            "--config-id",
+            kill_config_id,
+        )
+        job_id = str(data["data"]["id"])
+        assert job_id
+
+        # Dry-run first: should not touch the job
+        dry = self._run_ok(
+            "job",
+            "terminate",
+            "--project",
+            self.alias,
+            "--job-id",
+            job_id,
+            "--dry-run",
+        )["data"]
+        assert dry["dry_run"] is True
+        assert dry["would_terminate"] == [job_id]
+        assert dry["killed"] == []
+
+        # Real terminate
+        killed_result = self._run_ok(
+            "job",
+            "terminate",
+            "--project",
+            self.alias,
+            "--job-id",
+            job_id,
+            "--yes",
+        )["data"]
+        assert len(killed_result["killed"]) == 1
+        assert killed_result["killed"][0]["id"] == job_id
+        assert killed_result["killed"][0]["desiredStatus"] == "terminating"
+        assert killed_result["failed"] == []
+
+        # Poll until job reaches a terminal state (isFinished=True)
+        for _ in range(40):
+            detail = self._run_ok(
+                "job",
+                "detail",
+                "--project",
+                self.alias,
+                "--job-id",
+                job_id,
+            )["data"]
+            if detail["isFinished"]:
+                break
+            time.sleep(2)
+        else:
+            raise AssertionError(f"Job {job_id} did not reach terminal state within 80s")
+        assert detail["status"] in {"cancelled", "terminated"}
+
+        # Idempotency: re-terminate should hit the already_finished bucket
+        idemp = self._run_ok(
+            "job",
+            "terminate",
+            "--project",
+            self.alias,
+            "--job-id",
+            job_id,
+            "--yes",
+        )["data"]
+        assert idemp["killed"] == []
+        assert len(idemp["already_finished"]) == 1
+        assert idemp["already_finished"][0]["id"] == job_id
+
+        # Bogus ID should be classified as not_found (via GET fallback)
+        bogus = self._run_ok(
+            "job",
+            "terminate",
+            "--project",
+            self.alias,
+            "--job-id",
+            "99999999999999",
+            "--yes",
+        )["data"]
+        assert bogus["not_found"] == ["99999999999999"]
+        assert bogus["failed"] == []
+
+        # Cleanup the config now (don't leak resources even if later phases fail)
+        self.api.delete_config("keboola.python-transformation-v2", kill_config_id)
+        self._created_config_ids.remove(("keboola.python-transformation-v2", kill_config_id))
 
     def _test_transformation_cleanup(self, out_bucket_id: str, transform_config_id: str) -> None:
         """Clean up transformation resources via CLI."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1850,6 +1850,190 @@ class TestJobServiceRunJob:
         mock_client.wait_for_queue_job.assert_called_once_with("557", max_wait=60.0)
 
 
+def _make_job_store_and_project(tmp_config_dir: Path, alias: str = "prod") -> ConfigStore:
+    """Helper to register a single project so JobService.resolve_projects() works."""
+    store = ConfigStore(config_dir=tmp_config_dir)
+    store.add_project(
+        alias,
+        ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token="901-abc-defghijklmnopqrst",
+            project_name="Project",
+            project_id=1234,
+        ),
+    )
+    return store
+
+
+class TestJobServiceTerminateJobs:
+    """Tests for JobService.terminate_jobs() partition logic.
+
+    Queue API returns four distinct HTTP shapes for kill; the service has to
+    translate them into {killed, already_finished, not_found, failed}. The tests
+    exercise each branch with a mocked client so we can assert the bucket
+    assignment without hitting a live Queue.
+    """
+
+    def test_dry_run_reports_without_calling_kill(self, tmp_config_dir: Path) -> None:
+        """dry_run=True short-circuits before any HTTP call and echoes the ids back."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["1", "2"], dry_run=True)
+
+        assert result["dry_run"] is True
+        assert result["would_terminate"] == ["1", "2"]
+        assert result["killed"] == []
+        mock_client.kill_job.assert_not_called()
+
+    def test_kill_success_goes_to_killed_bucket(self, tmp_config_dir: Path) -> None:
+        """HTTP 200 response flows into 'killed' with id/status/desiredStatus summary."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.kill_job.return_value = {
+            "id": "111",
+            "status": "processing",
+            "desiredStatus": "terminating",
+            "isFinished": False,
+        }
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["111"])
+
+        assert result["killed"] == [
+            {"id": "111", "status": "processing", "desiredStatus": "terminating"}
+        ]
+        assert result["already_finished"] == []
+        assert result["not_found"] == []
+        assert result["failed"] == []
+
+    def test_400_not_killable_goes_to_already_finished(self, tmp_config_dir: Path) -> None:
+        """Job already in terminal state returns HTTP 400 -> already_finished (race-safe)."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.kill_job.side_effect = KeboolaApiError(
+            message='Job id "1" is not in one of killable states (created,waiting,processing).',
+            status_code=400,
+            error_code="API_ERROR",
+        )
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["1"])
+
+        assert result["already_finished"] == [{"id": "1", "reason": "not_killable"}]
+        assert result["killed"] == []
+        assert result["failed"] == []
+
+    def test_500_with_finished_job_goes_to_already_finished(self, tmp_config_dir: Path) -> None:
+        """Queue API's 500/404 mismatch: GET confirms isFinished=True -> already_finished."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.kill_job.side_effect = KeboolaApiError(
+            message="Internal Server Error occurred.",
+            status_code=500,
+            error_code="API_ERROR",
+        )
+        mock_client.get_job_detail.return_value = {
+            "id": "2",
+            "status": "success",
+            "isFinished": True,
+        }
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["2"])
+
+        assert result["already_finished"] == [{"id": "2", "reason": "terminal_state"}]
+        assert result["failed"] == []
+        mock_client.get_job_detail.assert_called_once_with("2")
+
+    def test_500_with_missing_job_goes_to_not_found(self, tmp_config_dir: Path) -> None:
+        """Queue API's 500/404 mismatch: GET returns 404 -> not_found bucket."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.kill_job.side_effect = KeboolaApiError(
+            message="Internal Server Error occurred.",
+            status_code=500,
+            error_code="API_ERROR",
+        )
+        mock_client.get_job_detail.side_effect = KeboolaApiError(
+            message="Not found",
+            status_code=404,
+            error_code="NOT_FOUND",
+        )
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["99"])
+
+        assert result["not_found"] == ["99"]
+        assert result["failed"] == []
+
+    def test_other_errors_go_to_failed(self, tmp_config_dir: Path) -> None:
+        """Auth/network/unknown errors land in 'failed' with the API message attached."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.kill_job.side_effect = KeboolaApiError(
+            message="Token expired",
+            status_code=401,
+            error_code="INVALID_TOKEN",
+        )
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["1"])
+
+        assert result["failed"] == [{"id": "1", "error": "Token expired"}]
+        assert result["killed"] == []
+
+    def test_batch_tolerates_partial_failures(self, tmp_config_dir: Path) -> None:
+        """One failure in a batch does not prevent other jobs from being killed."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+
+        def kill_side_effect(jid: str) -> dict:
+            if jid == "bad":
+                raise KeboolaApiError("Boom", status_code=502, error_code="API_ERROR")
+            return {"id": jid, "status": "processing", "desiredStatus": "terminating"}
+
+        mock_client.kill_job.side_effect = kill_side_effect
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        result = service.terminate_jobs(alias="prod", job_ids=["ok1", "bad", "ok2"])
+
+        assert {entry["id"] for entry in result["killed"]} == {"ok1", "ok2"}
+        assert result["failed"] == [{"id": "bad", "error": "Boom"}]
+
+    def test_resolve_job_ids_filters_by_branch_client_side(self, tmp_config_dir: Path) -> None:
+        """resolve_job_ids_by_filter applies branch_id filter client-side (Queue API doesn't)."""
+        store = _make_job_store_and_project(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.list_jobs.return_value = [
+            {"id": "1", "branchId": "100", "status": "processing"},
+            {"id": "2", "branchId": "200", "status": "processing"},
+            {"id": "3", "branchId": 100, "status": "waiting"},  # numeric variant
+        ]
+
+        service = JobService(store, client_factory=lambda url, token: mock_client)
+        jobs = service.resolve_job_ids_by_filter(
+            alias="prod",
+            status="processing",
+            branch_id=100,
+        )
+
+        assert {j["id"] for j in jobs} == {"1", "3"}
+
+    def test_filter_killable_drops_terminal_jobs(self) -> None:
+        """filter_killable() keeps only created/waiting/processing states."""
+        jobs = [
+            {"id": "1", "status": "processing"},
+            {"id": "2", "status": "terminated"},
+            {"id": "3", "status": "waiting"},
+            {"id": "4", "status": "success"},
+            {"id": "5", "status": "created"},
+        ]
+        kept = JobService.filter_killable(jobs)
+        assert {j["id"] for j in kept} == {"1", "3", "5"}
+
+
 # ---------------------------------------------------------------------------
 # Parallel-specific tests: deterministic ordering, unexpected exceptions
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.21.0"
+version = "0.20.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds `kbagent job terminate` — ability to stop runaway or stuck Queue API jobs from the CLI. Closes #181.

**Two modes:**

```bash
# Single / batch by ID
kbagent job terminate --project P --job-id ID [--job-id ID ...] [--dry-run] [--yes]

# Bulk by filter (typical runaway cleanup)
kbagent job terminate --project P --status any \
  [--component-id ID] [--config-id ID] [--branch ID] [--limit N] [--dry-run] [--yes]
```

**Response shape** — partitioned so bulk runs never false-fail on race conditions:

```json
{
  "killed":           [...],  // HTTP 200
  "already_finished": [...],  // 400 "not in killable states" OR 500/404 + GET shows isFinished=true
  "not_found":        [...],  // 500/404 + GET returns 404
  "failed":           [...]   // genuine errors (auth, network, 5xx)
}
```

Re-running on terminal jobs is an idempotent no-op.

## API contract verification

Endpoint `POST /jobs/{jobId}/kill` on Queue API, identical behavior across:
- **US AWS** (padak-2-0)
- **GCP europe-west3** (padak-gcp)
- **Azure north-europe** (padak-azure)

Verified state transitions, two terminal states (`waiting→cancelled`, `processing→terminated`), HTTP 400 on re-kill, HTTP 500/body-code-404 inconsistency for bogus/terminal IDs.

## What's in v1 (per agreement with @frantisekrehor)

- [x] CLI `job terminate` with `--job-id` / `--status` / `--component-id` / `--config-id` / `--branch` / `--dry-run` / `--yes`
- [x] `--status any` to catch all killable states at once (typical runaway cleanup)
- [x] `client.kill_job()` HTTP wrapper
- [x] `service.terminate_jobs()` with four-bucket partition + 500/404 disambiguation via GET fallback
- [x] Permission `job.terminate` (`destructive` class)
- [x] `--hint client` / `--hint service` code generation
- [x] Full test coverage: 4 client tests + 9 service tests + 9 CLI tests + 1 E2E phase
- [x] Docs: `kbagent context`, CLAUDE.md, commands-reference.md, gotchas.md, SKILL.md

## Deferred to follow-up issues

- `--conversation-id` filter — verified Queue API does not persist `X-Conversation-ID` on the job object nor accept it as a search filter; needs a platform-side request first
- Pre-run dedup guardrail (prevent pile-up at source instead of cleaning up) — orthogonal feature
- `--older-than` / `--queued-only` filters

## Test plan

- [x] `make check` passes locally (1754 tests, 4 skipped for missing credentials)
- [x] Manual smoke test on US / GCP / Azure via `kbagent` CLI in `/tmp/apify`: single kill, batch, bulk by `--status any --config-id`, idempotent re-kill, bogus ID
- [ ] CI green
- [ ] E2E test passes against real project (`make test-e2e`)