### PR TITLE
chore: bump version to 0.20.4

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.20.3"
+version = "0.20.4"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.20.4": [
+        "Docs: 'kbagent context' now includes a worked Parquet export example for AI agents",
+    ],
     "0.20.3": [
         "New: storage unload-table --file-type parquet -- export tables as Parquet (sliced)",
         "New: --download with parquet saves each slice as its own file + _manifest.json into a directory",

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.20.3"
+version = "0.20.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Patch release so users on 0.20.3 with auto-update enabled pick up the 'kbagent context' Parquet example added in #184. Docs-only diff beyond the version bump.