### PR TITLE
chore(docs+test): Parquet export -- CONTRIBUTING.md compliance + E2E (0.20.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ kbagent storage file-detail --project NAME --file-id ID
 kbagent storage file-delete --project NAME --file-id ID [--file-id ...] [--dry-run] [--yes]
 kbagent storage file-tag --project NAME --file-id ID [--add TAG ...] [--remove TAG ...]
 kbagent storage load-file --project NAME --file-id ID --table-id ID [--incremental] [--delimiter D] [--enclosure E] [--branch ID]
-kbagent storage unload-table --project NAME --table-id ID [--columns COL ...] [--limit N] [--tag TAG ...] [--download] [--output FILE] [--branch ID]
+kbagent storage unload-table --project NAME --table-id ID [--columns COL ...] [--limit N] [--tag TAG ...] [--download] [--output FILE|DIR] [--file-type csv|parquet] [--branch ID]
 
 kbagent lineage build --directory PATH --output PATH [--ai] [--refresh]
 kbagent lineage show --load PATH [--upstream NODE] [--downstream NODE] [--column COL] [--columns] [--project ALIAS] [--depth N] [--format text|mermaid|html|er]

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -55,6 +55,16 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 - `storage delete-column --project NAME --table-id ID --column COL [--column ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete columns from a table (branch-aware)
 - `storage delete-bucket --project NAME --bucket-id ID [--bucket-id ...] [--force] [--dry-run] [--yes] [--branch ID]` -- delete buckets (branch-aware)
 
+## Storage Files
+- `storage files --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]` -- list Storage Files, optionally filtered by tag/query
+- `storage file-detail --project NAME --file-id ID` -- file metadata (size, tags, sliced, provider)
+- `storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]` -- upload a file to Storage
+- `storage file-download --project NAME [--file-id ID | --tag TAG ...] [--output FILE|DIR]` -- download a Storage File. Auto-detects sliced `.parquet` files and writes per-slice into a directory (never concatenates -- parquet slices have their own footers)
+- `storage file-tag --project NAME --file-id ID [--add TAG ...] [--remove TAG ...]` -- add/remove tags on a file
+- `storage file-delete --project NAME --file-id ID [--file-id ...] [--dry-run] [--yes]` -- delete Storage Files
+- `storage load-file --project NAME --file-id ID --table-id ID [--incremental] [--delimiter D] [--enclosure E] [--branch ID]` -- import a Storage File into a table (CSV)
+- `storage unload-table --project NAME --table-id ID [--columns COL ...] [--limit N] [--tag TAG ...] [--download] [--output FILE|DIR] [--file-type csv|parquet] [--branch ID]` -- export a table to a Storage File. `--file-type parquet` produces sliced Parquet; `--download` saves each slice as its own file under `./{project}/{table_id}.parquet/` (default) together with `_manifest.json`
+
 ## Data Lineage
 - `lineage build -d DIR -o FILE [--refresh] [--ai]` -- build column-level lineage graph from sync'd data
 - `lineage show -l FILE --downstream "project:table" [--columns] [-c COL] [--format text|mermaid|html|er]` -- query downstream dependencies from cache

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -404,3 +404,28 @@ CLI hides via its four-bucket response, but they matter when interpreting result
   client-side. Picking a single status misses the other killable states -- e.g.
   a runaway loop often piles up `waiting` jobs while you're typing
   `--status processing`.
+
+## Parquet export: slices, not a single file
+
+- `storage unload-table --file-type parquet` always produces a **sliced** output.
+  With `--download`, the result is a **directory** (`./{project}/{table_id}.parquet/`),
+  never a single `.parquet` file. If your code expects a single file, adapt it to
+  read the directory as a Parquet dataset:
+  ```python
+  import pyarrow.parquet as pq
+  t = pq.read_table("./ALIAS/in.c-bucket.table.parquet/")
+  ```
+- **Never concatenate Parquet slices.** Each slice is a self-contained Parquet
+  file with its own footer. Binary concatenation (how CSV slices are merged)
+  would produce an invalid file. For the same reason, `storage file-download`
+  auto-detects sliced `.parquet` files and routes them to the per-slice
+  downloader -- there is no flag to force single-file mode.
+- The manifest sidecar is written as `_manifest.json` (**with a leading
+  underscore**). This is intentional: Hive/Spark/pyarrow parquet readers skip
+  files starting with `_` or `.` when scanning a directory as a dataset, so the
+  manifest is preserved for traceability without breaking direct reads. Same
+  convention as `_SUCCESS`, `_metadata`, `_common_metadata` in Hadoop.
+- The default path `./{project_alias}/{table_id}.parquet/` mirrors Keboola
+  addressing. When exporting multiple tables, each ends up in a predictable
+  subdirectory and there is no risk of name collisions. Override with
+  `--output DIR` if you need a custom location.

--- a/plugins/kbagent/skills/kbagent/references/storage-files-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/storage-files-workflow.md
@@ -119,7 +119,52 @@ kbagent --json storage unload-table \
 | File stays in Keboola | No (download only) | Yes (file persists) |
 | Can tag the output | No | Yes (`--tag`) |
 | Can download locally | Always | Optional (`--download`) |
+| Parquet export | No (CSV only) | Yes (`--file-type parquet`) |
 | Use case | Quick local export | Share data between components, snapshots |
+
+### Parquet export
+
+`unload-table --file-type parquet` produces a sliced Apache Parquet file in Storage Files.
+This avoids the CSV round-trip for analytics data, preserves Keboola's typed backend
+output, and is directly consumable by pyarrow, Spark, DuckDB and other Parquet readers.
+
+```bash
+# Export as Parquet (stays in Keboola)
+kbagent --json storage unload-table \
+  --project ALIAS \
+  --table-id in.c-data.users \
+  --file-type parquet --tag daily-snapshot
+
+# Export + download -- creates a directory (default layout mirrors Keboola addressing)
+kbagent storage unload-table \
+  --project ALIAS \
+  --table-id in.c-data.users \
+  --file-type parquet --download
+# -> ./ALIAS/in.c-data.users.parquet/
+#      ├── <slice>.parquet       (one or more)
+#      └── _manifest.json         (leading underscore -> skipped by parquet readers)
+```
+
+Read the dataset back in one line:
+
+```python
+import pyarrow.parquet as pq
+t = pq.read_table("./ALIAS/in.c-data.users.parquet/")
+```
+
+**Downloading an existing Parquet Storage File** -- `storage file-download` auto-detects
+sliced `.parquet` files and routes them to the per-slice downloader, so you cannot
+accidentally corrupt the output by asking for a single-file save:
+
+```bash
+kbagent storage file-download --project ALIAS --file-id 123 --output ./dir/
+# dir/ contains <slice>.parquet files + _manifest.json (same layout as unload-table --download)
+```
+
+**Constraints:**
+- Parquet output is **always sliced** -- `--download` produces a directory, never a single file
+- CSV concat logic is never used for parquet -- each slice is a self-contained file with its own footer
+- Default download path: `./{project_alias}/{table_id}.parquet/` -- override with `--output`
 
 ## Typical workflows
 
@@ -165,6 +210,6 @@ kbagent --json storage load-file \
 - Tag filtering uses **AND logic** -- all specified tags must match
 - `file-download --tag` downloads the **most recent** matching file
 - `load-file` skips the upload step -- the file is already in cloud storage
-- `unload-table` creates a **sliced file** for large tables (handled transparently on download)
+- `unload-table` creates a **sliced file** for large tables and always for Parquet (handled transparently on download; CSV slices are concatenated, Parquet slices are preserved as separate files)
 - All file commands support `--branch` for dev branch operations
 - Works across all cloud backends (AWS, GCP, Azure) transparently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.20.4"
+version = "0.20.5"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.20.5": [
+        "Docs: Parquet export covered in CLAUDE.md, skill commands-reference, storage-files-workflow, and gotchas (CONTRIBUTING.md compliance follow-up to 0.20.3)",
+        "Test: new E2E case for 'unload-table --file-type parquet' (slice layout + _manifest.json + PAR1 magic bytes)",
+    ],
     "0.20.4": [
         "Docs: 'kbagent context' now includes a worked Parquet export example for AI agents",
     ],

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -397,6 +397,9 @@ class TestFullE2E:
         _step(14, "storage unload-table", "export to file storage")
         self._test_unload_table(table_id)
 
+        _step(14.1, "storage unload-table --file-type parquet", "Parquet export + sliced download")
+        self._test_unload_table_parquet(table_id)
+
         _step(15, "storage load-file", "upload CSV as file then load into table")
         self._test_load_file(table_id)
 
@@ -865,6 +868,54 @@ class TestFullE2E:
         assert result_data["table_id"] == table_id
         assert result_data["file_id"] > 0
         assert unload_path.exists()
+
+    def _test_unload_table_parquet(self, table_id: str) -> None:
+        """Unload a table as sliced Parquet and verify the per-slice download layout.
+
+        Exercises the Storage async export with fileType=parquet and the
+        download_sliced_file_to_dir path (each slice saved as its own file,
+        _manifest.json sidecar preserved). Concatenation-based download
+        would produce an invalid parquet here -- the test fails loudly if
+        the wrong path is ever taken.
+        """
+        out_dir = self.data_dir / "parquet_out"
+        data = self._run_ok(
+            "storage",
+            "unload-table",
+            "--project",
+            self.alias,
+            "--table-id",
+            table_id,
+            "--file-type",
+            "parquet",
+            "--download",
+            "--output",
+            str(out_dir),
+        )
+        result = data["data"]
+        assert result["table_id"] == table_id
+        assert result["file_id"] > 0
+        assert result["file_type"] == "parquet"
+        assert result["is_sliced"] is True
+        assert result["downloaded"] is True
+        assert result["slice_count"] >= 1
+        assert len(result["slices"]) == result["slice_count"]
+        assert out_dir.is_dir()
+
+        manifest = out_dir / "_manifest.json"
+        assert manifest.is_file(), "parquet sidecar _manifest.json must be present"
+
+        parquet_files = list(out_dir.glob("*.parquet"))
+        assert len(parquet_files) == result["slice_count"], (
+            f"expected {result['slice_count']} parquet slices, found {len(parquet_files)}"
+        )
+        # Every slice should have the parquet magic bytes ("PAR1") at the start
+        # and end of the file -- cheap, dependency-free validity check.
+        for path in parquet_files:
+            raw = path.read_bytes()
+            assert len(raw) > 8, f"slice {path.name} is suspiciously small"
+            assert raw[:4] == b"PAR1", f"slice {path.name} is missing PAR1 header"
+            assert raw[-4:] == b"PAR1", f"slice {path.name} is missing PAR1 footer"
 
     def _test_load_file(self, table_id: str) -> None:
         """Upload a CSV as a file, then load it into a table via load-file."""

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.20.4"
+version = "0.20.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

0.20.3 shipped \`storage unload-table --file-type parquet\` but skipped several items on CONTRIBUTING.md's 'adding a new CLI command' checklist. This PR catches up without changing behavior.

- **CLAUDE.md** — \`unload-table\` signature now shows \`[--file-type csv|parquet]\` and \`[--output FILE|DIR]\`.
- **Plugin references**:
  - \`commands-reference.md\` was missing an entire \"Storage Files\" section (pre-existing gap since 0.18.4). Added with the full file-* surface, plus parquet flag and file-download auto-detect.
  - \`storage-files-workflow.md\` — new \"Parquet export\" section (layout, pyarrow read, auto-detect, constraints). Extended the unload-vs-download table with a Parquet row.
  - \`gotchas.md\` — new section documenting: parquet slices are never concatenated; \`_manifest.json\` naming is intentional (Hive/Spark/pyarrow convention); default layout mirrors Keboola addressing.
- **E2E test** — \`_test_unload_table_parquet\` in \`tests/test_e2e.py\` verifies per-slice layout, \`_manifest.json\` presence, and PAR1 magic bytes on each slice.

Live-verified against a real Keboola project in \`/tmp/apify\`:
- unload produced \`./padak/out.c-adaptive-debug.out.parquet/\` with \`_manifest.json\` + one slice
- PAR1 magic bytes on both ends, \`pyarrow.parquet.read_table\` on the directory returned 3 rows × 44 cols

SKILL.md is unchanged — \`make skill-gen\` only regenerates the decision table from command names, not options.

Version bumped to 0.20.5.

## Test plan

- [x] Full unit suite: 1762 passed, 4 skipped.
- [x] Ruff clean.
- [x] Live unload-table --file-type parquet against a real project.
- [ ] E2E via \`make test-e2e\` requires \`E2E_API_TOKEN\` + \`E2E_URL\` (deferred to CI/reviewer run).