### PR TITLE
fix(storage): stream multi-GB downloads + opt-in --keep-slices for CSV (0.20.6)

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.20.5"
+version = "0.20.6"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.20.6": [
+        "Fix: storage download-table / unload-table no longer OOM on multi-GB tables -- streamed downloads cap RAM at ~1 MiB regardless of table size (#187)",
+        "Fix: _prepend_csv_header() no longer loads the full CSV into RAM (was the second OOM source after slice download)",
+        "New: storage download-table --keep-slices -- save each slice as its own file under <output>/ (DuckDB/polars/Spark friendly), with a _columns.csv sidecar for the header",
+        "New: storage unload-table --download --keep-slices -- same option for the file-export flow (CSV only; parquet has been sliced from day one)",
+    ],
     "0.20.5": [
         "Docs: Parquet export covered in CLAUDE.md, skill commands-reference, storage-files-workflow, and gotchas (CONTRIBUTING.md compliance follow-up to 0.20.3)",
         "Test: new E2E case for 'unload-table --file-type parquet' (slice layout + _manifest.json + PAR1 magic bytes)",

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -23,6 +23,7 @@ from .constants import (
     DEFAULT_JOBS_PER_CONFIG,
     DEFAULT_TIMEOUT,
     EXPORT_JOB_MAX_WAIT,
+    FILE_DOWNLOAD_CHUNK_SIZE,
     FILE_DOWNLOAD_TIMEOUT,
     FILE_UPLOAD_TIMEOUT,
     IMPORT_JOB_MAX_WAIT,
@@ -1471,6 +1472,10 @@ class KeboolaClient(BaseHttpClient):
         Handles S3 (SigV4 auth) and GCS (bearer token) providers.
         Decompresses gzipped slices transparently.
 
+        Streams each slice chunk-by-chunk into a temp file and concatenates
+        into ``output_path``. Peak RAM is O(chunk size), not O(slice size) —
+        required for multi-GB tables on memory-constrained hosts (issue #187).
+
         The manifest `url` from file info is already a presigned URL (download
         directly). Manifest entries have cloud-native URLs (s3://, gs://) that
         need auth — we build HTTPS URLs from the s3Path/gcsPath credentials.
@@ -1483,13 +1488,47 @@ class KeboolaClient(BaseHttpClient):
         Returns:
             Number of bytes written.
         """
-        import gzip
+        import shutil
+        import tempfile
+
+        entries, base_url, downloader, _manifest_data = self._prepare_sliced_download(file_detail)
+
+        # Stream each slice into a temp file, then copy-append into output.
+        # Keeping per-slice temp files on disk (not in RAM) is the whole point.
+        total = 0
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("wb") as out_fh:
+            for entry in entries:
+                entry_url = entry.get("url", "")
+                slice_url = downloader.resolve_slice_url(base_url, entry_url, file_detail)
+                is_gz = entry_url.split("?")[0].endswith(".gz")
+                with tempfile.NamedTemporaryFile(
+                    dir=out_path.parent, prefix=".slice-", delete=True
+                ) as tmp:
+                    downloader.stream_to_file(slice_url, tmp.name, decompress_gzip=is_gz)
+                    tmp.seek(0)
+                    shutil.copyfileobj(tmp, out_fh, length=FILE_DOWNLOAD_CHUNK_SIZE)
+                    total += Path(tmp.name).stat().st_size
+
+        return total
+
+    def _prepare_sliced_download(
+        self, file_detail: dict[str, Any]
+    ) -> tuple[list[dict[str, Any]], str, "_CloudDownloader", bytes]:
+        """Fetch and parse the manifest, returning entries + download context.
+
+        The manifest is small JSON (few KB even for TB tables), so loading it
+        fully is fine. Entries are the per-slice URLs that callers iterate.
+
+        Returns a 4-tuple: (entries, base_url, downloader, raw_manifest_bytes).
+        The raw manifest is useful for callers that persist it next to slices.
+        """
         import json as json_mod
 
         provider = file_detail.get("provider", "")
         downloader = _CloudDownloader.create(file_detail)
 
-        # Step 1: Download the manifest (url is already presigned, no extra auth)
         with httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http:
             resp = http.get(file_detail["url"])
             resp.raise_for_status()
@@ -1506,26 +1545,8 @@ class KeboolaClient(BaseHttpClient):
             )
 
         logger.info("Downloading %d slices (provider=%s)", len(entries), provider)
-
-        # Step 2: Resolve the base URL from cloud path info
         base_url = downloader.resolve_base_url(file_detail)
-
-        # Step 3: Download and concatenate all slices
-        total = 0
-        with open(output_path, "wb") as fh:
-            for entry in entries:
-                entry_url = entry.get("url", "")
-                # Strip cloud prefix (s3://bucket/key/ or gs://bucket/key/)
-                # to get relative slice name, then build HTTPS URL
-                slice_url = downloader.resolve_slice_url(base_url, entry_url, file_detail)
-                raw = downloader.download_bytes(slice_url)
-                # Decompress if gzipped
-                if entry_url.split("?")[0].endswith(".gz"):
-                    raw = gzip.decompress(raw)
-                fh.write(raw)
-                total += len(raw)
-
-        return total
+        return entries, base_url, downloader, manifest_data
 
     def download_sliced_file_to_dir(
         self, file_detail: dict[str, Any], output_dir: str
@@ -1555,59 +1576,33 @@ class KeboolaClient(BaseHttpClient):
             Dict with ``output_dir``, ``slice_count``, ``total_bytes``, and
             ``slices`` (list of ``{path, size_bytes}``).
         """
-        import gzip
-        import json as json_mod
-        from pathlib import Path
-
-        provider = file_detail.get("provider", "")
-        downloader = _CloudDownloader.create(file_detail)
-
         out = Path(output_dir)
         out.mkdir(parents=True, exist_ok=True)
 
-        with httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http:
-            resp = http.get(file_detail["url"])
-            resp.raise_for_status()
-            manifest_data = resp.content
-
-        manifest = json_mod.loads(manifest_data)
-        entries = manifest.get("entries", [])
-        if not entries:
-            raise KeboolaApiError(
-                message="Sliced file manifest has no entries",
-                status_code=500,
-                error_code="EXPORT_EMPTY_MANIFEST",
-                retryable=False,
-            )
+        entries, base_url, downloader, manifest_data = self._prepare_sliced_download(file_detail)
 
         # Persist the manifest alongside slices for traceability.
         (out / "_manifest.json").write_bytes(manifest_data)
 
-        logger.info("Downloading %d slices to %s (provider=%s)", len(entries), out, provider)
-
-        base_url = downloader.resolve_base_url(file_detail)
         slices: list[dict[str, Any]] = []
         total = 0
 
         for idx, entry in enumerate(entries):
             entry_url = entry.get("url", "")
             slice_url = downloader.resolve_slice_url(base_url, entry_url, file_detail)
-            raw = downloader.download_bytes(slice_url)
 
             clean_url = entry_url.split("?")[0]
             basename = clean_url.rsplit("/", 1)[-1]
-
-            if clean_url.endswith(".gz"):
-                raw = gzip.decompress(raw)
+            is_gz = clean_url.endswith(".gz")
+            if is_gz:
                 basename = basename.removesuffix(".gz")
-
             if not basename:
                 basename = f"part-{idx:05d}"
 
             slice_path = out / basename
-            slice_path.write_bytes(raw)
-            slices.append({"path": str(slice_path.resolve()), "size_bytes": len(raw)})
-            total += len(raw)
+            written = downloader.stream_to_file(slice_url, slice_path, decompress_gzip=is_gz)
+            slices.append({"path": str(slice_path.resolve()), "size_bytes": written})
+            total += written
 
         return {
             "output_dir": str(out.resolve()),
@@ -1619,35 +1614,35 @@ class KeboolaClient(BaseHttpClient):
     def download_file(self, url: str, output_path: str) -> int:
         """Download a non-sliced file from a presigned URL.
 
-        Handles gzip decompression transparently.
+        Streams the body chunk-by-chunk and decompresses gzip on the fly, so
+        peak RAM stays at O(chunk size) even for multi-GB payloads (issue #187).
 
         Args:
             url: Presigned download URL from file info.
             output_path: Local file path to write to.
 
         Returns:
-            Number of bytes written.
+            Number of bytes written (post-decompression if the URL is gzipped).
         """
         import gzip
+        import shutil
+
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        is_gzipped = url.rstrip("?").split("?")[0].endswith(".gz")
 
         with (
             httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http,
             http.stream("GET", url) as response,
         ):
             response.raise_for_status()
-            is_gzipped = url.rstrip("?").split("?")[0].endswith(".gz")
+            source: Any = _IterBytesReader(response.iter_bytes(FILE_DOWNLOAD_CHUNK_SIZE))
             if is_gzipped:
-                compressed = b"".join(response.iter_bytes())
-                data = gzip.decompress(compressed)
-                Path(output_path).write_bytes(data)
-                return len(data)
-            else:
-                total = 0
-                with open(output_path, "wb") as fh:
-                    for chunk in response.iter_bytes():
-                        fh.write(chunk)
-                        total += len(chunk)
-                return total
+                source = gzip.GzipFile(fileobj=source, mode="rb")
+            with out_path.open("wb") as fh:
+                shutil.copyfileobj(source, fh, length=FILE_DOWNLOAD_CHUNK_SIZE)
+
+        return out_path.stat().st_size
 
     def list_jobs(
         self,
@@ -2141,6 +2136,36 @@ def _build_abs_upload_url(abs_params: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
+class _IterBytesReader:
+    """Adapt an httpx iter_bytes() iterator to a .read(n) file-like interface.
+
+    shutil.copyfileobj and gzip.GzipFile both need a binary stream with
+    read(size). httpx exposes an iterator instead, so we buffer the current
+    chunk and hand out at most ``size`` bytes per read, refilling from the
+    iterator as needed. The buffer holds at most one iterator chunk at a time
+    (~1 MiB), so total memory stays bounded regardless of response size.
+    """
+
+    def __init__(self, chunks: Any) -> None:
+        self._chunks = iter(chunks)
+        self._buf = b""
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            pieces = [self._buf]
+            self._buf = b""
+            pieces.extend(self._chunks)
+            return b"".join(pieces)
+        while len(self._buf) < size:
+            try:
+                self._buf += next(self._chunks)
+            except StopIteration:
+                break
+        out = self._buf[:size]
+        self._buf = self._buf[size:]
+        return out
+
+
 class _CloudDownloader:
     """Abstraction for downloading from cloud storage using Keboola file credentials.
 
@@ -2279,16 +2304,50 @@ class _CloudDownloader:
             # Other: entry URLs should be full HTTPS URLs
             return entry_url
 
-    def download_bytes(self, url: str) -> bytes:
-        """Download content from a cloud URL with appropriate authentication."""
+    def _request_headers(self, url: str) -> dict[str, str]:
+        """Resolve auth headers for a cloud URL.
+
+        Azure stores metadata (endpoint, SAS) in the auth_fn result (keys
+        prefixed with "_"); those are filtered out here. The SAS token itself
+        is embedded into the URL by resolve_slice_url().
+        """
         auth_result = self._auth_fn(url)
-        # Azure stores metadata (endpoint, SAS) in auth_fn result, not HTTP headers.
-        # The SAS token is embedded in the URL by resolve_slice_url().
-        headers = {k: v for k, v in auth_result.items() if not k.startswith("_")}
-        with httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http:
-            response = http.get(url, headers=headers)
+        return {k: v for k, v in auth_result.items() if not k.startswith("_")}
+
+    def stream_to_file(self, url: str, dest: "Path | str", decompress_gzip: bool) -> int:
+        """Stream a cloud URL directly to a local file in bounded-memory chunks.
+
+        Used for slice downloads where the payload can be hundreds of MB per
+        slice. Peak RAM is O(chunk size), not O(slice size), which is what
+        makes multi-GB table exports survive on small VMs (see issue #187).
+
+        Args:
+            url: Full HTTPS URL (with auth baked in for Azure).
+            dest: Local file path to write to.
+            decompress_gzip: If True, wrap the response stream in gzip.GzipFile
+                so the decompressed bytes are what lands on disk. Streaming
+                gzip keeps both compressed and decompressed state bounded.
+
+        Returns:
+            Number of bytes written to ``dest`` (post-decompression if applicable).
+        """
+        import gzip
+        import shutil
+
+        headers = self._request_headers(url)
+        dest_path = Path(dest)
+        with (
+            httpx.Client(timeout=FILE_DOWNLOAD_TIMEOUT) as http,
+            http.stream("GET", url, headers=headers) as response,
+        ):
             response.raise_for_status()
-            return response.content
+            source: Any = _IterBytesReader(response.iter_bytes(FILE_DOWNLOAD_CHUNK_SIZE))
+            if decompress_gzip:
+                source = gzip.GzipFile(fileobj=source, mode="rb")
+            with dest_path.open("wb") as fh:
+                shutil.copyfileobj(source, fh, length=FILE_DOWNLOAD_CHUNK_SIZE)
+
+        return dest_path.stat().st_size
 
 
 def _s3_signed_headers(

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -655,7 +655,10 @@ def storage_download_table(
     output: str | None = typer.Option(
         None,
         "--output",
-        help="Output file path (default: {table_name}.csv)",
+        help=(
+            "Output path. Default mode: file path (e.g. table.csv). "
+            "With --keep-slices: directory path (default ./{project}/{table_id}.csv/)."
+        ),
     ),
     columns: list[str] | None = typer.Option(
         None,
@@ -672,12 +675,25 @@ def storage_download_table(
         "--branch",
         help="Dev branch ID (defaults to active branch if set via 'branch use')",
     ),
+    keep_slices: bool = typer.Option(
+        False,
+        "--keep-slices",
+        help=(
+            "Save each slice as its own file under --output (treated as a "
+            "directory). Avoids the concat pass, matches the parquet download "
+            "layout, and is the analytical-workflow-friendly option for DuckDB, "
+            "polars, Spark. A _columns.csv sidecar holds the column order."
+        ),
+    ),
 ) -> None:
     """Export a storage table to a local CSV file.
 
     Downloads table data via the async export API. Handles gzip
     decompression transparently. Use --columns to select specific
     columns and --limit to cap row count.
+
+    Use --keep-slices to write the individual slices into a directory
+    instead of concatenating them into a single file.
     """
     if should_hint(ctx):
         emit_hint(
@@ -689,6 +705,7 @@ def storage_download_table(
             columns=columns,
             limit=limit,
             branch=branch,
+            keep_slices=keep_slices,
         )
 
     formatter = get_formatter(ctx)
@@ -713,6 +730,7 @@ def storage_download_table(
             columns=columns,
             limit=limit,
             branch_id=effective_branch,
+            keep_slices=keep_slices,
         )
     except ValueError as exc:
         formatter.error(message=str(exc), error_code="INVALID_ARGUMENT")
@@ -728,9 +746,14 @@ def storage_download_table(
         formatter.output(result)
     else:
         size_mb = result["file_size_bytes"] / (1024 * 1024)
+        suffix = (
+            f", {result['slice_count']} slices"
+            if result.get("keep_slices") and result.get("slice_count")
+            else ""
+        )
         formatter.console.print(
             f"[bold green]Exported:[/bold green] {result['table_id']} -> {result['output_path']} "
-            f"({size_mb:.2f} MB)"
+            f"({size_mb:.2f} MB{suffix})"
         )
 
 
@@ -1693,6 +1716,16 @@ def storage_unload_table(
         "always sliced; with --download each slice is saved as its own file "
         "under --output (treated as a directory).",
     ),
+    keep_slices: bool = typer.Option(
+        False,
+        "--keep-slices",
+        help=(
+            "CSV-only with --download: write each slice as its own file under "
+            "--output (treated as a directory) instead of concatenating into a "
+            "single CSV. Mirrors the parquet download layout. Ignored for "
+            "parquet (always sliced) and for non-sliced exports."
+        ),
+    ),
 ) -> None:
     """Export a table to a Storage File.
 
@@ -1725,6 +1758,7 @@ def storage_unload_table(
             output=output,
             branch=branch,
             file_type=file_type,
+            keep_slices=keep_slices,
         )
 
     formatter = get_formatter(ctx)
@@ -1750,6 +1784,7 @@ def storage_unload_table(
             output_path=output,
             branch_id=effective_branch,
             file_type=file_type,
+            keep_slices=keep_slices,
         )
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code="CONFIG_ERROR")

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -75,6 +75,12 @@ FILE_DOWNLOAD_TIMEOUT: httpx.Timeout = httpx.Timeout(
     connect=30.0, read=3600.0, write=10.0, pool=30.0
 )
 
+# --- File Download Streaming ---
+# Chunk size for streamed downloads. Bounded buffer keeps peak RSS small even
+# for multi-GB tables (see GitHub issue #187: 200MB parquet slices OOM'd on 2GB RAM
+# hosts when loaded whole-body via response.content).
+FILE_DOWNLOAD_CHUNK_SIZE: int = 1024 * 1024  # 1 MiB
+
 # --- Export Job ---
 EXPORT_JOB_MAX_WAIT: float = 600.0  # 10 min for table export jobs (large tables)
 

--- a/src/keboola_agent_cli/hints/definitions/storage.py
+++ b/src/keboola_agent_cli/hints/definitions/storage.py
@@ -308,6 +308,7 @@ HintRegistry.register(
                         "columns": "{columns}",
                         "limit": "{limit}",
                         "branch_id": "{branch}",
+                        "keep_slices": "{keep_slices}",
                     },
                 ),
             ),
@@ -315,6 +316,7 @@ HintRegistry.register(
         notes=[
             "Client layer: export_table_async -> get_file_info -> download_file.",
             "Service layer handles the full flow including CSV header prepending.",
+            "keep_slices=True writes per-slice files into a directory (DuckDB/polars-friendly).",
         ],
     )
 )
@@ -668,10 +670,14 @@ HintRegistry.register(
                         "output_path": "{output}",
                         "branch_id": "{branch}",
                         "file_type": "{file_type}",
+                        "keep_slices": "{keep_slices}",
                     },
                 ),
             ),
         ],
-        notes=["Service layer handles optional tagging and local download."],
+        notes=[
+            "Service layer handles optional tagging and local download.",
+            "keep_slices=True (CSV only) preserves slices in a directory.",
+        ],
     )
 )

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -37,21 +37,30 @@ def _read_csv_header(file_path: str, delimiter: str = ",") -> list[str]:
 def _prepend_csv_header(file_path: str, columns: list[str]) -> None:
     """Prepend a CSV header row to an existing file.
 
-    Reads the file content, writes header + content back.
-    Uses CSV quoting for column names to match Keboola's RFC4180 format.
+    Streams the original body into a temp file so that multi-GB CSV exports
+    never sit in RAM at once (issue #187: the old read_bytes() peaked at the
+    full file size). Uses CSV quoting to match Keboola's RFC4180 format.
     """
     import io
+    import shutil
+    import tempfile
 
     writer_buf = io.StringIO()
     writer = csv.writer(writer_buf, quoting=csv.QUOTE_ALL)
     writer.writerow(columns)
-    header_line = writer_buf.getvalue()
+    header_line = writer_buf.getvalue().encode("utf-8")
 
     p = Path(file_path)
-    original = p.read_bytes()
-    with p.open("wb") as fh:
-        fh.write(header_line.encode("utf-8"))
-        fh.write(original)
+    # Temp file sits next to the target so shutil.move is a cheap rename on
+    # the same filesystem.
+    with tempfile.NamedTemporaryFile(
+        dir=p.parent, prefix=p.name + ".", suffix=".tmp", delete=False
+    ) as tmp:
+        tmp_path = Path(tmp.name)
+        tmp.write(header_line)
+        with p.open("rb") as src:
+            shutil.copyfileobj(src, tmp, length=1024 * 1024)
+    tmp_path.replace(p)
 
 
 class StorageService(BaseService):

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -34,6 +34,22 @@ def _read_csv_header(file_path: str, delimiter: str = ",") -> list[str]:
     return columns
 
 
+def _write_columns_sidecar(output_dir: str, columns: list[str]) -> None:
+    """Write a _columns.csv sidecar listing the table's column order.
+
+    Storage exports slices without a header row; the column list comes from
+    the table metadata. Writing a tiny sidecar here lets downstream tools
+    (DuckDB read_csv, polars scan_csv) reconstruct the schema without
+    querying Storage. Using the ``_`` prefix matches the _manifest.json
+    convention that pyarrow/Spark/Hive use for "skip when reading as a
+    dataset".
+    """
+    sidecar = Path(output_dir) / "_columns.csv"
+    with sidecar.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, quoting=csv.QUOTE_ALL)
+        writer.writerow(columns)
+
+
 def _prepend_csv_header(file_path: str, columns: list[str]) -> None:
     """Prepend a CSV header row to an existing file.
 
@@ -550,6 +566,7 @@ class StorageService(BaseService):
         columns: list[str] | None = None,
         limit: int | None = None,
         branch_id: int | None = None,
+        keep_slices: bool = False,
     ) -> dict[str, Any]:
         """Export a storage table to a local CSV file.
 
@@ -560,24 +577,33 @@ class StorageService(BaseService):
         Args:
             alias: Project alias.
             table_id: Full table ID (e.g. "in.c-bucket.table").
-            output_path: Local file path to write to. If None, derives
-                from table name (e.g. "my-table.csv").
+            output_path: Local file path (default mode) or directory
+                (``keep_slices=True``) to write to. Defaults to
+                ``<table>.csv`` / ``<alias>/<table_id>.csv/`` respectively.
             columns: Optional list of column names to export.
             limit: Optional max number of rows to export.
             branch_id: If set, target a specific dev branch.
+            keep_slices: If True, write each slice as its own file inside
+                the output directory and preserve the manifest. The CSV
+                header is written to a sidecar ``_columns.csv`` rather than
+                prepended to any slice so no slice has to be rewritten
+                end-to-end (which would defeat the memory story). For most
+                analytical tools the slices themselves are header-less
+                parts of a single logical CSV; headers come from catalog
+                metadata, not the slice bodies.
 
         Returns:
-            Dict with export metadata: path, size, rows, table_id, etc.
+            Dict with export metadata. With ``keep_slices`` the result also
+            contains ``slice_count`` and ``slices`` (list of {path, size}).
         """
         from ..errors import KeboolaApiError
 
         projects = self.resolve_projects([alias])
         project = projects[alias]
 
-        # Derive output filename from table ID if not specified
+        table_name = table_id.rsplit(".", 1)[-1] if "." in table_id else table_id
         if not output_path:
-            table_name = table_id.rsplit(".", 1)[-1] if "." in table_id else table_id
-            output_path = f"{table_name}.csv"
+            output_path = f"{alias}/{table_id}.csv" if keep_slices else f"{table_name}.csv"
 
         client = self._client_factory(project.stack_url, project.token)
         try:
@@ -620,7 +646,38 @@ class StorageService(BaseService):
                     retryable=False,
                 )
 
-            # Step 4: Download the file
+            # Step 4a: Sliced-directory mode -- each slice is its own file.
+            # This is the OOM-safe-by-default path for analytical workflows
+            # (DuckDB, polars, Spark read a directory natively).
+            if keep_slices:
+                if not file_detail.get("isSliced"):
+                    raise KeboolaApiError(
+                        message=(
+                            "--keep-slices is only meaningful for tables that "
+                            "Storage exports as multiple slices; this export "
+                            "produced a single file. Re-run without --keep-slices."
+                        ),
+                        status_code=400,
+                        error_code="NOT_SLICED",
+                        retryable=False,
+                    )
+                slice_info = client.download_sliced_file_to_dir(file_detail, output_path)
+                # Sidecar with the column order so downstream readers can
+                # reconstruct the header without hitting Storage.
+                _write_columns_sidecar(slice_info["output_dir"], table_columns or [])
+                return {
+                    "project_alias": alias,
+                    "table_id": table_id,
+                    "output_path": slice_info["output_dir"],
+                    "file_size_bytes": slice_info["total_bytes"],
+                    "columns": table_columns or [],
+                    "limit": limit,
+                    "keep_slices": True,
+                    "slice_count": slice_info["slice_count"],
+                    "slices": slice_info["slices"],
+                }
+
+            # Step 4b: Default mode -- concat into a single CSV file.
             if file_detail.get("isSliced"):
                 bytes_written = client.download_sliced_file(file_detail, output_path)
             else:
@@ -641,6 +698,7 @@ class StorageService(BaseService):
             "file_size_bytes": bytes_written,
             "columns": table_columns or [],
             "limit": limit,
+            "keep_slices": False,
         }
 
     # ------------------------------------------------------------------
@@ -1245,6 +1303,7 @@ class StorageService(BaseService):
         output_path: str | None = None,
         branch_id: int | None = None,
         file_type: str = "csv",
+        keep_slices: bool = False,
     ) -> dict[str, Any]:
         """Export a table to a Storage File.
 
@@ -1340,7 +1399,27 @@ class StorageService(BaseService):
                     result["downloaded_bytes"] = slice_info["total_bytes"]
                     result["slice_count"] = slice_info["slice_count"]
                     result["slices"] = slice_info["slices"]
+                elif keep_slices and file_detail.get("isSliced"):
+                    # Preserve slices as a directory (parallel to parquet layout)
+                    effective_output = output_path or f"{alias}/{table_id}.csv"
+                    slice_info = client.download_sliced_file_to_dir(file_detail, effective_output)
+                    result["downloaded"] = True
+                    result["output_path"] = slice_info["output_dir"]
+                    result["downloaded_bytes"] = slice_info["total_bytes"]
+                    result["slice_count"] = slice_info["slice_count"]
+                    result["slices"] = slice_info["slices"]
+                    result["keep_slices"] = True
                 else:
+                    if keep_slices:
+                        raise KeboolaApiError(
+                            message=(
+                                "--keep-slices requires a sliced export; this "
+                                "file is a single non-sliced CSV. Drop the flag."
+                            ),
+                            status_code=400,
+                            error_code="NOT_SLICED",
+                            retryable=False,
+                        )
                     effective_output = output_path or f"{table_short}.csv"
 
                     if file_detail.get("isSliced"):

--- a/tests/test_storage_files.py
+++ b/tests/test_storage_files.py
@@ -1472,3 +1472,96 @@ class TestClientDownloadSlicedFileToDir:
 
         assert exc_info.value.error_code == "EXPORT_EMPTY_MANIFEST"
         client.close()
+
+
+class TestDownloadTableKeepSlices:
+    """download_table(keep_slices=True) writes slices into a directory."""
+
+    def _make_service(self, tmp_path: Path, fake_client: MagicMock) -> StorageService:
+        config_dir = tmp_path / "cfg"
+        config_dir.mkdir(exist_ok=True)
+        store = ConfigStore(config_dir=config_dir)
+        store.save(
+            AppConfig(
+                projects={
+                    "proj": ProjectConfig(
+                        stack_url="https://connection.keboola.com",
+                        token=TEST_TOKEN,
+                    )
+                }
+            )
+        )
+        return StorageService(config_store=store, client_factory=lambda _u, _t: fake_client)
+
+    def test_keep_slices_writes_directory_with_columns_sidecar(self, tmp_path: Path) -> None:
+        """With keep_slices=True we expect a dir + slice files + _columns.csv."""
+        out_dir = tmp_path / "proj" / "in.c-b.t.csv"
+        slice_a = out_dir / "part-0.csv"
+        slice_b = out_dir / "part-1.csv"
+
+        def _fake_download_to_dir(file_detail: dict, output_dir: str) -> dict:
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
+            slice_a.write_bytes(b"1,2\n")
+            slice_b.write_bytes(b"3,4\n")
+            (Path(output_dir) / "_manifest.json").write_text("{}")
+            return {
+                "output_dir": str(Path(output_dir).resolve()),
+                "slice_count": 2,
+                "total_bytes": 8,
+                "slices": [
+                    {"path": str(slice_a.resolve()), "size_bytes": 4},
+                    {"path": str(slice_b.resolve()), "size_bytes": 4},
+                ],
+            }
+
+        fake_client = MagicMock()
+        fake_client.list_tables.return_value = [{"id": "in.c-b.t", "columns": ["a", "b"]}]
+        fake_client.export_table_async.return_value = {"results": {"file": {"id": 99}}}
+        fake_client.get_file_info.return_value = {
+            "id": 99,
+            "isSliced": True,
+            "url": "https://example.com/manifest",
+        }
+        fake_client.download_sliced_file_to_dir.side_effect = _fake_download_to_dir
+
+        svc = self._make_service(tmp_path, fake_client)
+        result = svc.download_table(
+            alias="proj",
+            table_id="in.c-b.t",
+            output_path=str(out_dir),
+            keep_slices=True,
+        )
+
+        assert result["keep_slices"] is True
+        assert result["slice_count"] == 2
+        assert result["file_size_bytes"] == 8
+        # Sidecar with the column order is the contract for downstream readers
+        sidecar = out_dir / "_columns.csv"
+        assert sidecar.exists()
+        assert sidecar.read_text().strip() == '"a","b"'
+        # Each slice is left as-is, no header was prepended into a slice
+        assert slice_a.read_bytes() == b"1,2\n"
+        assert slice_b.read_bytes() == b"3,4\n"
+
+    def test_keep_slices_on_non_sliced_export_errors(self, tmp_path: Path) -> None:
+        """The flag is meaningless if the export wasn't sliced -- error early."""
+        fake_client = MagicMock()
+        fake_client.list_tables.return_value = [{"id": "in.c-b.t", "columns": ["a"]}]
+        fake_client.export_table_async.return_value = {"results": {"file": {"id": 7}}}
+        fake_client.get_file_info.return_value = {
+            "id": 7,
+            "isSliced": False,
+            "url": "https://example.com/file.csv.gz",
+        }
+
+        svc = self._make_service(tmp_path, fake_client)
+        with pytest.raises(KeboolaApiError) as exc_info:
+            svc.download_table(
+                alias="proj",
+                table_id="in.c-b.t",
+                output_path=str(tmp_path / "out"),
+                keep_slices=True,
+            )
+        assert exc_info.value.error_code == "NOT_SLICED"
+        # Crucially: the sliced download path must not have been reached
+        fake_client.download_sliced_file_to_dir.assert_not_called()

--- a/tests/test_storage_files.py
+++ b/tests/test_storage_files.py
@@ -1346,11 +1346,20 @@ class TestClientDownloadSlicedFileToDir:
             content=json_mod.dumps(manifest).encode(),
         )
 
-        # Stub the cloud downloader to avoid real S3/GCS calls
+        # Stub the cloud downloader to avoid real S3/GCS calls. stream_to_file
+        # is the OOM-safe path (issue #187): it writes directly to disk rather
+        # than returning bytes, so the fake has to side-effect the destination.
+        slice_payloads = iter([b"PAR1_slice_1", b"PAR1_slice_2"])
+
+        def _fake_stream_to_file(url: str, dest, decompress_gzip: bool) -> int:
+            payload = next(slice_payloads)
+            Path(dest).write_bytes(payload)
+            return len(payload)
+
         fake_downloader = MagicMock()
         fake_downloader.resolve_base_url.return_value = "https://bucket.s3.amazonaws.com/export"
         fake_downloader.resolve_slice_url.side_effect = lambda base, entry_url, fd: entry_url
-        fake_downloader.download_bytes.side_effect = [b"PAR1_slice_1", b"PAR1_slice_2"]
+        fake_downloader.stream_to_file.side_effect = _fake_stream_to_file
 
         client = KeboolaClient(
             stack_url="https://connection.keboola.com",
@@ -1398,10 +1407,17 @@ class TestClientDownloadSlicedFileToDir:
             content=json_mod.dumps(manifest).encode(),
         )
 
+        # The real stream_to_file streams+decompresses gzip; mirror that so
+        # the test still verifies the .gz-suffix handling in the caller.
+        def _fake_stream_to_file(url: str, dest, decompress_gzip: bool) -> int:
+            data = payload if decompress_gzip else gz_payload
+            Path(dest).write_bytes(data)
+            return len(data)
+
         fake_downloader = MagicMock()
         fake_downloader.resolve_base_url.return_value = "https://bucket.s3.amazonaws.com/export"
         fake_downloader.resolve_slice_url.side_effect = lambda base, entry_url, fd: entry_url
-        fake_downloader.download_bytes.return_value = gz_payload
+        fake_downloader.stream_to_file.side_effect = _fake_stream_to_file
 
         client = KeboolaClient(
             stack_url="https://connection.keboola.com",

--- a/tests/test_storage_write.py
+++ b/tests/test_storage_write.py
@@ -1485,6 +1485,7 @@ class TestDownloadTableCLI:
             columns=None,
             limit=None,
             branch_id=None,
+            keep_slices=False,
         )
 
     def test_download_table_with_columns_and_limit(self, tmp_path: Path) -> None:
@@ -1531,6 +1532,7 @@ class TestDownloadTableCLI:
             columns=["id", "name"],
             limit=50,
             branch_id=None,
+            keep_slices=False,
         )
 
     def test_download_table_api_error(self, tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.20.5"
+version = "0.20.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Closes #187 by streaming downloads chunk-by-chunk and adds an opt-in `--keep-slices` mode to the CSV export paths.

### Streaming fix (commit 1)

Sliced file downloads previously loaded each slice into memory whole via `response.content`. With 200 MB parquet slices this peaked at 1.78 GB RSS on a 2 GB host and the OOM killer fired (issue #187). All download paths now stream through `shutil.copyfileobj` with bounded 1 MiB chunks.

**Reproduction on a 2 GB DO droplet** (Slevomat `in.c-db.carts`, 27.8M rows, 1.0 GB CSV / 3.85 GB parquet):

| Command | Before | After |
|---|---|---|
| `unload-table --file-type parquet --download` | **1.78 GB RSS / OOM (rc=137)** | **90 MB RSS / exit 0** |
| `download-table` (CSV concat) | OOM at ≥ ~1 GB tables | **102 MB RSS / exit 0** |
| `download-table --keep-slices` (new) | n/a | **96 MB RSS / exit 0** |

Touched paths:
- `_CloudDownloader.stream_to_file()` replaces `download_bytes()` in both slice download paths.
- `_IterBytesReader` adapts httpx `iter_bytes()` to the `read(n)` interface so `gzip.GzipFile` / `shutil.copyfileobj` can consume it.
- `download_file()` now streams both plain and gzipped non-sliced files.
- `download_sliced_file()` writes each slice into a per-slice `NamedTemporaryFile` next to the output, then copy-appends -- neither the slice nor the concatenated buffer ever sits in RAM.
- `_prepend_csv_header()` uses a temp file + `shutil.copyfileobj` instead of `read_bytes()`, so a 1 GB CSV no longer gets loaded just to prepend the header.

### `--keep-slices` (commit 2)

Opt-in flag for `storage download-table` and `storage unload-table --download` (CSV path). Mirrors how parquet has worked since 0.20.3: the output path is treated as a directory, each manifest entry lands as its own file, plus a `_columns.csv` sidecar holds the column order. Keeps existing single-file behavior as the default so existing scripts don't break.

Validation: `--keep-slices` against a non-sliced export raises `NOT_SLICED` with a clear message rather than silently writing a one-file directory.

### Version

Bumps to **0.20.6**, syncs `plugin.json`, updates `changelog.py`, and updates the storage hint definitions to expose `keep_slices`.

## Test plan

- [x] Unit tests added: `TestDownloadTableKeepSlices` covers happy path (slice dir + sidecar) and NOT_SLICED rejection
- [x] Existing CLI tests updated (download_table now passes `keep_slices=False`)
- [x] Full local suite green (1764 passed, 4 skipped)
- [x] Reproduced original OOM on the reporter's 2 GB DigitalOcean droplet, then verified the fix on the same host (numbers above)
- [ ] Manual E2E on a small project (smoke check to confirm no regression for sub-GB tables)