### PR TITLE
fix(0.21.1): sync pull on new dev branch now writes config rows (#193)

### DIFF
--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.21.0"
+version = "0.21.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.21.1": [
+        "Fix: sync pull on a newly created dev branch now writes config rows (#193) -- idempotent skip guard for rows was missing a file-existence check, causing rows to be silently skipped when the branch directory was new (hash matched main because the branch is a clone)",
+    ],
     "0.21.0": [
         "New: config variables-set / variables-get / variables-clear -- variables as a first-class attachment, not a resource to manage. Auto-creates the backing keboola.variables config + default row on first set, merges or replaces on update, encrypts #-prefixed values fail-closed, unlinks without deleting the backing config.",
         "New: sync push now deploys config rows (create/update/delete via /rows endpoints) -- previously rows edited locally were silently skipped (FIIA P0-1)",

--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -528,8 +528,16 @@ class SyncService(BaseService):
                                 "reason": "row locally modified",
                             }
                         )
-                    elif existing_row and old_row_cfg_hash and old_row_cfg_hash == row_api_cfg_hash:
+                    elif (
+                        existing_row
+                        and old_row_cfg_hash
+                        and old_row_cfg_hash == row_api_cfg_hash
+                        and row_file.exists()
+                    ):
                         # Idempotent: remote unchanged since last pull, file untouched.
+                        # Guard: row_file.exists() ensures we don't skip writing when
+                        # the directory is new (e.g. first pull of a dev branch that
+                        # clones main -- same hash but no file on disk yet).
                         row_file_hash = (
                             self._file_hash(row_file) if row_file.exists() else old_row_file_hash
                         )

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -696,6 +696,54 @@ class TestPull:
         assert renamed_details[0]["old_path"] == "extractor/keboola.ex-http/my-http-extractor"
         assert renamed_details[0]["path"] == "extractor/keboola.ex-http/renamed-http-extractor"
 
+    def test_pull_dev_branch_writes_rows(self, tmp_config_dir: Path, tmp_path: Path) -> None:
+        """Regression: first pull of a new dev branch must write config rows (issue #193).
+
+        A fresh branch is a clone of main -- API hashes are identical. The idempotent
+        skip guard must NOT fire when the row file doesn't exist on disk yet.
+        """
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        # Init with both main + dev branch registered
+        store = self._init_project(
+            tmp_config_dir, project_root, branches_response=SAMPLE_BRANCHES_WITH_DEV
+        )
+
+        # Pull main (branch_id 12345) first so manifest carries rows from main
+        main_client = _make_sync_mock_client(
+            components_response=SAMPLE_COMPONENTS,
+        )
+        main_client.list_dev_branches.return_value = SAMPLE_BRANCHES_WITH_DEV
+        svc = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: main_client,
+        )
+        result_main = svc.pull(alias="prod", project_root=project_root)
+        assert result_main["rows_pulled"] == 1
+
+        # Switch active branch to the dev branch (branch_id 99999)
+        store.set_project_branch("prod", 99999)
+
+        # Pull dev branch -- same API payload (clone of main, identical hashes)
+        dev_client = _make_sync_mock_client(
+            components_response=SAMPLE_COMPONENTS,
+        )
+        dev_client.list_dev_branches.return_value = SAMPLE_BRANCHES_WITH_DEV
+        svc2 = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: dev_client,
+        )
+        result_dev = svc2.pull(alias="prod", project_root=project_root)
+
+        # Row files must be written for the dev branch directory
+        assert result_dev["rows_pulled"] == 1, (
+            "Dev branch pull must write row files even when API hash matches main"
+        )
+        dev_branch_dir = project_root / result_dev["branch_dir"]
+        row_files = [f for f in dev_branch_dir.rglob(CONFIG_FILENAME) if "rows" in f.parts]
+        assert len(row_files) >= 1, "Row _config.yml files must exist under dev branch dir"
+
 
 # ===================================================================
 # status tests

--- a/uv.lock
+++ b/uv.lock
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- **Bug:** First `sync pull` on a newly created dev branch silently skips config rows. Parent `_config.yml` is written correctly but `rows/` subdirectory is empty.
- **Root cause:** The idempotent skip guard for rows (`elif existing_row and old_row_cfg_hash == row_api_cfg_hash`) checked only the API hash. A fresh branch is a clone of main, so the hash always matches — but the row file doesn't exist yet in the new branch directory. The guard fired and skipped the write.
- **Fix:** Added `and row_file.exists()` to the elif condition in `sync_service.py`. If the file isn't on disk yet, the guard doesn't fire and the file is written. One-line change, no behavioral change for existing already-pulled branches.
- **Test:** Added `test_pull_dev_branch_writes_rows` — pulls main (rows land), switches to dev branch, pulls again with identical API payload, asserts `rows_pulled > 0` and row files exist under the dev branch directory.

## Test plan

- [x] Unit test `TestPull::test_pull_dev_branch_writes_rows` passes
- [x] All 10 `TestPull` tests pass
- [x] Verified on real project `padak-2-0` in `/tmp/kosik`: 30 rows pulled into fresh `test-issue-193` branch, `diff -rq main test-issue-193` reports no missing `rows/` directories
- [x] `make lint` passes, pre-commit hook passes