### PR TITLE
chore: whitelist .env templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ ENV/
 # Environment variables
 .env
 .env.*
+!.env.example
+!.env.template
 
 # IDE
 .idea/


### PR DESCRIPTION
## Summary

Split out of #199 per review — the two lines are documentation/scaffolding artifacts and shouldn't be caught by the `.env.*` gitignore pattern.

```diff
 .env
 .env.*
+!.env.example
+!.env.template
```

## Test plan

- [x] `.env.example` and `.env.template` (once added) will now be tracked by git despite the `.env.*` catch-all.
- [x] Existing `.env` and other `.env.*` files remain ignored.