### PR TITLE
release: v0.21.2 — customer bugfix batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ ENV/
 # Environment variables
 .env
 .env.*
+!.env.example
+!.env.template
 
 # IDE
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ kbagent job terminate --project NAME (--job-id ID [--job-id ID ...] | --status a
 
 kbagent storage buckets [--project NAME] [--branch ID]
 kbagent storage bucket-detail --project NAME --bucket-id ID [--branch ID]
-kbagent storage tables --project NAME [--bucket-id ID] [--branch ID]
+kbagent storage tables [--project NAME ...] [--bucket-id ID] [--branch ID]
 kbagent storage table-detail --project NAME --table-id ID [--branch ID]
 kbagent storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]
 kbagent storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -102,7 +102,7 @@ When working inside a git repository or project directory, run `kbagent init` (o
 | Terminate one or more Queue API jobs (use to stop runaway or stuck jobs) | `kbagent job terminate --project PROJECT` |
 | List storage buckets with sharing/linked bucket information | `kbagent storage buckets` |
 | Show detailed bucket info including Snowflake direct access paths | `kbagent storage bucket-detail --project PROJECT --bucket-id BUCKET-ID` |
-| List storage tables from a project | `kbagent storage tables --project PROJECT` |
+| List storage tables from one or more projects | `kbagent storage tables` |
 | Show detailed table info including columns and types | `kbagent storage table-detail --project PROJECT --table-id TABLE-ID` |
 | Create a new storage bucket | `kbagent storage create-bucket --project PROJECT --stage STAGE --name NAME` |
 | Create a new storage table with typed columns | `kbagent storage create-table --project PROJECT --bucket-id BUCKET-ID --name NAME --column COLUMN` |

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -48,7 +48,7 @@ All commands support `--json` for structured output. Multi-project flags (`--pro
 ## Storage
 - `storage buckets [--project NAME] [--branch ID]` -- list buckets with sharing/linked info (branch-aware)
 - `storage bucket-detail --project NAME --bucket-id ID [--branch ID]` -- bucket detail with Snowflake paths (branch-aware)
-- `storage tables --project NAME [--bucket-id ID] [--branch ID]` -- list tables, optionally by bucket (branch-aware)
+- `storage tables [--project NAME ...] [--bucket-id ID] [--branch ID]` -- list tables across all connected projects in parallel (multi-project by default, same as `storage buckets`); repeat `--project` to target a subset; `--bucket-id` is applied independently per project (missing buckets become per-project errors); `--branch` requires exactly one `--project`
 - `storage table-detail --project NAME --table-id ID [--branch ID]` -- table detail with columns, types, primary key, row count (branch-aware)
 - `storage create-bucket --project NAME --stage STAGE --name NAME [--description D] [--backend B] [--branch ID]` -- create bucket (branch-aware)
 - `storage create-table --project NAME --bucket-id ID --name NAME --column COL:TYPE [...] [--primary-key COL] [--branch ID]` -- create typed table (branch-aware)

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -392,6 +392,25 @@ seamlessly. This is transparent -- no user action required.
 - Skipped for: dev/editable installs, `update`/`version` commands
 - Never crashes the CLI -- update failures are silently ignored
 
+## `lineage build` and sync layouts
+
+`lineage build` reads synced data from disk and supports both layouts produced by
+`kbagent sync pull`:
+
+- **Flat** (after `sync pull --project X`): `./.keboola/manifest.json` directly in CWD.
+- **Nested** (after `sync pull --all-projects`): `./<alias>/.keboola/manifest.json`
+  for each project side by side.
+
+Pass the matching directory to `--directory` / `-d`:
+
+- Flat: `kbagent lineage build -d . -o lineage.json`
+- Nested: `kbagent lineage build -d /path/to/parent -o lineage.json`
+
+If the scan finds zero projects, the build still writes the cache file but
+emits a warning (both in the human-readable output and as a `warnings` array
+in `--json` mode) with a hint about the expected layouts. In JSON mode, inspect
+`result["data"]["warnings"]` to detect this situation programmatically.
+
 ## Sync and dev branches
 
 When an active branch is set (`branch use --branch ID`), sync commands automatically

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -143,6 +143,12 @@ One project failing does not block others. Check the `errors` array:
 - **Branch scope**: when active branch is set, MCP tools and config commands automatically scope to that branch.
   `branch_id` is a **CLI flag** (`--branch`), NOT a tool input parameter -- do not pass it inside `--input`.
   Config read commands (`config list`, `config detail`, `config search`) also support `--branch`.
+- **Storage read commands are the exception**: `storage buckets`, `storage bucket-detail`,
+  `storage tables`, `storage table-detail`, and `storage files` **ignore the implicit active
+  dev branch** and query production by default. The Storage API branch-scoped endpoint only
+  returns resources locally modified in the dev branch (empty for a fresh branch), so
+  auto-scoping would surprise users with "No tables found". Explicit `--branch ID` still
+  works. Storage **write** commands (create-*, upload-*, delete-*, file-*) stay branch-aware.
 - **Schema discovery**: use `kbagent --json tool list` to inspect each tool's `inputSchema` and find
   accepted parameters. For example, `get_configs` takes `configs` (a list of `{component_id, configuration_id}`
   objects), not a flat `config_id` string.

--- a/plugins/kbagent/skills/kbagent/references/lineage-deep-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/lineage-deep-workflow.md
@@ -15,6 +15,19 @@ kbagent sync pull --all-projects
 
 The sync'd directory structure is the input for lineage analysis.
 
+### Supported layouts
+
+`lineage build` auto-detects both layouts produced by `sync pull`:
+
+| Source command | Layout | Example manifest path |
+|----------------|--------|------------------------|
+| `sync pull --project X` | **Flat** -- CWD *is* the project | `./.keboola/manifest.json` |
+| `sync pull --all-projects` | **Nested** -- one subdir per project | `./<alias>/.keboola/manifest.json` |
+
+Pass the directory that *contains* the manifest (flat) or the parent of all
+project subdirs (nested). When the build finds zero projects it emits a
+warning with a hint rather than silently returning an empty graph.
+
 ## Build lineage
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.21.1"
+version = "0.21.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.21.2": [
+        "Fix: `kbagent job run` rich-mode banner now reads `resolvedVariableValuesId` from the service response instead of echoing the raw `--variable-values-id` flag -- shows the auto-resolved row even when the flag was omitted",
+        "Fix: `--variable-values-id` value is stripped of surrounding whitespace before reaching the service -- prevents a padded input from bypassing the empty-string guard",
+        "Fix: `--hint client job run --branch ID` now threads `branch_id` through all three client calls (get_config_detail, list_config_rows, create_job) -- previously the branch arg was silently dropped, causing the hint to target production",
+        "Chore: `rich.markup.escape` import hoisted to module level in commands/job.py",
+    ],
     "0.21.1": [
         "Fix: sync pull on a newly created dev branch now writes config rows (#193) -- idempotent skip guard for rows was missing a file-existence check, causing rows to be silently skipped when the branch directory was new (hash matched main because the branch is a clone)",
     ],

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
     "0.21.2": [
+        "Fix: `kbagent config search` now scans `rows[].configuration` in addition to the top-level configuration body (#196) -- queries like `--query '\"incremental\": false'` previously returned zero matches for row-based components (Snowflake/MySQL/BigQuery writers, DB extractors, Google Sheets) because the service only fetched `include=configuration`; match paths are now reported as `rows[N].configuration.parameters.<key>`",
+        "Fix: `kbagent storage tables` now accepts zero-or-more `--project` flags and queries all connected projects in parallel (#198) -- matches the multi-project behaviour of `storage buckets`, `config list`, `job list`; JSON envelope now returns `{tables: [...], errors: [...]}` with per-row `project_alias`; `--branch` still requires exactly one `--project`",
+        "Fix: storage READ commands (`buckets`, `bucket-detail`, `tables`, `table-detail`, `files`) no longer auto-scope to the implicit active dev branch set via `branch use` (#207) -- the Storage API branch endpoint only returns locally modified tables, so a fresh dev branch listed nothing; explicit `--branch ID` still overrides. Write/destructive commands remain branch-aware",
+        "Fix: `kbagent lineage build` now supports the flat single-project sync layout (#208) -- previously `sync pull --project foo` followed by `lineage build` returned `0/0/0` because the scanner assumed the nested `<alias>/.keboola/` layout produced by `sync pull --all-projects`; lineage also emits a warning instead of silently returning an empty graph when zero projects are found",
         "Fix: `kbagent job run` rich-mode banner now reads `resolvedVariableValuesId` from the service response instead of echoing the raw `--variable-values-id` flag -- shows the auto-resolved row even when the flag was omitted",
         "Fix: `--variable-values-id` value is stripped of surrounding whitespace before reaching the service -- prevents a padded input from bypassing the empty-string guard",
         "Fix: `--hint client job run --branch ID` now threads `branch_id` through all three client calls (get_config_detail, list_config_rows, create_job) -- previously the branch arg was silently dropped, causing the hint to target production",
+        "Chore: `.gitignore` whitelists `.env.example` and `.env.template` so documentation/scaffolding env templates can be tracked alongside the catch-all `.env.*` ignore rule",
         "Chore: `rich.markup.escape` import hoisted to module level in commands/job.py",
     ],
     "0.21.1": [

--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -216,25 +216,35 @@ class KeboolaClient(BaseHttpClient):
         response = self._request("GET", f"{prefix}/components", params=params)
         return response.json()
 
-    def list_components_with_configs(self, branch_id: int | None = None) -> list[dict[str, Any]]:
+    def list_components_with_configs(
+        self,
+        branch_id: int | None = None,
+        component_type: str | None = None,
+    ) -> list[dict[str, Any]]:
         """List all components with full configuration bodies and rows.
 
-        Makes a single API call to fetch everything needed for sync pull.
-        Uses the include=configuration,rows parameter to get full config
-        bodies and config rows in one request.
+        Makes a single API call to fetch everything needed for sync pull and
+        for deep search (row-level configuration). Uses the
+        include=configuration,rows parameter to get full config bodies and
+        config rows in one request.
 
         Args:
             branch_id: If set, target a specific dev branch.
+            component_type: Optional filter (extractor, writer, transformation,
+                application). Passed to the API as ``componentType``.
 
         Returns:
             List of component dicts, each containing a 'configurations' list
             with full config bodies and nested 'rows'.
         """
         prefix = f"/v2/storage/branch/{branch_id}" if branch_id else "/v2/storage"
+        params: dict[str, str] = {"include": "configuration,rows"}
+        if component_type:
+            params["componentType"] = component_type
         resp = self._request(
             "GET",
             f"{prefix}/components",
-            params={"include": "configuration,rows"},
+            params=params,
         )
         return resp.json()
 

--- a/src/keboola_agent_cli/commands/_helpers.py
+++ b/src/keboola_agent_cli/commands/_helpers.py
@@ -176,6 +176,8 @@ def resolve_branch(
     formatter: OutputFormatter,
     project: str | None,
     branch: int | None,
+    *,
+    ignore_active_branch: bool = False,
 ) -> tuple[str | None, int | None]:
     """Resolve the effective branch and project.
 
@@ -192,6 +194,14 @@ def resolve_branch(
         formatter: Output formatter for info messages.
         project: Explicit --project alias or None.
         branch: Explicit --branch integer or None.
+        ignore_active_branch: When True, the implicit active_branch_id from
+            config is ignored and the production endpoint (branch_id=None) is
+            used unless --branch was passed explicitly. An info message is
+            printed so the user can see the active dev branch was skipped.
+            Intended for storage READ commands -- the Storage API
+            branch-scoped endpoint returns only locally-modified resources,
+            which for a freshly created dev branch is an empty set. Explicit
+            --branch still overrides.
 
     Returns:
         Tuple of (effective_project, effective_branch_id).
@@ -202,6 +212,14 @@ def resolve_branch(
     if project is not None:
         proj_config = config_store.get_project(project)
         if proj_config and proj_config.active_branch_id is not None:
+            if ignore_active_branch:
+                if not formatter.json_mode:
+                    formatter.err_console.print(
+                        f"[bold blue]Info:[/bold blue] Using production branch for read "
+                        f"(active dev branch '{proj_config.active_branch_id}' ignored; "
+                        f"pass --branch {proj_config.active_branch_id} to override)"
+                    )
+                return project, None
             if not formatter.json_mode:
                 formatter.err_console.print(
                     f"[bold blue]Info:[/bold blue] Using active branch "
@@ -217,6 +235,14 @@ def resolve_branch(
         ]
         if len(active_projects) == 1:
             alias, proj = active_projects[0]
+            if ignore_active_branch:
+                if not formatter.json_mode:
+                    formatter.err_console.print(
+                        f"[bold blue]Info:[/bold blue] Using production branch for read "
+                        f"(active dev branch '{proj.active_branch_id}' on project '{alias}' "
+                        f"ignored; pass --branch {proj.active_branch_id} to override)"
+                    )
+                return alias, None
             if not formatter.json_mode:
                 formatter.err_console.print(
                     f"[bold blue]Info:[/bold blue] Using active branch "

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -252,8 +252,12 @@ Use `kbagent <command> --help` for full flag details and examples.
   kbagent lineage build --directory PATH --output PATH [--ai] [--refresh]
     Build column-level lineage graph from sync'd data. Scans all sync'd projects,
     detects dependencies via config mappings and SQL parsing, saves to cache file.
-    --refresh runs sync pull first. --ai generates .lineage_ai_tasks.json with
-    AI analysis tasks for an AI agent to process (2-step flow).
+    Auto-detects both sync layouts: flat (./.keboola/manifest.json from
+    sync pull --project X) and nested (./<alias>/.keboola/manifest.json from
+    sync pull --all-projects). Emits a warning in response data if no projects
+    are found. --refresh runs sync pull first. --ai generates
+    .lineage_ai_tasks.json with AI analysis tasks for an AI agent to process
+    (2-step flow).
 
   kbagent lineage show --load PATH [--upstream NODE] [--downstream NODE]
       [--column COL] [--columns] [--project ALIAS] [--depth N]

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -172,8 +172,14 @@ remain branch-aware because modifying a dev branch is the expected intent.
     Bucket detail with Snowflake direct access paths. Resolves linked bucket source DB.
     Uses production by default; pass --branch to query a dev branch explicitly.
 
-  kbagent storage tables --project NAME [--bucket-id BUCKET_ID] [--branch ID]
-    List storage tables, optionally filtered by bucket.
+  kbagent storage tables [--project NAME ...] [--bucket-id BUCKET_ID] [--branch ID]
+    List storage tables from one or more projects (in parallel). Omit --project
+    to query all connected projects. Repeat --project for a specific subset.
+    Multi-project by default, matching `storage buckets`, `config list`, `job list`.
+    Each row is tagged with project_alias; per-project errors accumulate in the
+    response envelope. --branch is only valid with a single --project.
+    --bucket-id is applied independently per project; missing buckets are
+    reported as per-project errors, not fatal.
     Uses production by default; pass --branch to query a dev branch explicitly.
 
   kbagent storage table-detail --project NAME --table-id TABLE_ID [--branch ID]

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -155,17 +155,30 @@ Use `kbagent <command> --help` for full flag details and examples.
 
 ### Storage
 
+Note on branches: storage READ commands (buckets, bucket-detail, tables,
+table-detail, files, file-detail) use the production endpoint by default,
+even when a dev branch is active via `branch use`. The Storage API
+branch-scoped endpoint returns only resources that were locally modified
+in the dev branch, so a freshly-created branch lists nothing. Pass
+`--branch ID` explicitly to query dev-branch-local tables/buckets.
+Storage WRITE commands (create-*, upload-*, delete-*, file-upload, etc.)
+remain branch-aware because modifying a dev branch is the expected intent.
+
   kbagent storage buckets [--project NAME] [--branch ID]
-    List buckets with sharing/linked info. Shows source project for linked buckets. Branch-aware.
+    List buckets with sharing/linked info. Shows source project for linked buckets.
+    Uses production by default; pass --branch to query a dev branch explicitly.
 
   kbagent storage bucket-detail --project NAME --bucket-id BUCKET_ID [--branch ID]
-    Bucket detail with Snowflake direct access paths. Resolves linked bucket source DB. Branch-aware.
+    Bucket detail with Snowflake direct access paths. Resolves linked bucket source DB.
+    Uses production by default; pass --branch to query a dev branch explicitly.
 
   kbagent storage tables --project NAME [--bucket-id BUCKET_ID] [--branch ID]
-    List storage tables, optionally filtered by bucket. Branch-aware.
+    List storage tables, optionally filtered by bucket.
+    Uses production by default; pass --branch to query a dev branch explicitly.
 
   kbagent storage table-detail --project NAME --table-id TABLE_ID [--branch ID]
-    Show detailed table info: columns (with types if available), primary key, row count, size, last import date. Branch-aware.
+    Show detailed table info: columns (with types if available), primary key, row count, size, last import date.
+    Uses production by default; pass --branch to query a dev branch explicitly.
 
   kbagent storage create-bucket --project NAME --stage STAGE --name BUCKET_NAME [--description D] [--backend B] [--branch ID]
     Create a new storage bucket. Stage must be "in" or "out". Branch-aware.
@@ -196,7 +209,8 @@ Use `kbagent <command> --help` for full flag details and examples.
 ### Storage Files
 
   kbagent storage files --project NAME [--tag TAG ...] [--limit N] [--offset N] [--query Q] [--branch ID]
-    List Storage Files. --tag filters by tags (AND logic, repeat for multiple). --query for full-text search on name. Branch-aware.
+    List Storage Files. --tag filters by tags (AND logic, repeat for multiple). --query for full-text search on name.
+    Uses production by default; pass --branch to query a dev branch explicitly.
 
   kbagent storage file-upload --project NAME --file PATH [--name NAME] [--tag TAG ...] [--permanent] [--branch ID]
     Upload any file to Storage Files. --tag assigns tags (repeatable). --permanent prevents auto-deletion after 15 days.

--- a/src/keboola_agent_cli/commands/job.py
+++ b/src/keboola_agent_cli/commands/job.py
@@ -5,6 +5,7 @@ No business logic belongs here.
 """
 
 import typer
+from rich.markup import escape
 
 from ..config_store import ConfigStore
 from ..constants import (
@@ -244,15 +245,17 @@ def job_run(
     service = get_service(ctx, "job_service")
     config_store: ConfigStore = ctx.obj["config_store"]
 
-    if variable_values_id is not None and not variable_values_id.strip():
-        formatter.error(
-            message=(
-                "--variable-values-id cannot be empty or whitespace. "
-                "Pass a row id, or omit the flag to auto-resolve the default row."
-            ),
-            error_code="INVALID_ARGUMENT",
-        )
-        raise typer.Exit(code=2)
+    if variable_values_id is not None:
+        variable_values_id = variable_values_id.strip()
+        if not variable_values_id:
+            formatter.error(
+                message=(
+                    "--variable-values-id cannot be empty or whitespace. "
+                    "Pass a row id, or omit the flag to auto-resolve the default row."
+                ),
+                error_code="INVALID_ARGUMENT",
+            )
+            raise typer.Exit(code=2)
 
     if variable_values_id and no_variables:
         formatter.error(
@@ -278,13 +281,7 @@ def job_run(
             msg += f" [dim](waiting up to {timeout:.0f}s)[/dim]"
         msg += "..."
         formatter.console.print(msg)
-        if variable_values_id:
-            from rich.markup import escape
-
-            formatter.console.print(
-                f"[dim]Using variable values row: {escape(variable_values_id)}[/dim]"
-            )
-        elif no_variables:
+        if no_variables:
             formatter.console.print("[dim]Skipping variable-values resolution.[/dim]")
 
     try:
@@ -314,6 +311,9 @@ def job_run(
     if formatter.json_mode:
         formatter.output(result)
     else:
+        resolved_id = result.get("resolvedVariableValuesId")
+        if resolved_id:
+            formatter.console.print(f"[dim]Bound variable values row: {escape(resolved_id)}[/dim]")
         job_id = result.get("id", "?")
         status = result.get("status", "unknown")
         if status in ("success", "terminated"):

--- a/src/keboola_agent_cli/commands/lineage.py
+++ b/src/keboola_agent_cli/commands/lineage.py
@@ -158,6 +158,9 @@ def lineage_build(
             formatter.console.print(
                 "  Next: let your AI agent process the tasks, then re-run this command."
             )
+        # Surface warnings (e.g. empty scan) so users notice layout issues.
+        for warning in result.get("warnings", []) or []:
+            formatter.console.print(f"\n[yellow]Warning:[/yellow] {warning}")
         formatter.console.print(f"\n  Saved to: {output}")
 
 

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -226,15 +226,16 @@ def storage_bucket_detail(
 @storage_app.command("tables", rich_help_panel=_TABLES)
 def storage_tables(
     ctx: typer.Context,
-    project: str = typer.Option(
-        ...,
+    project: list[str] | None = typer.Option(
+        None,
         "--project",
-        help="Project alias",
+        help="Project alias (can be repeated for multiple projects). "
+        "Omit to query all connected projects in parallel.",
     ),
     bucket_id: str | None = typer.Option(
         None,
         "--bucket-id",
-        help="Filter tables by bucket ID",
+        help="Filter tables by bucket ID (applied independently per project)",
     ),
     branch: int | None = typer.Option(
         None,
@@ -242,7 +243,12 @@ def storage_tables(
         help="Dev branch ID (defaults to active branch if set via 'branch use')",
     ),
 ) -> None:
-    """List storage tables from a project.
+    """List storage tables from one or more projects.
+
+    Queries all connected projects in parallel by default, matching the
+    behaviour of ``storage buckets``, ``config list``, ``job list``, and other
+    read commands. Each row in the output is tagged with ``project_alias``
+    so results from multiple projects can be distinguished.
 
     Branch handling: this read command uses the production endpoint by
     default, even when a dev branch is active via `branch use`. The
@@ -256,14 +262,30 @@ def storage_tables(
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
     config_store: ConfigStore = ctx.obj["config_store"]
-    # Read command: ignore implicit active dev branch (empty listing trap).
-    _, effective_branch = resolve_branch(
-        config_store, formatter, project, branch, ignore_active_branch=True
-    )
+
+    # --branch requires exactly one --project (branch ID is per-project).
+    # Mirrors the validation used by `storage buckets` and `config list`.
+    if branch is not None and (not project or len(project) != 1):
+        formatter.error(
+            message="--branch requires exactly one --project (branch ID is per-project)",
+            error_code="INVALID_ARGUMENT",
+        )
+        raise typer.Exit(code=2)
+
+    # Resolve active branch only for single-project queries; multi-project
+    # listing intentionally skips active-branch resolution because branches
+    # are per-project state. Read commands use ignore_active_branch=True:
+    # Storage API branch endpoint only returns locally modified tables, so
+    # auto-scoping to the active branch traps users into an empty listing.
+    effective_branch: int | None = branch
+    if branch is None and project and len(project) == 1:
+        _, effective_branch = resolve_branch(
+            config_store, formatter, project[0], None, ignore_active_branch=True
+        )
 
     try:
         result = service.list_tables(
-            alias=project,
+            aliases=project,
             bucket_id=bucket_id,
             branch_id=effective_branch,
         )
@@ -282,27 +304,38 @@ def storage_tables(
         tables = result["tables"]
         if not tables:
             formatter.console.print("[dim]No tables found.[/dim]")
+            emit_project_warnings(formatter, result)
             return
 
-        table = Table(title=f"Tables - {result['project_alias']}")
-        table.add_column("Table ID", style="bold cyan")
-        table.add_column("Rows", justify="right")
-        table.add_column("Size", justify="right", style="dim")
-        table.add_column("Last Import", style="dim")
-
+        # Group by project so multi-project output stays readable.
+        by_project: dict[str, list[dict]] = {}
         for t in tables:
-            size_mb = t["data_size_bytes"] / (1024 * 1024) if t["data_size_bytes"] else 0
-            last_import = t.get("last_import_date", "")
-            if last_import and "T" in last_import:
-                last_import = last_import.split("T")[0]
-            table.add_row(
-                t["id"],
-                str(t["rows_count"]),
-                f"{size_mb:.1f} MB",
-                last_import,
-            )
+            alias = t["project_alias"]
+            by_project.setdefault(alias, []).append(t)
 
-        formatter.console.print(table)
+        for alias, proj_tables in by_project.items():
+            table = Table(title=f"Tables - {alias}")
+            table.add_column("Table ID", style="bold cyan")
+            table.add_column("Rows", justify="right")
+            table.add_column("Size", justify="right", style="dim")
+            table.add_column("Last Import", style="dim")
+
+            for t in proj_tables:
+                size_mb = t["data_size_bytes"] / (1024 * 1024) if t["data_size_bytes"] else 0
+                last_import = t.get("last_import_date", "")
+                if last_import and "T" in last_import:
+                    last_import = last_import.split("T")[0]
+                table.add_row(
+                    t["id"],
+                    str(t["rows_count"]),
+                    f"{size_mb:.1f} MB",
+                    last_import,
+                )
+
+            formatter.console.print(table)
+            formatter.console.print()
+
+        emit_project_warnings(formatter, result)
 
 
 @storage_app.command("table-detail", rich_help_panel=_TABLES)

--- a/src/keboola_agent_cli/commands/storage.py
+++ b/src/keboola_agent_cli/commands/storage.py
@@ -53,6 +53,12 @@ def storage_buckets(
     Shows which buckets are linked from other projects, including the
     source project ID and name. This information is not available via
     MCP tools.
+
+    Branch handling: this read command uses the production endpoint by
+    default, even when a dev branch is active via `branch use`. The
+    Storage API branch-scoped endpoint only returns locally-modified
+    buckets, so a fresh dev branch lists nothing. Pass --branch to query
+    a dev branch explicitly.
     """
     if should_hint(ctx):
         emit_hint(ctx, "storage.buckets", project=project, branch=branch)
@@ -69,10 +75,16 @@ def storage_buckets(
         )
         raise typer.Exit(code=2)
 
-    # Resolve active branch for single-project queries
+    # Resolve active branch for single-project queries.
+    # Storage read commands ignore the implicit active dev branch: the
+    # Storage API branch-scoped endpoint returns only locally-modified
+    # buckets, which for a freshly created dev branch is an empty set.
+    # Explicit --branch still wins.
     effective_branch: int | None = branch
     if branch is None and project and len(project) == 1:
-        _, effective_branch = resolve_branch(config_store, formatter, project[0], None)
+        _, effective_branch = resolve_branch(
+            config_store, formatter, project[0], None, ignore_active_branch=True
+        )
 
     try:
         result = service.list_buckets(aliases=project, branch_id=effective_branch)
@@ -151,7 +163,10 @@ def storage_bucket_detail(
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
     config_store: ConfigStore = ctx.obj["config_store"]
-    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+    # Read command: ignore implicit active dev branch (empty listing trap).
+    _, effective_branch = resolve_branch(
+        config_store, formatter, project, branch, ignore_active_branch=True
+    )
 
     try:
         result = service.get_bucket_detail(
@@ -227,14 +242,24 @@ def storage_tables(
         help="Dev branch ID (defaults to active branch if set via 'branch use')",
     ),
 ) -> None:
-    """List storage tables from a project."""
+    """List storage tables from a project.
+
+    Branch handling: this read command uses the production endpoint by
+    default, even when a dev branch is active via `branch use`. The
+    Storage API branch-scoped endpoint only returns tables that were
+    locally modified in the dev branch, so a fresh dev branch lists
+    nothing. Pass --branch to query a dev branch explicitly.
+    """
     if should_hint(ctx):
         emit_hint(ctx, "storage.tables", project=project, bucket_id=bucket_id, branch=branch)
 
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
     config_store: ConfigStore = ctx.obj["config_store"]
-    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+    # Read command: ignore implicit active dev branch (empty listing trap).
+    _, effective_branch = resolve_branch(
+        config_store, formatter, project, branch, ignore_active_branch=True
+    )
 
     try:
         result = service.list_tables(
@@ -306,7 +331,10 @@ def storage_table_detail(
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
     config_store: ConfigStore = ctx.obj["config_store"]
-    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+    # Read command: ignore implicit active dev branch (empty listing trap).
+    _, effective_branch = resolve_branch(
+        config_store, formatter, project, branch, ignore_active_branch=True
+    )
 
     try:
         result = service.get_table_detail(
@@ -1152,7 +1180,10 @@ def storage_file_list(
     formatter = get_formatter(ctx)
     service = get_service(ctx, "storage_service")
     config_store: ConfigStore = ctx.obj["config_store"]
-    _, effective_branch = resolve_branch(config_store, formatter, project, branch)
+    # Read command: ignore implicit active dev branch (empty listing trap).
+    _, effective_branch = resolve_branch(
+        config_store, formatter, project, branch, ignore_active_branch=True
+    )
 
     try:
         result = service.list_files(

--- a/src/keboola_agent_cli/hints/definitions/job.py
+++ b/src/keboola_agent_cli/hints/definitions/job.py
@@ -85,6 +85,7 @@ HintRegistry.register(
                     args={
                         "component_id": "{component_id}",
                         "config_id": "{config_id}",
+                        "branch_id": "{branch}",
                     },
                     result_var="detail",
                     result_hint="dict",
@@ -97,6 +98,7 @@ HintRegistry.register(
                     args={
                         "component_id": '"keboola.variables"',
                         "config_id": 'detail["configuration"]["variables_id"]',
+                        "branch_id": "{branch}",
                     },
                     result_var="var_rows",
                     result_hint="list",
@@ -110,6 +112,7 @@ HintRegistry.register(
                         "component_id": "{component_id}",
                         "config_id": "{config_id}",
                         "config_row_ids": "{row_id}",
+                        "branch_id": "{branch}",
                         "variable_values_id": 'var_rows[0]["id"] if var_rows else None',
                     },
                     result_var="job",

--- a/src/keboola_agent_cli/hints/definitions/storage.py
+++ b/src/keboola_agent_cli/hints/definitions/storage.py
@@ -139,7 +139,7 @@ HintRegistry.register(
 HintRegistry.register(
     CommandHint(
         cli_command="storage.tables",
-        description="List tables in a project",
+        description="List tables in one or more projects",
         steps=[
             HintStep(
                 comment="List tables",
@@ -158,7 +158,7 @@ HintRegistry.register(
                     service_module="storage_service",
                     method="list_tables",
                     args={
-                        "alias": "{project}",
+                        "aliases": "{project}",
                         "bucket_id": "{bucket_id}",
                         "branch_id": "{branch}",
                     },

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -721,13 +721,20 @@ class ConfigService(BaseService):
         component_id: str | None = None,
         branch_id: int | None = None,
     ) -> tuple[str, dict[str, Any], bool] | tuple[str, dict[str, str]]:
-        """Search configs in a single project (worker thread)."""
+        """Search configs in a single project (worker thread).
+
+        Uses ``list_components_with_configs`` (``include=configuration,rows``)
+        so that row-level configuration (Snowflake writer rows, DB extractor
+        tables, Google Sheets sheets, etc.) is included in the search tree.
+        Without ``rows``, the API returns only the top-level configuration
+        body, and searches for row-only properties always miss (see #196).
+        """
         client = self._client_factory(project.stack_url, project.token)
         try:
             effective_branch_id = branch_id or project.active_branch_id
-            components = client.list_components(
-                component_type=component_type,
+            components = client.list_components_with_configs(
                 branch_id=effective_branch_id,
+                component_type=component_type,
             )
             matches: list[dict[str, Any]] = []
             configs_searched = 0

--- a/src/keboola_agent_cli/services/deep_lineage_service.py
+++ b/src/keboola_agent_cli/services/deep_lineage_service.py
@@ -375,17 +375,39 @@ class DeepLineageService:
         if present. Use generate_ai_tasks=True to write a task file
         for the AI agent to process.
 
+        Supports both sync layouts:
+          - Flat (``sync pull --project X``): ``root/.keboola/manifest.json``
+          - Nested (``sync pull --all-projects``): ``root/<alias>/.keboola/manifest.json``
+
         Args:
-            root: Root directory containing sync'd project subdirectories.
+            root: Root directory containing sync'd project data. Can be either
+                the project directory itself (flat layout) or a parent directory
+                with one subdirectory per project (nested layout).
             generate_ai_tasks: If True, write .lineage_ai_tasks.json for AI.
 
         Returns:
-            Dict with lineage graph data, summary, and ai_status.
+            Dict with lineage graph data, summary, ai_status, and ``warnings``
+            (list of human-readable warnings emitted during the build, e.g. when
+            no sync'd projects were found).
         """
         project_id_to_alias = self._build_project_map()
+        warnings: list[str] = []
 
         # Phase 1: Scan
         graph = self._scan_projects(root, project_id_to_alias)
+
+        # Empty-scan warning -- most often caused by a layout mismatch between
+        # ``sync pull --project X`` (flat) and ``sync pull --all-projects`` (nested).
+        if not graph.tables and not graph.configurations:
+            warning = (
+                f"No synced projects found in {root}. Expected either:\n"
+                f"  - {root}/.keboola/manifest.json (single-project flat layout), or\n"
+                f"  - {root}/<alias>/.keboola/manifest.json (multi-project nested layout)\n"
+                "Hint: run 'kbagent sync pull --all-projects' or pass --directory "
+                "pointing to the parent of your synced projects."
+            )
+            warnings.append(warning)
+            logger.warning(warning)
 
         # Phase 2: Deterministic edges
         self._build_deterministic_edges(graph, project_id_to_alias)
@@ -403,6 +425,7 @@ class DeepLineageService:
 
         result = graph.to_dict()
         result["ai_status"] = ai_status
+        result["warnings"] = warnings
         return result
 
     def build_and_cache(
@@ -480,53 +503,99 @@ class DeepLineageService:
         return mapping
 
     def _scan_projects(self, root: Path, project_id_to_alias: dict[int, str]) -> LineageGraph:
-        """Scan all sync'd projects and build initial graph."""
+        """Scan all sync'd projects and build initial graph.
+
+        Supports two directory layouts (written by ``kbagent sync pull``):
+          - **Flat** (``sync pull --project X``): manifest lives directly at
+            ``root/.keboola/manifest.json`` and ``root`` itself *is* the project.
+          - **Nested** (``sync pull --all-projects``): each project is a
+            subdirectory, i.e. ``root/<alias>/.keboola/manifest.json``.
+
+        Flat layout is detected first and, when present, returned exclusively
+        (nested iteration would be redundant -- in the flat case there are no
+        sibling project directories under ``root``).
+        """
         graph = LineageGraph()
 
-        for project_dir in sorted(root.iterdir()):
-            if not project_dir.is_dir() or project_dir.name.startswith("."):
-                continue
-            manifest_path = project_dir / ".keboola" / "manifest.json"
-            if not manifest_path.exists():
-                continue
-
-            with open(manifest_path) as f:
-                manifest = json.load(f)
-
-            project_alias = project_dir.name
-            project_id = manifest.get("project", {}).get("id", 0)
-            project_id_to_alias[project_id] = project_alias
-
-            # Scan storage tables
-            storage_dir = project_dir / "storage" / "tables"
-            if storage_dir.exists():
-                for bucket_dir in sorted(storage_dir.iterdir()):
-                    if not bucket_dir.is_dir():
-                        continue
-                    for table_file in sorted(bucket_dir.glob("*.json")):
-                        with open(table_file) as f:
-                            meta = json.load(f)
-                        table = Table(
-                            table_id=meta["id"],
-                            project_alias=project_alias,
-                            project_id=project_id,
-                            bucket_id=meta["id"].rsplit(".", 1)[0],
-                            name=meta["name"],
-                            columns=meta.get("columns", []),
-                            primary_key=meta.get("primary_key", []),
-                            rows_count=meta.get("rows_count", 0),
-                        )
-                        graph.tables[table.fqn] = table
-
-            # Scan configurations
-            for config_entry in manifest.get("configurations", []):
-                self._scan_configuration(
-                    project_dir, config_entry, project_alias, project_id, graph
-                )
+        flat_manifest = root / ".keboola" / "manifest.json"
+        if flat_manifest.exists():
+            project_alias = self._resolve_alias_from_manifest(flat_manifest, fallback=root.name)
+            self._scan_one_project(root, project_alias, project_id_to_alias, graph)
+        else:
+            for project_dir in sorted(root.iterdir()):
+                if not project_dir.is_dir() or project_dir.name.startswith("."):
+                    continue
+                manifest_path = project_dir / ".keboola" / "manifest.json"
+                if not manifest_path.exists():
+                    continue
+                self._scan_one_project(project_dir, project_dir.name, project_id_to_alias, graph)
 
         # Store mapping for cross-project resolution
         graph._project_id_to_alias = project_id_to_alias  # type: ignore[attr-defined]
         return graph
+
+    def _resolve_alias_from_manifest(self, manifest_path: Path, *, fallback: str) -> str:
+        """Resolve a project alias for a flat-layout root.
+
+        In a flat layout the parent directory name is meaningless (it's the
+        user's CWD, not the project alias). We prefer the alias configured in
+        ``ConfigStore`` for the project id recorded in the manifest; if no such
+        mapping exists, we fall back to the directory name so the graph stays
+        consistent but still disambiguated from other projects on disk.
+        """
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+            project_id = int(manifest.get("project", {}).get("id", 0) or 0)
+        except (OSError, json.JSONDecodeError, ValueError):
+            return fallback
+
+        if project_id:
+            app_config = self._config_store.load()
+            for alias, project in app_config.projects.items():
+                if project.project_id == project_id:
+                    return alias
+        return fallback
+
+    def _scan_one_project(
+        self,
+        project_dir: Path,
+        project_alias: str,
+        project_id_to_alias: dict[int, str],
+        graph: LineageGraph,
+    ) -> None:
+        """Populate ``graph`` with tables and configs from a single project dir."""
+        manifest_path = project_dir / ".keboola" / "manifest.json"
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+
+        project_id = manifest.get("project", {}).get("id", 0)
+        project_id_to_alias[project_id] = project_alias
+
+        # Scan storage tables
+        storage_dir = project_dir / "storage" / "tables"
+        if storage_dir.exists():
+            for bucket_dir in sorted(storage_dir.iterdir()):
+                if not bucket_dir.is_dir():
+                    continue
+                for table_file in sorted(bucket_dir.glob("*.json")):
+                    with open(table_file) as f:
+                        meta = json.load(f)
+                    table = Table(
+                        table_id=meta["id"],
+                        project_alias=project_alias,
+                        project_id=project_id,
+                        bucket_id=meta["id"].rsplit(".", 1)[0],
+                        name=meta["name"],
+                        columns=meta.get("columns", []),
+                        primary_key=meta.get("primary_key", []),
+                        rows_count=meta.get("rows_count", 0),
+                    )
+                    graph.tables[table.fqn] = table
+
+        # Scan configurations
+        for config_entry in manifest.get("configurations", []):
+            self._scan_configuration(project_dir, config_entry, project_alias, project_id, graph)
 
     def _scan_configuration(
         self,

--- a/src/keboola_agent_cli/services/job_service.py
+++ b/src/keboola_agent_cli/services/job_service.py
@@ -281,11 +281,9 @@ class JobService(BaseService):
                 error_code="NO_VARIABLE_ROWS",
             )
 
-        # Defense against a malformed Storage API response: a row without a
-        # usable `id` would otherwise be returned as `""`, which the client
-        # treats as "omit from Queue body" -- silently running the job with
-        # empty variable bindings. Fail loud instead (same silent-skip class
-        # as the PR1 encryption asymmetry bug).
+        # A row without a usable `id` would otherwise coerce to `""`, which
+        # the HTTP client treats as "omit from Queue body" -- silently
+        # submitting a job with empty variable bindings. Fail loud instead.
         first_row = rows[0] if isinstance(rows[0], dict) else {}
         first_row_id = first_row.get("id")
         if not first_row_id:

--- a/src/keboola_agent_cli/services/storage_service.py
+++ b/src/keboola_agent_cli/services/storage_service.py
@@ -291,47 +291,59 @@ class StorageService(BaseService):
 
     def list_tables(
         self,
-        alias: str,
+        aliases: list[str] | None = None,
         bucket_id: str | None = None,
         branch_id: int | None = None,
     ) -> dict[str, Any]:
-        """List tables from a project, optionally filtered by bucket.
+        """List tables from one or more projects (in parallel).
+
+        When ``bucket_id`` is specified with multiple projects, the filter is
+        applied independently in each project -- a missing bucket in a given
+        project is recorded as a per-project error without aborting the others.
 
         Args:
-            alias: Project alias.
-            bucket_id: Optional bucket ID filter.
-            branch_id: If set, target a specific dev branch.
+            aliases: Project aliases to query. If None, queries all.
+            bucket_id: Optional bucket ID filter applied per project.
+            branch_id: If set, target a specific dev branch
+                (only valid with a single project).
 
         Returns:
-            Dict with 'tables' list.
+            Dict with 'tables' list (each row tagged with ``project_alias``)
+            and 'errors' list (per-project failures).
         """
-        projects = self.resolve_projects([alias])
-        project = projects[alias]
+        projects = self.resolve_projects(aliases)
 
-        client = self._client_factory(project.stack_url, project.token)
-        try:
-            raw_tables = client.list_tables(bucket_id=bucket_id, branch_id=branch_id)
-        finally:
-            client.close()
+        def _worker(alias: str, project: ProjectConfig) -> tuple[str, list[dict[str, Any]], bool]:
+            return self._fetch_tables(
+                alias,
+                project,
+                bucket_id=bucket_id,
+                branch_id=branch_id,
+            )
 
-        tables = [
-            {
-                "project_alias": alias,
-                "id": t.get("id", ""),
-                "name": t.get("name", ""),
-                "display_name": t.get("displayName", t.get("name", "")),
-                "bucket_id": t.get("bucket", {}).get("id", "")
-                if isinstance(t.get("bucket"), dict)
-                else "",
-                "rows_count": t.get("rowsCount", 0),
-                "data_size_bytes": t.get("dataSizeBytes", 0),
-                "is_alias": t.get("isAlias", False),
-                "last_import_date": t.get("lastImportDate", ""),
-            }
-            for t in raw_tables
-        ]
+        successes, errors = self._run_parallel(projects, _worker)
 
-        return {"tables": tables, "project_alias": alias}
+        tables: list[dict[str, Any]] = []
+        for result in successes:
+            alias = result[0]
+            for t in result[1]:
+                tables.append(
+                    {
+                        "project_alias": alias,
+                        "id": t.get("id", ""),
+                        "name": t.get("name", ""),
+                        "display_name": t.get("displayName", t.get("name", "")),
+                        "bucket_id": t.get("bucket", {}).get("id", "")
+                        if isinstance(t.get("bucket"), dict)
+                        else "",
+                        "rows_count": t.get("rowsCount", 0),
+                        "data_size_bytes": t.get("dataSizeBytes", 0),
+                        "is_alias": t.get("isAlias", False),
+                        "last_import_date": t.get("lastImportDate", ""),
+                    }
+                )
+
+        return {"tables": tables, "errors": errors}
 
     # ------------------------------------------------------------------
     # Write operations
@@ -1462,6 +1474,36 @@ class StorageService(BaseService):
         try:
             buckets = client.list_buckets(include="linkedBuckets", branch_id=branch_id)
             return (alias, buckets, True)
+        except KeboolaApiError as exc:
+            return (
+                alias,
+                {
+                    "project_alias": alias,
+                    "error_code": exc.error_code,
+                    "message": exc.message,
+                },
+            )
+        finally:
+            client.close()
+
+    def _fetch_tables(
+        self,
+        alias: str,
+        project: ProjectConfig,
+        bucket_id: str | None = None,
+        branch_id: int | None = None,
+    ) -> tuple[str, list[dict[str, Any]], bool]:
+        """Fetch tables for a single project (worker for _run_parallel).
+
+        Per-project failures (e.g. bucket not found in this project, invalid
+        token) are returned as error tuples so other projects still complete.
+        """
+        from ..errors import KeboolaApiError
+
+        client = self._client_factory(project.stack_url, project.token)
+        try:
+            tables = client.list_tables(bucket_id=bucket_id, branch_id=branch_id)
+            return (alias, tables, True)
         except KeboolaApiError as exc:
             return (
                 alias,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2331,6 +2331,9 @@ class TestJobRun:
         kwargs = job_service.run_job.call_args.kwargs
         assert kwargs["no_variables"] is True
         assert kwargs["variable_values_id"] is None
+        # resolvedVariableValuesId must be absent when resolution was skipped.
+        payload = json.loads(result.output).get("data", {})
+        assert "resolvedVariableValuesId" not in payload
 
     def test_job_run_mutually_exclusive_flags_rejected(self, tmp_path: Path) -> None:
         """--variable-values-id + --no-variables is an invalid combination (exit 2)."""
@@ -2380,8 +2383,7 @@ class TestJobRun:
 
         Locks the fail-loud contract: an empty string must not fall through
         to create_job(variable_values_id="") where it would silently be
-        omitted from the Queue body (same silent-skip class as the PR1
-        encryption asymmetry).
+        omitted from the Queue body.
         """
         config_dir = tmp_path / "config"
         config_dir.mkdir()
@@ -2510,6 +2512,92 @@ class TestJobRun:
 
         assert result.exit_code != 0
         assert "NO_VARIABLE_ROWS" in result.output
+
+    def test_job_run_rich_mode_echoes_resolved_values_id(self, tmp_path: Path) -> None:
+        """Rich (non-JSON) output echoes ``resolvedVariableValuesId`` so auto-resolve is visible."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = _setup_config_test(
+            config_dir,
+            {"prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"}},
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.run_job.return_value = {
+                "id": 800,
+                "status": "waiting",
+                "resolvedVariableValuesId": "row-auto-resolved",
+            }
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "job",
+                    "run",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.snowflake-transformation",
+                    "--config-id",
+                    "100",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "row-auto-resolved" in result.output
+        assert "Bound variable values row" in result.output
+
+    def test_job_run_strips_whitespace_around_variable_values_id(self, tmp_path: Path) -> None:
+        """`--variable-values-id '  row-1  '` is trimmed before reaching the service."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        store = _setup_config_test(
+            config_dir,
+            {"prod": {"token": "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"}},
+        )
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+            patch("keboola_agent_cli.cli.JobService") as MockJobService,
+        ):
+            MockStore.return_value = store
+            job_service = MagicMock()
+            job_service.run_job.return_value = {"id": 801, "status": "waiting"}
+            MockJobService.return_value = job_service
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(config_store=store)
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "job",
+                    "run",
+                    "--project",
+                    "prod",
+                    "--component-id",
+                    "keboola.snowflake-transformation",
+                    "--config-id",
+                    "100",
+                    "--variable-values-id",
+                    "  row-trimmed  ",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert job_service.run_job.call_args.kwargs["variable_values_id"] == "row-trimmed"
 
 
 class TestJobTerminate:

--- a/tests/test_config_search.py
+++ b/tests/test_config_search.py
@@ -12,9 +12,13 @@ from keboola_agent_cli.services.config_service import ConfigService, _find_match
 
 
 def _make_list_components_client(components: list[dict]) -> MagicMock:
-    """Create a mock KeboolaClient with list_components returning given data."""
+    """Create a mock KeboolaClient with list_components_with_configs returning given data.
+
+    ConfigService.search_configs uses ``list_components_with_configs`` (which
+    issues ``include=configuration,rows``) so we mock that method.
+    """
     mock_client = MagicMock()
-    mock_client.list_components.return_value = components
+    mock_client.list_components_with_configs.return_value = components
     return mock_client
 
 
@@ -342,7 +346,135 @@ class TestSearchConfigs:
         for m in matches:
             assert m["component_type"] == "extractor"
 
-        # The client was called with the component_type filter
-        mock_client.list_components.assert_called_once_with(
-            component_type="extractor", branch_id=None
+        # The client was called with the component_type filter and rows included
+        mock_client.list_components_with_configs.assert_called_once_with(
+            branch_id=None, component_type="extractor"
+        )
+
+
+# ===========================================================================
+# Regression tests for issue #196 -- search must look inside rows[]
+# ===========================================================================
+
+
+# Sample data that mirrors how real row-based components (Snowflake writer,
+# DB extractors, Google Sheets, etc.) store per-item configuration under
+# ``rows[].configuration``. Top-level ``configuration`` is intentionally
+# minimal -- the interesting properties live inside rows.
+SAMPLE_COMPONENTS_WITH_ROWS = [
+    {
+        "id": "keboola.wr-db-snowflake",
+        "name": "Snowflake Writer",
+        "type": "writer",
+        "configurations": [
+            {
+                "id": "900",
+                "name": "Write to DWH",
+                "description": "Writer with per-table rows",
+                "configuration": {
+                    "parameters": {
+                        "db": {"host": "dwh.snowflakecomputing.com"},
+                    }
+                },
+                "rows": [
+                    {
+                        "id": "900-row-1",
+                        "name": "customers table",
+                        "configuration": {
+                            "parameters": {
+                                "dbName": "CUSTOMERS",
+                                "incremental": False,
+                                "primaryKey": ["id"],
+                            }
+                        },
+                    },
+                    {
+                        "id": "900-row-2",
+                        "name": "orders table",
+                        "configuration": {
+                            "parameters": {
+                                "dbName": "ORDERS",
+                                "incremental": True,
+                                "primaryKey": ["order_id"],
+                            }
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+]
+
+
+class TestSearchConfigsRowsCoverage:
+    """Regression tests ensuring ``config search`` also inspects ``rows[]``.
+
+    Before #196, the service only fetched ``include=configuration`` so row-level
+    properties were invisible to the search even though the command's help text
+    promised coverage of "row definitions".
+    """
+
+    def test_search_matches_row_configuration(self, tmp_config_dir: Path) -> None:
+        """A property that only exists in ``rows[].configuration`` is found."""
+        store = setup_single_project(tmp_config_dir)
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_WITH_ROWS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        # "CUSTOMERS" appears only inside rows[0].configuration.parameters.dbName
+        result = service.search_configs(query="CUSTOMERS")
+
+        assert result["errors"] == []
+        matches = result["matches"]
+        assert len(matches) == 1
+        assert matches[0]["component_id"] == "keboola.wr-db-snowflake"
+        assert matches[0]["config_id"] == "900"
+
+        # The match path must point inside rows[0]
+        assert any(
+            loc.startswith("rows[0].configuration") and "dbName" in loc
+            for loc in matches[0]["match_locations"]
+        )
+
+    def test_search_matches_boolean_inside_row(self, tmp_config_dir: Path) -> None:
+        """Scalar values (booleans) inside rows are matched as strings.
+
+        This mirrors the exact query from issue #196 where users searched for
+        ``"incremental": false`` to audit writer configurations.
+        """
+        store = setup_single_project(tmp_config_dir)
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_WITH_ROWS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        # The recursive walker stringifies booleans; case-insensitive matches "False"
+        result = service.search_configs(query="false", ignore_case=True)
+
+        matches = result["matches"]
+        assert len(matches) == 1
+        incremental_paths = [
+            loc for loc in matches[0]["match_locations"] if loc.endswith("incremental")
+        ]
+        # Only row-1 has incremental=False; row-2 has incremental=True
+        assert incremental_paths == ["rows[0].configuration.parameters.incremental"]
+
+    def test_search_client_receives_rows_include(self, tmp_config_dir: Path) -> None:
+        """Service must call ``list_components_with_configs`` (include=rows)."""
+        store = setup_single_project(tmp_config_dir)
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_WITH_ROWS)
+        service = ConfigService(
+            config_store=store,
+            client_factory=lambda url, token: mock_client,
+        )
+
+        service.search_configs(query="anything")
+
+        # The old ``list_components`` (include=configuration only) must NOT be used.
+        mock_client.list_components.assert_not_called()
+        mock_client.list_components_with_configs.assert_called_once_with(
+            branch_id=None, component_type=None
         )

--- a/tests/test_config_search_cli.py
+++ b/tests/test_config_search_cli.py
@@ -93,9 +93,14 @@ def _setup_config_store(config_dir: Path, projects: dict[str, dict] | None = Non
 
 
 def _make_list_components_client(components: list[dict]) -> MagicMock:
-    """Create a mock KeboolaClient with list_components returning given data."""
+    """Create a mock KeboolaClient with list_components_with_configs returning given data.
+
+    ``ConfigService.search_configs`` now uses ``list_components_with_configs``
+    (``include=configuration,rows``) so that row-level configuration is part
+    of the search tree -- see issue #196.
+    """
     mock_client = MagicMock()
-    mock_client.list_components.return_value = components
+    mock_client.list_components_with_configs.return_value = components
     return mock_client
 
 
@@ -315,3 +320,75 @@ class TestConfigSearch:
         output = json.loads(result.output)
         assert output["status"] == "error"
         assert output["error"]["code"] == "CONFIG_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Row-level search regression (issue #196)
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_COMPONENTS_WITH_ROWS = [
+    {
+        "id": "keboola.wr-db-snowflake",
+        "name": "Snowflake Writer",
+        "type": "writer",
+        "configurations": [
+            {
+                "id": "555",
+                "name": "Warehouse Writer",
+                "description": "Per-table row configs",
+                "configuration": {"parameters": {"db": {"host": "dwh.example.com"}}},
+                "rows": [
+                    {
+                        "id": "555-row-1",
+                        "name": "customers",
+                        "configuration": {
+                            "parameters": {
+                                "dbName": "CUSTOMERS",
+                                "incremental": False,
+                            }
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+]
+
+
+class TestConfigSearchRows:
+    """End-to-end CLI coverage of the row-level search fix (issue #196)."""
+
+    def test_search_finds_property_inside_row(self, tmp_path: Path) -> None:
+        """`kbagent config search --query CUSTOMERS` returns the row match."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        mock_client = _make_list_components_client(SAMPLE_COMPONENTS_WITH_ROWS)
+        store = _setup_config_store(config_dir, {"prod": {"token": TEST_TOKEN}})
+
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.ProjectService") as MockProjService,
+            patch("keboola_agent_cli.cli.ConfigService") as MockCfgService,
+        ):
+            MockStore.return_value = store
+            MockProjService.return_value = ProjectService(config_store=store)
+            MockCfgService.return_value = ConfigService(
+                config_store=store,
+                client_factory=lambda url, token: mock_client,
+            )
+
+            result = runner.invoke(
+                app,
+                ["--json", "config", "search", "--query", "CUSTOMERS"],
+            )
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        data = output["data"]
+        assert data["stats"]["matches_found"] == 1
+        match = data["matches"][0]
+        assert match["config_id"] == "555"
+        assert any(loc.startswith("rows[0].configuration") for loc in match["match_locations"])

--- a/tests/test_deep_lineage_service.py
+++ b/tests/test_deep_lineage_service.py
@@ -605,3 +605,256 @@ class TestLineageDeepCli:
             ],
         )
         assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Sync layout handling: flat (single project in CWD) vs. nested (multi-project)
+# ---------------------------------------------------------------------------
+
+
+def _create_flat_project(
+    root: Path,
+    *,
+    project_id: int = 42,
+    with_storage: bool = True,
+    with_config: bool = True,
+) -> None:
+    """Create a single-project flat layout directly under ``root``.
+
+    This mirrors what ``kbagent sync pull --project X`` produces: the
+    ``.keboola/manifest.json`` lives at the provided root (no alias subdir).
+    """
+    keboola = root / ".keboola"
+    keboola.mkdir(parents=True)
+    configurations: list[dict] = []
+    if with_config:
+        configurations.append(
+            {
+                "branchId": 1,
+                "componentId": "keboola.snowflake-transformation",
+                "id": "cfg-flat",
+                "path": "transformation/keboola.snowflake-transformation/flat-transform",
+                "rows": [],
+            }
+        )
+    manifest = {
+        "version": 2,
+        "project": {"id": project_id, "name": "Flat Project"},
+        "configurations": configurations,
+        "branches": [],
+    }
+    (keboola / "manifest.json").write_text(json.dumps(manifest))
+
+    if with_storage:
+        storage = root / "storage" / "tables" / "in-c-flat"
+        storage.mkdir(parents=True)
+        (storage / "accounts.json").write_text(
+            json.dumps(
+                {
+                    "id": "in.c-flat.accounts",
+                    "name": "accounts",
+                    "columns": ["id", "name"],
+                    "primary_key": ["id"],
+                    "rows_count": 10,
+                }
+            )
+        )
+
+    if with_config:
+        transform_dir = (
+            root / "main" / "transformation" / "keboola.snowflake-transformation" / "flat-transform"
+        )
+        transform_dir.mkdir(parents=True)
+        (transform_dir / "_config.yml").write_text(
+            yaml.dump(
+                {
+                    "version": 2,
+                    "name": "Flat Transform",
+                    "input": {
+                        "tables": [
+                            {"source": "in.c-flat.accounts", "destination": "accounts"},
+                        ]
+                    },
+                    "output": {"tables": []},
+                }
+            )
+        )
+        (transform_dir / "transform.sql").write_text('SELECT * FROM "in.c-flat"."accounts"\n')
+
+
+class TestDeepLineageLayouts:
+    """Covers the flat vs. nested sync-layout detection in ``_scan_projects``."""
+
+    def test_flat_layout_detects_single_project(self, tmp_path: Path) -> None:
+        """``root/.keboola/manifest.json`` is treated as a single project."""
+        root = tmp_path / "synced-foo"
+        root.mkdir()
+        _create_flat_project(root)
+
+        store = ConfigStore(config_dir=tmp_path / "cfg")
+        (tmp_path / "cfg").mkdir()
+        service = DeepLineageService(config_store=store)
+
+        with patch.object(service, "_add_cross_project_lineage"):
+            result = service.build_lineage(root)
+
+        assert result["summary"]["tables"] == 1
+        assert result["summary"]["configurations"] == 1
+        # Edges: input_mapping + sql_tokenizer (table referenced in SQL)
+        assert result["summary"]["edges"] >= 1
+        assert result["warnings"] == []
+
+    def test_flat_layout_uses_config_store_alias_when_available(self, tmp_path: Path) -> None:
+        """In flat mode the alias comes from ConfigStore, not the CWD name."""
+        from keboola_agent_cli.models import AppConfig, ProjectConfig
+
+        root = tmp_path / "some-random-cwd"
+        root.mkdir()
+        _create_flat_project(root, project_id=77)
+
+        cfg_dir = tmp_path / "cfg"
+        cfg_dir.mkdir()
+        store = ConfigStore(config_dir=cfg_dir)
+        config = AppConfig()
+        config.projects["prod"] = ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token="test-token",
+            project_id=77,
+        )
+        store.save(config)
+
+        service = DeepLineageService(config_store=store)
+        with patch.object(service, "_add_cross_project_lineage"):
+            result = service.build_lineage(root)
+
+        # Exactly one table keyed by the ConfigStore alias, not by dir name.
+        assert list(result["tables"].keys()) == ["prod:in.c-flat.accounts"]
+
+    def test_flat_layout_falls_back_to_dir_name_without_config_store_match(
+        self, tmp_path: Path
+    ) -> None:
+        """If no alias matches ``project.id`` we keep the directory name."""
+        root = tmp_path / "my-alias"
+        root.mkdir()
+        _create_flat_project(root, project_id=999)
+
+        cfg_dir = tmp_path / "cfg"
+        cfg_dir.mkdir()
+        store = ConfigStore(config_dir=cfg_dir)  # empty store
+        service = DeepLineageService(config_store=store)
+
+        with patch.object(service, "_add_cross_project_lineage"):
+            result = service.build_lineage(root)
+
+        assert list(result["tables"].keys()) == ["my-alias:in.c-flat.accounts"]
+
+    def test_nested_layout_still_works(self, tmp_path: Path) -> None:
+        """Regression guard: nested ``sync pull --all-projects`` layout."""
+        root = _create_sync_tree(tmp_path)  # nested layout helper
+        store = ConfigStore(config_dir=tmp_path / "cfg")
+        (tmp_path / "cfg").mkdir()
+        service = DeepLineageService(config_store=store)
+
+        with patch.object(service, "_add_cross_project_lineage"):
+            result = service.build_lineage(root)
+
+        assert result["summary"]["tables"] == 2
+        assert result["summary"]["configurations"] == 2
+        assert result["warnings"] == []
+
+    def test_empty_directory_emits_warning(self, tmp_path: Path) -> None:
+        """Neither flat nor nested layout -> zero-scan + hint warning."""
+        root = tmp_path / "empty"
+        root.mkdir()
+        store = ConfigStore(config_dir=tmp_path / "cfg")
+        (tmp_path / "cfg").mkdir()
+        service = DeepLineageService(config_store=store)
+
+        with patch.object(service, "_add_cross_project_lineage"):
+            result = service.build_lineage(root)
+
+        assert result["summary"]["tables"] == 0
+        assert result["summary"]["configurations"] == 0
+        assert len(result["warnings"]) == 1
+        warning = result["warnings"][0]
+        assert "No synced projects found" in warning
+        assert "flat layout" in warning
+        assert "nested layout" in warning
+        assert "sync pull --all-projects" in warning
+
+
+class TestLineageBuildCli:
+    """CLI-layer smoke tests for the flat/empty layouts."""
+
+    def _runner(self):
+        return __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+
+    def test_build_flat_layout_non_empty_graph(self, tmp_path: Path) -> None:
+        """``lineage build`` against a flat-layout dir produces a non-empty graph."""
+        from keboola_agent_cli.cli import app
+
+        # Place synced project next to cfg dir so cwd doesn't matter.
+        synced = tmp_path / "synced"
+        synced.mkdir()
+        _create_flat_project(synced)
+        cache_path = tmp_path / "lineage.json"
+
+        with patch(
+            "keboola_agent_cli.services.deep_lineage_service."
+            "DeepLineageService._add_cross_project_lineage"
+        ):
+            result = self._runner().invoke(
+                app,
+                [
+                    "--json",
+                    "--config-dir",
+                    str(tmp_path / "cfg"),
+                    "lineage",
+                    "build",
+                    "--directory",
+                    str(synced),
+                    "--output",
+                    str(cache_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)["data"]
+        assert data["summary"]["tables"] == 1
+        assert data["summary"]["configurations"] == 1
+        assert data["warnings"] == []
+        assert cache_path.exists()
+
+    def test_build_empty_directory_exits_zero_with_warning(self, tmp_path: Path) -> None:
+        """Empty dir -> exit 0 with a warning describing the expected layouts."""
+        from keboola_agent_cli.cli import app
+
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        cache_path = tmp_path / "lineage.json"
+
+        with patch(
+            "keboola_agent_cli.services.deep_lineage_service."
+            "DeepLineageService._add_cross_project_lineage"
+        ):
+            result = self._runner().invoke(
+                app,
+                [
+                    "--json",
+                    "--config-dir",
+                    str(tmp_path / "cfg"),
+                    "lineage",
+                    "build",
+                    "--directory",
+                    str(empty),
+                    "--output",
+                    str(cache_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)["data"]
+        assert data["summary"]["tables"] == 0
+        assert len(data["warnings"]) == 1
+        assert "No synced projects found" in data["warnings"][0]
+        assert cache_path.exists()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3069,7 +3069,7 @@ class TestE2EToolCommands:
 
 
 # ---------------------------------------------------------------------------
-# Job run variable values resolution (PR2 / P0-2)
+# Job run variable values resolution
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -227,3 +227,148 @@ class TestResolveBranch:
         project, branch_id = resolve_branch(store, formatter, "prod", None)
         assert project == "prod"
         assert branch_id is None
+
+    def test_ignore_active_branch_returns_none_when_active_set(self, tmp_config_dir) -> None:
+        """With ignore_active_branch=True, implicit active_branch_id is skipped.
+
+        Used by storage read commands so users with an active dev branch
+        still see production tables/buckets by default.
+        """
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+                active_branch_id=15931,
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(
+            store, formatter, "prod", None, ignore_active_branch=True
+        )
+        assert project == "prod"
+        assert branch_id is None
+        # User must be told production is being used despite active dev branch.
+        formatter.err_console.print.assert_called_once()
+        msg = formatter.err_console.print.call_args.args[0]
+        assert "production" in msg.lower()
+        assert "15931" in msg
+
+    def test_ignore_active_branch_does_not_override_explicit_branch(self, tmp_config_dir) -> None:
+        """Explicit --branch wins even when ignore_active_branch=True."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+                active_branch_id=15931,
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(store, formatter, "prod", 99, ignore_active_branch=True)
+        assert project == "prod"
+        assert branch_id == 99
+
+    def test_ignore_active_branch_no_config_returns_none(self, tmp_config_dir) -> None:
+        """With ignore_active_branch=True and no active branch, still returns None."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(
+            store, formatter, "prod", None, ignore_active_branch=True
+        )
+        assert project == "prod"
+        assert branch_id is None
+        # No info message needed -- there was no active branch to ignore.
+        formatter.err_console.print.assert_not_called()
+
+    def test_ignore_active_branch_json_mode_silent(self, tmp_config_dir) -> None:
+        """In --json mode, ignore_active_branch still works but prints nothing."""
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+                active_branch_id=15931,
+            ),
+        )
+
+        formatter = MagicMock(json_mode=True)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(
+            store, formatter, "prod", None, ignore_active_branch=True
+        )
+        assert project == "prod"
+        assert branch_id is None
+        formatter.err_console.print.assert_not_called()
+
+    def test_ignore_active_branch_single_project_inferred(self, tmp_config_dir) -> None:
+        """Without --project, if a single project has an active branch and
+        ignore_active_branch=True, the project is still returned but branch_id is None.
+        """
+        from unittest.mock import MagicMock
+
+        from keboola_agent_cli.commands._helpers import resolve_branch
+        from keboola_agent_cli.config_store import ConfigStore
+        from keboola_agent_cli.models import ProjectConfig
+
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.add_project(
+            "prod",
+            ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token="tok-123",
+                active_branch_id=15931,
+            ),
+        )
+
+        formatter = MagicMock(json_mode=False)
+        formatter.err_console = MagicMock()
+
+        project, branch_id = resolve_branch(store, formatter, None, None, ignore_active_branch=True)
+        assert project == "prod"
+        assert branch_id is None
+        formatter.err_console.print.assert_called_once()

--- a/tests/test_hints.py
+++ b/tests/test_hints.py
@@ -157,6 +157,37 @@ class TestClientRenderer:
         assert "KBC_MANAGE_API_TOKEN" in code
         assert "KeboolaClient" not in code
 
+    def test_job_run_hint_threads_branch_id_through_all_steps(self) -> None:
+        """Branch is passed to all three client calls in the job.run hint.
+
+        Locks the contract: if branch_id is dropped from any of the
+        get_config_detail / list_config_rows / create_job calls, the rendered
+        hint would silently hit the production branch even when --branch is
+        supplied.
+        """
+        import keboola_agent_cli.hints.definitions.job  # noqa: F401 — trigger registration
+
+        hint = HintRegistry.get("job.run")
+        code = ClientRenderer.render(
+            hint,
+            params={
+                "component_id": '"keboola.snowflake-transformation"',
+                "config_id": '"123"',
+                "row_id": None,
+                "branch": 42,
+            },
+            stack_url=STACK_URL,
+            branch_id=42,
+        )
+        # The renderer may also inject branch_id into the poll-loop steps, so
+        # assert >= 3 (one per resolver/create step) rather than an exact count.
+        assert code.count("branch_id=42") >= 3
+        # Confirm each of the three key methods is actually present.
+        assert "get_config_detail" in code
+        assert "list_config_rows" in code
+        assert "create_job" in code
+        compile(code, "<hint>", "exec")
+
     def test_poll_loop_rendering(self) -> None:
         """Poll loop steps generate a while loop with sleep."""
         hint = CommandHint(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1860,8 +1860,8 @@ class TestJobServiceRunJob:
 class TestJobServiceVariableValuesResolution:
     """Tests for `resolve_variable_values_id` + auto-resolution in `run_job`.
 
-    Locks the P0-2 contract: transformations with linked variables must
-    run against the deployed values row, not empty strings.
+    Locks the contract: transformations with linked variables must run
+    against the deployed values row, not empty strings.
     """
 
     def _store(self, tmp_config_dir: Path) -> ConfigStore:
@@ -1963,8 +1963,7 @@ class TestJobServiceVariableValuesResolution:
         Locks the fail-loud contract: if the Storage API ever returns a row
         without a usable ``id``, the resolver must refuse rather than
         returning ``""`` and letting the Queue body quietly omit
-        ``variableValuesId`` -- same silent-skip class as the PR1
-        encryption-asymmetry bug.
+        ``variableValuesId``.
         """
         mock_client = MagicMock()
         mock_client.get_config_detail.return_value = {
@@ -2045,7 +2044,7 @@ class TestJobServiceVariableValuesResolution:
         mock_client = MagicMock()
         mock_client.create_job.return_value = {"id": 702, "status": "waiting"}
 
-        self._service(store, mock_client).run_job(
+        result = self._service(store, mock_client).run_job(
             alias="prod",
             component_id="keboola.snowflake-transformation",
             config_id="100",
@@ -2054,6 +2053,39 @@ class TestJobServiceVariableValuesResolution:
 
         mock_client.get_config_detail.assert_not_called()
         assert mock_client.create_job.call_args.kwargs["variable_values_id"] is None
+        assert "resolvedVariableValuesId" not in result
+
+    def test_run_job_wait_preserves_resolved_variable_values_id(self, tmp_config_dir: Path) -> None:
+        """resolvedVariableValuesId is stamped on the waited job, not the initial create result.
+
+        Locks the ordering: `job = wait_for_queue_job(...)` replaces the dict
+        returned by `create_job`; the stamp must happen AFTER the wait so the
+        final returned dict carries it.
+        """
+        store = self._store(tmp_config_dir)
+        mock_client = MagicMock()
+        mock_client.get_config_detail.return_value = {
+            "configuration": {"variables_id": "vars-cfg-99"}
+        }
+        mock_client.list_config_rows.return_value = [{"id": "row-waited"}]
+        mock_client.create_job.return_value = {"id": 750, "status": "waiting"}
+        mock_client.wait_for_queue_job.return_value = {
+            "id": 750,
+            "status": "success",
+            "isFinished": True,
+        }
+
+        result = self._service(store, mock_client).run_job(
+            alias="prod",
+            component_id="keboola.snowflake-transformation",
+            config_id="100",
+            wait=True,
+            timeout=30.0,
+        )
+
+        assert result["status"] == "success"
+        assert result["resolvedVariableValuesId"] == "row-waited"
+        mock_client.wait_for_queue_job.assert_called_once_with("750", max_wait=30.0)
 
     def test_run_job_closes_client_when_resolver_raises(self, tmp_config_dir: Path) -> None:
         """NO_VARIABLE_ROWS raised by the resolver inside run_job still closes the client.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1178,7 +1178,7 @@ class TestConfigServiceSearchConfigs:
     """Tests for ConfigService.search_configs() with branch_id support."""
 
     def test_search_configs_with_branch_id(self, tmp_config_dir: Path) -> None:
-        """search_configs passes branch_id to client.list_components."""
+        """search_configs passes branch_id to client.list_components_with_configs."""
         store = ConfigStore(config_dir=tmp_config_dir)
         store.add_project(
             "prod",
@@ -1188,7 +1188,10 @@ class TestConfigServiceSearchConfigs:
             ),
         )
 
-        mock_client = _make_list_components_client(SAMPLE_COMPONENTS)
+        # search_configs uses list_components_with_configs (include=configuration,rows)
+        # so row-level properties are part of the search tree (see #196).
+        mock_client = MagicMock()
+        mock_client.list_components_with_configs.return_value = SAMPLE_COMPONENTS
         service = ConfigService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -1201,7 +1204,9 @@ class TestConfigServiceSearchConfigs:
         assert len(matches) == 1
         assert matches[0]["config_name"] == "Production Load"
 
-        mock_client.list_components.assert_called_once_with(component_type=None, branch_id=123)
+        mock_client.list_components_with_configs.assert_called_once_with(
+            branch_id=123, component_type=None
+        )
         mock_client.close.assert_called_once()
 
     def test_search_configs_uses_active_branch(self, tmp_config_dir: Path) -> None:
@@ -1216,7 +1221,8 @@ class TestConfigServiceSearchConfigs:
             ),
         )
 
-        mock_client = _make_list_components_client(SAMPLE_COMPONENTS)
+        mock_client = MagicMock()
+        mock_client.list_components_with_configs.return_value = SAMPLE_COMPONENTS
         service = ConfigService(
             config_store=store,
             client_factory=lambda url, token: mock_client,
@@ -1224,7 +1230,9 @@ class TestConfigServiceSearchConfigs:
 
         service.search_configs(query="nonexistent-query")
 
-        mock_client.list_components.assert_called_once_with(component_type=None, branch_id=88)
+        mock_client.list_components_with_configs.assert_called_once_with(
+            branch_id=88, component_type=None
+        )
         mock_client.close.assert_called_once()
 
 

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -957,3 +957,324 @@ class TestDeleteColumnBranch:
         assert result.exit_code == 0
         call_kwargs = svc.delete_columns.call_args.kwargs
         assert call_kwargs["branch_id"] == 42
+
+
+def _make_store_with_active_branch(tmp_path: Path, branch_id: int) -> ConfigStore:
+    """Build a config store with one project that has an active dev branch."""
+    store = _make_store(tmp_path)
+    store.set_project_branch("test", branch_id)
+    return store
+
+
+class TestStorageReadIgnoresActiveBranch:
+    """Regression tests for GitHub issue #207.
+
+    Storage READ commands (tables, buckets, bucket-detail, table-detail,
+    files) must NOT follow the implicit active dev branch -- the Storage
+    API branch-scoped endpoint returns only locally-modified resources,
+    so a fresh dev branch lists nothing. Explicit --branch still wins.
+    Storage WRITE commands stay branch-aware (user intent to modify).
+    """
+
+    # Read commands ---------------------------------------------------------
+
+    def test_storage_tables_with_active_branch_uses_production(self, tmp_path: Path) -> None:
+        """storage tables sends branch_id=None when only an active branch is set."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {"tables": [], "project_alias": "test"}
+
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "tables", "--project", "test"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_tables.call_args.kwargs
+        assert call_kwargs["branch_id"] is None
+
+    def test_storage_tables_explicit_branch_overrides_active(self, tmp_path: Path) -> None:
+        """Explicit --branch wins even when active_branch_id is set."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {"tables": [], "project_alias": "test"}
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "tables",
+                    "--project",
+                    "test",
+                    "--branch",
+                    "99",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_tables.call_args.kwargs
+        assert call_kwargs["branch_id"] == 99
+
+    def test_storage_buckets_with_active_branch_uses_production(self, tmp_path: Path) -> None:
+        """storage buckets ignores active_branch_id (single-project case)."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_buckets.return_value = {"buckets": [], "errors": []}
+
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "buckets", "--project", "test"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_buckets.call_args.kwargs
+        assert call_kwargs["branch_id"] is None
+
+    def test_storage_buckets_explicit_branch_overrides_active(self, tmp_path: Path) -> None:
+        """Explicit --branch wins for storage buckets too."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_buckets.return_value = {"buckets": [], "errors": []}
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "buckets",
+                    "--project",
+                    "test",
+                    "--branch",
+                    "77",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_buckets.call_args.kwargs
+        assert call_kwargs["branch_id"] == 77
+
+    def test_storage_bucket_detail_with_active_branch_uses_production(self, tmp_path: Path) -> None:
+        """storage bucket-detail sends branch_id=None despite active dev branch."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.get_bucket_detail.return_value = {
+                "project_alias": "test",
+                "project_id": 1234,
+                "bucket_id": "in.c-data",
+                "display_name": "data",
+                "stage": "in",
+                "description": "",
+                "backend": "snowflake",
+                "is_linked": False,
+                "source_project_id": None,
+                "source_project_name": "",
+                "source_bucket_id": "",
+                "snowflake_database": "SAPI_1234",
+                "snowflake_schema": "in.c-data",
+                "tables": [],
+                "table_count": 0,
+            }
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "bucket-detail",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-data",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.get_bucket_detail.call_args.kwargs
+        assert call_kwargs["branch_id"] is None
+
+    def test_storage_table_detail_with_active_branch_uses_production(self, tmp_path: Path) -> None:
+        """storage table-detail sends branch_id=None despite active dev branch."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.get_table_detail.return_value = {
+                "project_alias": "test",
+                "project_id": 1234,
+                "table_id": "in.c-data.users",
+                "name": "users",
+                "display_name": "users",
+                "bucket_id": "in.c-data",
+                "rows_count": 10,
+                "data_size_bytes": 1024,
+                "primary_key": [],
+                "column_details": [],
+                "last_import_date": None,
+            }
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "table-detail",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.get_table_detail.call_args.kwargs
+        assert call_kwargs["branch_id"] is None
+
+    def test_storage_files_with_active_branch_uses_production(self, tmp_path: Path) -> None:
+        """storage files sends branch_id=None despite active dev branch."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_files.return_value = {"files": [], "count": 0}
+
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "files", "--project", "test"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_files.call_args.kwargs
+        assert call_kwargs["branch_id"] is None
+
+    def test_storage_files_explicit_branch_overrides_active(self, tmp_path: Path) -> None:
+        """Explicit --branch wins for storage files."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_files.return_value = {"files": [], "count": 0}
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "files",
+                    "--project",
+                    "test",
+                    "--branch",
+                    "55",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_files.call_args.kwargs
+        assert call_kwargs["branch_id"] == 55
+
+    # Write commands remain branch-aware -----------------------------------
+
+    def test_storage_create_bucket_still_follows_active_branch(self, tmp_path: Path) -> None:
+        """Write command create-bucket keeps branch-awareness (user intent)."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.create_bucket.return_value = {
+                "id": "in.c-foo",
+                "stage": "in",
+                "project_alias": "test",
+                "display_name": "foo",
+                "description": "",
+                "backend": "snowflake",
+            }
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "create-bucket",
+                    "--project",
+                    "test",
+                    "--stage",
+                    "in",
+                    "--name",
+                    "foo",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.create_bucket.call_args.kwargs
+        assert call_kwargs["branch_id"] == 15931
+
+    def test_storage_delete_table_still_follows_active_branch(self, tmp_path: Path) -> None:
+        """Destructive delete-table keeps branch-awareness."""
+        store = _make_store_with_active_branch(tmp_path, 15931)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.delete_tables.return_value = {
+                "deleted": ["in.c-data.users"],
+                "failed": [],
+                "dry_run": False,
+                "project_alias": "test",
+            }
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "delete-table",
+                    "--project",
+                    "test",
+                    "--table-id",
+                    "in.c-data.users",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.delete_tables.call_args.kwargs
+        assert call_kwargs["branch_id"] == 15931

--- a/tests/test_storage_delete.py
+++ b/tests/test_storage_delete.py
@@ -884,7 +884,7 @@ class TestStorageTablesBranch:
         ):
             MockStore.return_value = store
             svc = MockSvc.return_value
-            svc.list_tables.return_value = {"tables": [], "project_alias": "test"}
+            svc.list_tables.return_value = {"tables": [], "errors": []}
             result = runner.invoke(
                 app,
                 [
@@ -900,6 +900,8 @@ class TestStorageTablesBranch:
         assert result.exit_code == 0
         call_kwargs = svc.list_tables.call_args.kwargs
         assert call_kwargs["branch_id"] == 30
+        # Multi-project CLI passes --project as a list
+        assert call_kwargs["aliases"] == ["test"]
 
 
 class TestDeleteColumnBranch:

--- a/tests/test_storage_tables.py
+++ b/tests/test_storage_tables.py
@@ -1,0 +1,399 @@
+"""Tests for storage tables multi-project listing (issue #198).
+
+Covers:
+- StorageService.list_tables() multi-project parallel execution
+- CLI storage tables without --project (all projects)
+- CLI storage tables with multiple --project flags
+- Error accumulation across projects
+- --branch/--project validation (branch requires single project)
+- --bucket-id filter applied independently per project
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.models import AppConfig, ProjectConfig
+from keboola_agent_cli.services.storage_service import StorageService
+
+runner = CliRunner()
+
+TEST_TOKEN = "901-10493007-VDtlEDWDF6Tx5V8jjE8FshFlqM0Hl0c08KHqpt0k"
+
+
+def _make_multi_store(tmp_path: Path) -> ConfigStore:
+    """Config store with two projects ('p1' and 'p2')."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    store = ConfigStore(config_dir=config_dir)
+    config = AppConfig(
+        projects={
+            "p1": ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            ),
+            "p2": ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            ),
+        },
+    )
+    store.save(config)
+    return store
+
+
+def _make_single_store(tmp_path: Path) -> ConfigStore:
+    """Config store with a single project ('test')."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    store = ConfigStore(config_dir=config_dir)
+    config = AppConfig(
+        projects={
+            "test": ProjectConfig(
+                stack_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+            )
+        },
+    )
+    store.save(config)
+    return store
+
+
+def _mk_table(table_id: str) -> dict:
+    """Helper to build a minimal raw API table dict."""
+    return {
+        "id": table_id,
+        "name": table_id.split(".")[-1],
+        "displayName": table_id.split(".")[-1],
+        "bucket": {"id": ".".join(table_id.split(".")[:2])},
+        "rowsCount": 100,
+        "dataSizeBytes": 1024,
+        "isAlias": False,
+        "lastImportDate": "2026-04-22T00:00:00+0000",
+    }
+
+
+# ------------------------------------------------------------------
+# Service-layer tests
+# ------------------------------------------------------------------
+
+
+class TestListTablesMultiProject:
+    """StorageService.list_tables() with multiple project aliases."""
+
+    def test_two_projects_aggregate_tables(self, tmp_path: Path) -> None:
+        """aliases=['p1','p2'] returns tables from both with project_alias set."""
+        store = _make_multi_store(tmp_path)
+
+        p1_client = MagicMock()
+        p1_client.list_tables.return_value = [_mk_table("in.c-a.t1")]
+        p2_client = MagicMock()
+        p2_client.list_tables.return_value = [_mk_table("in.c-b.t2")]
+
+        # Route client_factory by token to return the right mock; both projects
+        # share the same token in the fixture, so use stack_url for routing
+        # would not work either. Instead, dispatch by call order using a
+        # rotating list -- _run_parallel spawns threads so ordering may vary,
+        # so we use a dict keyed by call count and assert set-wise below.
+        clients: dict[int, MagicMock] = {0: p1_client, 1: p2_client}
+        call_count = {"n": 0}
+
+        def factory(url: str, token: str) -> MagicMock:
+            idx = call_count["n"]
+            call_count["n"] += 1
+            return clients[idx]
+
+        service = StorageService(config_store=store, client_factory=factory)
+
+        result = service.list_tables(aliases=["p1", "p2"])
+
+        assert len(result["tables"]) == 2
+        assert result["errors"] == []
+        aliases_seen = {t["project_alias"] for t in result["tables"]}
+        assert aliases_seen == {"p1", "p2"}
+        ids_seen = {t["id"] for t in result["tables"]}
+        assert ids_seen == {"in.c-a.t1", "in.c-b.t2"}
+
+    def test_aliases_none_queries_all_projects(self, tmp_path: Path) -> None:
+        """aliases=None resolves to all projects."""
+        store = _make_multi_store(tmp_path)
+
+        mock_client = MagicMock()
+        mock_client.list_tables.return_value = [_mk_table("in.c-b.t")]
+
+        service = StorageService(
+            config_store=store,
+            client_factory=lambda _u, _t: mock_client,
+        )
+
+        result = service.list_tables(aliases=None)
+
+        # Both p1 and p2 hit the client once each (same mock)
+        assert mock_client.list_tables.call_count == 2
+        assert len(result["tables"]) == 2
+        assert {t["project_alias"] for t in result["tables"]} == {"p1", "p2"}
+
+    def test_error_accumulation_partial_success(self, tmp_path: Path) -> None:
+        """One project 404s; other succeeds. Errors list captures the failure."""
+        store = _make_multi_store(tmp_path)
+
+        good_client = MagicMock()
+        good_client.list_tables.return_value = [_mk_table("in.c-x.ok")]
+
+        bad_client = MagicMock()
+        bad_client.list_tables.side_effect = KeboolaApiError(
+            message="Bucket not found",
+            error_code="NOT_FOUND",
+            status_code=404,
+        )
+
+        clients = [good_client, bad_client]
+        call_count = {"n": 0}
+
+        def factory(url: str, token: str) -> MagicMock:
+            idx = call_count["n"]
+            call_count["n"] += 1
+            return clients[idx]
+
+        service = StorageService(config_store=store, client_factory=factory)
+
+        result = service.list_tables(aliases=["p1", "p2"], bucket_id="in.c-missing")
+
+        # Exactly one project returned tables, one produced an error
+        assert len(result["tables"]) == 1
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["error_code"] == "NOT_FOUND"
+        assert result["errors"][0]["project_alias"] in {"p1", "p2"}
+
+    def test_bucket_id_filter_applied_per_project(self, tmp_path: Path) -> None:
+        """bucket_id is forwarded to each per-project client call."""
+        store = _make_multi_store(tmp_path)
+
+        mock_client = MagicMock()
+        mock_client.list_tables.return_value = []
+        service = StorageService(
+            config_store=store,
+            client_factory=lambda _u, _t: mock_client,
+        )
+
+        service.list_tables(aliases=["p1", "p2"], bucket_id="in.c-shared")
+
+        assert mock_client.list_tables.call_count == 2
+        for call in mock_client.list_tables.call_args_list:
+            assert call.kwargs == {"bucket_id": "in.c-shared", "branch_id": None}
+
+    def test_unknown_alias_raises_config_error(self, tmp_path: Path) -> None:
+        """Passing an unknown alias raises ConfigError (from resolve_projects)."""
+        store = _make_multi_store(tmp_path)
+        service = StorageService(
+            config_store=store,
+            client_factory=lambda _u, _t: MagicMock(),
+        )
+
+        with pytest.raises(ConfigError):
+            service.list_tables(aliases=["does-not-exist"])
+
+
+# ------------------------------------------------------------------
+# CLI-layer tests
+# ------------------------------------------------------------------
+
+
+class TestStorageTablesCli:
+    """CLI tests for `kbagent storage tables`."""
+
+    def test_no_project_queries_all(self, tmp_path: Path) -> None:
+        """Omitting --project passes aliases=None to the service."""
+        store = _make_multi_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {"tables": [], "errors": []}
+            result = runner.invoke(app, ["--json", "storage", "tables"])
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_tables.call_args.kwargs
+        # Typer delivers a list[str] | None -- when nothing is passed it's None
+        assert call_kwargs["aliases"] is None
+
+        payload = json.loads(result.output)
+        assert payload["data"] == {"tables": [], "errors": []}
+
+    def test_multi_project_flags(self, tmp_path: Path) -> None:
+        """Two --project flags are delivered as a list to the service."""
+        store = _make_multi_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {
+                "tables": [
+                    {
+                        "project_alias": "p1",
+                        "id": "in.c-a.t1",
+                        "name": "t1",
+                        "display_name": "t1",
+                        "bucket_id": "in.c-a",
+                        "rows_count": 10,
+                        "data_size_bytes": 100,
+                        "is_alias": False,
+                        "last_import_date": "",
+                    },
+                    {
+                        "project_alias": "p2",
+                        "id": "in.c-b.t2",
+                        "name": "t2",
+                        "display_name": "t2",
+                        "bucket_id": "in.c-b",
+                        "rows_count": 20,
+                        "data_size_bytes": 200,
+                        "is_alias": False,
+                        "last_import_date": "",
+                    },
+                ],
+                "errors": [],
+            }
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "tables",
+                    "--project",
+                    "p1",
+                    "--project",
+                    "p2",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = svc.list_tables.call_args.kwargs
+        assert call_kwargs["aliases"] == ["p1", "p2"]
+        payload = json.loads(result.output)
+        ids = {t["id"] for t in payload["data"]["tables"]}
+        assert ids == {"in.c-a.t1", "in.c-b.t2"}
+
+    def test_single_project_with_bucket_id(self, tmp_path: Path) -> None:
+        """--project + --bucket-id narrows to a single project and forwards filter."""
+        store = _make_single_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {"tables": [], "errors": []}
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "tables",
+                    "--project",
+                    "test",
+                    "--bucket-id",
+                    "in.c-data",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = svc.list_tables.call_args.kwargs
+        assert call_kwargs["aliases"] == ["test"]
+        assert call_kwargs["bucket_id"] == "in.c-data"
+
+    def test_multi_project_with_branch_rejected(self, tmp_path: Path) -> None:
+        """--branch with two --project flags fails with exit code 2."""
+        store = _make_multi_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_tables.return_value = {"tables": [], "errors": []}
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "storage",
+                    "tables",
+                    "--project",
+                    "p1",
+                    "--project",
+                    "p2",
+                    "--branch",
+                    "99",
+                ],
+            )
+
+        # Per CONTRIBUTING.md exit code 2 = usage/argument validation
+        assert result.exit_code == 2, result.output
+        assert "--branch requires exactly one --project" in result.output
+
+    def test_branch_without_project_rejected(self, tmp_path: Path) -> None:
+        """--branch with no --project is also a usage error."""
+        store = _make_multi_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_tables.return_value = {"tables": [], "errors": []}
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "tables", "--branch", "99"],
+            )
+
+        assert result.exit_code == 2, result.output
+
+    def test_errors_surface_in_json_output(self, tmp_path: Path) -> None:
+        """Per-project errors are preserved verbatim in JSON mode."""
+        store = _make_multi_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            svc = MockSvc.return_value
+            svc.list_tables.return_value = {
+                "tables": [],
+                "errors": [
+                    {
+                        "project_alias": "p1",
+                        "error_code": "NOT_FOUND",
+                        "message": "Bucket not found",
+                    }
+                ],
+            }
+            result = runner.invoke(app, ["--json", "storage", "tables"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["data"]["errors"][0]["project_alias"] == "p1"
+        assert payload["data"]["errors"][0]["error_code"] == "NOT_FOUND"
+
+    def test_unknown_project_exits_with_config_error(self, tmp_path: Path) -> None:
+        """Service ConfigError is mapped to exit code 5."""
+        store = _make_multi_store(tmp_path)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch("keboola_agent_cli.cli.StorageService") as MockSvc,
+        ):
+            MockStore.return_value = store
+            MockSvc.return_value.list_tables.side_effect = ConfigError("Project 'ghost' not found.")
+            result = runner.invoke(
+                app,
+                ["--json", "storage", "tables", "--project", "ghost"],
+            )
+
+        assert result.exit_code == 5

--- a/uv.lock
+++ b/uv.lock
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Integration PR for **v0.21.2 hotfix release**, bundling 6 merged PRs into a single reviewable unit. All 6 PRs were squash-merged into `release/0.21.2` in the order listed below; a single conflict between #211 and #212 in `commands/storage.py` + `commands/context.py` was resolved during rebase (composition of both changes: \`storage tables\` is now multi-project **and** ignores the implicit active dev branch on single-project reads).

## Contents

| PR | Type | What | Closes |
|---|---|---|---|
| #213 | chore | Whitelist \`.env.example\` / \`.env.template\` in \`.gitignore\` (split from #199 per review) | — |
| #199 | fix | \`job run\` banner reads resolved id, hint threads \`branch_id\`, whitespace strip on \`--variable-values-id\` | — |
| #209 | fix | \`config search\` also scans \`rows[].configuration\` — matches docstring promise | #196 |
| #210 | fix | \`lineage build\` supports flat single-project sync layout + emits warning on empty graph | #208 |
| #211 | fix | Storage **read** commands (\`buckets\`, \`tables\`, \`bucket-detail\`, \`table-detail\`, \`files\`) ignore implicit active dev branch — avoids empty-listing trap. Write/destructive commands unchanged. | #207 |
| #212 | fix | \`storage tables\` accepts zero-or-more \`--project\`, queries all connected projects in parallel — matches \`storage buckets\`, \`config list\`, etc. | #198 |

## Customer-reported bugs included

- **jakubsebek-kosik** (kosik): #207 (storage tables empty on dev branch), #208 (lineage empty graph on single-project sync)
- **ondrej-lorenc** (14-project audit): #196 (config search misses row configs), #198 (storage tables single-project inconsistency)

## Conflict resolution notes

Rebase of #212 on top of #211 required resolving:

1. \`commands/context.py\` — docstring for \`storage tables\` merged (multi-project signature + production-by-default branch note)
2. \`commands/storage.py\` — docstring merged; branch resolution now calls \`resolve_branch(..., ignore_active_branch=True)\` **only** for single-project queries (multi-project skips branch resolution entirely because branches are per-project state)
3. \`tests/test_storage_delete.py\` — git auto-merge, no manual intervention needed

## Pending before merge

- [ ] Bump \`pyproject.toml\` to \`0.21.2\`
- [ ] Add changelog entry in \`src/keboola_agent_cli/changelog.py\`
- [ ] \`make version-sync\` (updates \`plugins/kbagent/.claude-plugin/plugin.json\`)
- [ ] \`make check\` — full CI (lint + format + changelog-check + tests)

## Test plan

- [x] \`uv run pytest tests/test_storage_tables.py tests/test_storage_delete.py tests/test_helpers.py\` — 86/86 passed after merge conflict resolution
- [x] \`uv run ruff check\` + \`ruff format --check\` on affected files — clean
- [ ] Full \`make check\` with version bump + changelog before merge
- [ ] \`make test-e2e\` against real Keboola project (optional; customer bugs already verified manually)

## Post-merge

- Tag \`v0.21.2\`
- Publish to PyPI
- Auto-closes issues: #196, #198, #207, #208