### PR TITLE
docs: mandate `/kbagent:review` self-review before tagging a human reviewer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,8 +284,82 @@ to catch this before the change ships.
 - **Pre-commit hook must pass** -- `ruff check` + `ruff format --check`. Install via `make hooks`
 - **Never skip hooks** (`--no-verify`) -- fix the lint issue instead
 - **Protected main branch** -- always work on a feature branch, create PR, merge via GitHub
+- **Self-review with `/kbagent:review` before tagging a human** -- see
+  [Self-review before tagging a human reviewer](#self-review-before-tagging-a-human-reviewer)
+  for what it does and how to run it. CI does not catch the silent-drift
+  surfaces (Plugin synchronization map); the self-review does.
 
 For reference on commit style: https://github.com/padak/claude-code-kit/blob/main/CLAUDE.md
+
+## Self-review before tagging a human reviewer
+
+Before you ping a maintainer, **run the `/kbagent:review` slash command
+against your open PR**. It is a read-only specialist subagent
+(`kbagent-pr-reviewer`, shipped with the kbagent Claude Code plugin) that
+walks the same playbook a careful human reviewer would: 3-layer compliance,
+[Plugin synchronization map](#plugin-synchronization-map) silent-drift hunt,
+test coverage, behavior verification, backward compatibility, security and
+token discipline. It posts ONE structured comment review on the PR with
+findings rated BLOCKING / NON-BLOCKING / NIT, each carrying a `file:line`
+citation.
+
+### How to run it
+
+1. Push your branch and open the PR (`gh pr create ...`).
+2. Stay checked out on the PR's branch with a clean working tree.
+3. Confirm `gh auth status` is authenticated to the same fork as the PR.
+4. In a Claude Code session in the repo root, type:
+
+   ```
+   /kbagent:review
+   ```
+
+   The slash command auto-detects the PR for the current branch. To target a
+   different PR explicitly:
+
+   ```
+   /kbagent:review 234
+   /kbagent:review https://github.com/padak/keboola_agent_cli/pull/234
+   /kbagent:review 234 focus on the new cache semantics
+   ```
+
+5. The reviewer reads `CONTRIBUTING.md`, walks the diff, runs `make check`,
+   attempts to reproduce the PR's claimed behavior, and posts a single
+   `gh pr review --comment` to the PR. It NEVER approves, requests changes,
+   merges, or pushes -- the verdict in the comment body is advice; you and
+   the human reviewer retain every veto.
+
+### What to do with the findings
+
+- **BLOCKING** -- address before tagging a human, OR push back in a PR
+  comment explaining why you disagree. Some BLOCKING findings are
+  calibration mistakes; the reviewer defaults conservative, and a
+  ~30-second human disposition is faster than a re-run.
+- **NON-BLOCKING** -- address if quick; otherwise mention them in the PR
+  description so the human reviewer knows they are not regressions hiding
+  in the diff.
+- **NIT** -- optional. Address if you agree.
+
+### This is a courtesy, not a CI gate
+
+The reviewer is intentionally NOT wired into CI. It depends on Claude Code
+with the kbagent plugin installed and an authenticated `gh`, which is not
+portable across all contributor setups. Running it remains a per-author
+courtesy that:
+
+- catches the silent-drift gaps (`OPERATION_REGISTRY`, `gotchas.md`
+  version tags, `keboola-expert.md` matrix, `commands/context.py`
+  `AGENT_CONTEXT`, `commands-reference.md`, `--hint` definitions) that
+  CI does not check;
+- demonstrates to the human reviewer that you have walked the
+  [Plugin synchronization map](#plugin-synchronization-map);
+- saves a review round-trip when the reviewer would otherwise catch the
+  same issues.
+
+If you genuinely cannot run it (offline, no `gh` auth, plugin not
+installed), say so explicitly in the PR description (`self-review
+skipped: <reason>`) -- the human reviewer may run it on your behalf, or
+ask you to address it before merge.
 
 ## Testing Guidelines
 


### PR DESCRIPTION
## Summary

Now that `/kbagent:review` and `kbagent-pr-reviewer` have shipped (#228), document the self-review workflow in `CONTRIBUTING.md` so contributors run the agent against their open PR **before** pinging a maintainer.

## What changed

- **New top-level section "## Self-review before tagging a human reviewer"** between `## Commit & PR Conventions` and `## Testing Guidelines`. Covers:
  - what the reviewer does (3-layer compliance, Plugin synchronization map silent-drift hunt, test coverage, behavior verification, backward compat, security/token discipline)
  - how to invoke it (no-arg auto-detect, explicit PR number, URL, trailing focus hint)
  - how to triage findings by severity (BLOCKING / NON-BLOCKING / NIT)
  - why it is a per-author courtesy rather than a CI gate (depends on Claude Code + plugin + `gh auth`, not portable across all setups)
  - the escape hatch (`self-review skipped: <reason>` in PR description)
- **New bullet inside `## Commit & PR Conventions`** cross-linking to the new section, so authors see it in the natural PR-flow convention list -- not only when they scroll to the new section.

## Why

The reviewer catches the silent-drift gaps that CI does not: missing `OPERATION_REGISTRY` entry, missing `(since vX.Y.Z)` tag in `gotchas.md`, missing AGENT_CONTEXT entry, missing `--hint` definition, layer violations, etc. (see CONTRIBUTING.md > [Plugin synchronization map](https://github.com/padak/keboola_agent_cli/blob/main/CONTRIBUTING.md#plugin-synchronization-map) -- this PR adds a step that USES that map).

Without this section, the reviewer exists but contributors don't know they should run it. After this section, the workflow is documented and discoverable from both the PR-conventions list and a top-level heading.

## Tone

Section uses "courtesy, not a CI gate" framing intentionally:

- It can't be a hard CI gate -- contributors without Claude Code installed cannot run it.
- BUT contributors who DO have it should run it, and the PR description doubles as the social pressure ("self-review skipped" is an explicit signal to the human reviewer).
- This matches the rest of CONTRIBUTING.md's gradient: hard "MUST" for CI-checkable items (lint, tests, conventional commits), softer "SHOULD" for hand-maintained / agent-driven items.

## Test plan

- [x] Render `CONTRIBUTING.md` on GitHub and confirm:
  - new heading "## Self-review before tagging a human reviewer" appears in the right position (after Commit & PR Conventions, before Testing Guidelines)
  - cross-reference anchor `#self-review-before-tagging-a-human-reviewer` from the new bullet in `## Commit & PR Conventions` resolves
  - cross-reference to `#plugin-synchronization-map` from the new section also resolves
  - code blocks render (the `/kbagent:review` invocations)
- [x] `make check` passes (no Python touched -- expected to be a no-op).