### PR TITLE
fix(plugin): kbagent-pr-reviewer posts English-only body to GitHub

### DIFF
--- a/plugins/kbagent/agents/kbagent-pr-reviewer.md
+++ b/plugins/kbagent/agents/kbagent-pr-reviewer.md
@@ -19,9 +19,12 @@ You operate with `Bash`, `Read`, `Grep`, and `Glob` only. You DO NOT use
 git branches, push, force-push, or merge. The only mutation you make is one
 `gh pr review --comment --body-file` call at the end of a successful run.
 
-Respond in the same language as the parent agent's prompt (Czech, English,
-etc.). Findings stay in English so they're greppable across the codebase;
-only the Summary section may be Czech.
+Always respond in English, regardless of the parent agent's prompt
+language. PR reviews are public GitHub artifacts that need to be
+greppable, indexed, and accessible to all contributors and downstream AI
+agents. The brief 3-5 line summary you return to the parent agent at the
+end of the run may be in the parent's language, but the GitHub-posted
+review body is English-only.
 
 ---
 
@@ -421,9 +424,12 @@ Fix: change the heading to `## Storage retype performs DDL atomically (since 0.2
    the highest-signal 15. ≤ 200 words per finding (most should be 50-80).
 8. **Severity is mandatory.** Every finding has a level. No "this might
    be an issue" -- decide and commit.
-9. **English findings; Czech Summary if PR description is Czech.** Read
-   the PR body; if it's Czech, write the Summary section in Czech.
-   Findings stay English so they're greppable across the codebase.
+9. **English everywhere in the GitHub-posted body.** Even if the PR
+   description, branch name, or parent prompt is in another language,
+   the entire review body (Summary, Findings, Verification log, Open
+   questions) is English. PR reviews are public, indexed, greppable
+   artifacts. The brief 3-5 line summary you return to the parent agent
+   in-process can match the parent's language; the GitHub body cannot.
 
 ---
 


### PR DESCRIPTION
## Summary

Forces the `kbagent-pr-reviewer` subagent to post the entire GitHub review body in English, regardless of the parent agent's prompt language. The brief 3-5 line summary the subagent returns to the parent in-process can still match the parent's language; only the public GitHub artifact is English-only.

## Why

The previous prompt allowed a Czech Summary section when the parent prompt was Czech (see review on #227 for an example). PR reviews are public, indexed by GitHub search, greppable across the codebase, and read by future contributors and AI agents -- they should be English even when the local conversation is in another language. The same argument the prompt already used for findings ("greppable across the codebase") applies to the Summary too.

## Changes

- `plugins/kbagent/agents/kbagent-pr-reviewer.md`: replaces the "Respond in the same language as the parent agent's prompt" rule (top-of-file + Anti-drift rule #9) with "Always respond in English" + carved-out exception for the in-process parent return summary.

## Scope deliberately not changed

- `plugins/kbagent/agents/keboola-expert.md` and `plugins/kbagent/commands/keboola.md` keep their "respond in the same language" rule -- those produce in-terminal answers to the user, not public GitHub artifacts.

## Test plan

- [ ] Next `/kbagent:review` invocation in a Czech parent context posts a fully English review body to GitHub