### PR TITLE
fix(0.28.0): VERSION GATE + test client.close() assertion (PR #247 review NB-1, NB-2)

### DIFF
--- a/plugins/kbagent/agents/keboola-expert.md
+++ b/plugins/kbagent/agents/keboola-expert.md
@@ -65,7 +65,8 @@ a critical failure.
    `schedule find` needs 0.23.0+, `config set-default-bucket` needs
    0.26.0+, `data-app create / deploy / start / stop / delete / password`
    need 0.27.0+, `config update` script[] auto-normalize against #245
-   trap needs 0.28.0+, `storage retype` is a future composite), you
+   trap needs 0.28.0+, `storage swap-tables` needs 0.28.0+,
+   `storage retype` is a future composite), you
    MUST refuse the task and return a handoff message to the parent:
    `"Cannot proceed safely on kbagent <version>. Missing: <commands>.
    Ask user to run kbagent update, then re-invoke me."` Do not attempt

--- a/tests/test_storage_swap.py
+++ b/tests/test_storage_swap.py
@@ -194,6 +194,7 @@ class TestSwapTablesService:
             target_table_id="in.c-foo.data_change_log",
             branch_id=9999,
         )
+        mock_client.close.assert_called_once()
 
     def test_dry_run_skips_client_call(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -269,6 +270,9 @@ class TestSwapTablesService:
                 target_table_id="in.c-foo.b",
                 branch_id=42,
             )
+        # Service must close the client even when the API call raises
+        # (try/finally contract -- regression guard for the lifecycle).
+        mock_client.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two carry-over findings from the PR #247 self-review that landed as non-blocking but should be cleaned up before `feat-0.28.0 -> main`:

- **NB-1: VERSION GATE drift** in `plugins/kbagent/agents/keboola-expert.md` Rule 6. The parenthetical enumerates `config update script[] auto-normalize ... 0.28.0+` but did not list `storage swap-tables 0.28.0+`. An agent on an older install would not refuse the task before attempting a command that does not exist on that version. Added `\`storage swap-tables\` needs 0.28.0+`.
- **NB-2: missing close-assertion** in `tests/test_storage_swap.py::TestSwapTablesService`. CONTRIBUTING.md line 371 mandates `mock_client.close.assert_called_once()` to lock the lifecycle. Production code's `finally: client.close()` is correct, but a future refactor that drops it would have shipped silent. Added the assertion to `test_success` (happy path) and `test_api_error_propagates` (error path -- guards the `finally` discipline).

Both findings were also surfaced in the standalone `feat-0.28.0` audit against `CONTRIBUTING.md`'s release checklist; they are the only items that would have needed addressing before tagging the release.

## Test plan

- [x] `make check` green: 2483 tests, 6 skipped, lint + format + skill + version + changelog all pass.
- [x] `tests/test_storage_swap.py` -- 14 tests still green; new assertions exercise both `try` (success) and `finally` (raise) paths.
- [x] No functional code changes: only doc text in the agent prompt and test assertions. Behavior identical to `feat-0.28.0` HEAD (`ad040e8`).