### PR TITLE
fix(0.28.0): TestE2EStorageSwapTables must skip without E2E_API_TOKEN (CI fix for PR #249)

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5871,6 +5871,7 @@ class TestE2EStorageNativeTypesAndBranchMaterialize:
 # ---------------------------------------------------------------------------
 
 
+@skip_without_credentials
 @pytest.mark.e2e
 class TestE2EStorageSwapTables:
     """End-to-end coverage for ``kbagent storage swap-tables``.


### PR DESCRIPTION
## Summary

PR #249 (release rollup) broke CI on the unit-suite job because `TestE2EStorageSwapTables` (introduced in #247) was decorated only with `@pytest.mark.e2e`, missing the `@skip_without_credentials` skipif decorator that all other E2E classes use. CI runs `pytest tests/ -v -m 'not integration'`, which does NOT deselect the `e2e` marker -- the class collected, the autouse `setup` fixture ran, and `os.environ[ENV_TOKEN]` raised `KeyError`. 3 errors, exit 1.

CI run: https://github.com/padak/keboola_agent_cli/actions/runs/25440815047

Fix is one line: add `@skip_without_credentials` (the skipif decorator already used by `TestE2EStorageNativeTypesAndBranchMaterialize` and friends) above the existing `@pytest.mark.e2e` marker.

## Test plan

Verified locally with the exact CI command:
```bash
$ unset E2E_API_TOKEN
$ uv run pytest tests/ -v -m 'not integration'
========= 2480 passed, 69 skipped, 7 deselected, 14 warnings in 37.89s =========
```

Before: 3 errors (`KeyError: 'E2E_API_TOKEN'` in `setup`).
After: 3 skips (`E2E tests require E2E_API_TOKEN environment variable`).

The `@pytest.mark.e2e` marker is preserved so explicit `-m e2e` runs (with credentials) still pick the class up. This matches the pattern already established by `TestE2EStorageNativeTypesAndBranchMaterialize`.