### PR TITLE
docs: 0.29.0 silent-drift cleanup (post-release audit nits)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ All three inherit from `BaseHttpClient` (`http_base.py`) which provides shared r
 
 11. **Error accumulation**: multi-project operations collect per-project errors without stopping. One project failing doesn't block others (see `lineage_service.py`, `org_service.py`).
 
-12. **Manage token security**: never persisted, never passed as CLI argument, never logged. Default-deny since 0.28.0: only via interactive hidden prompt; the `KBC_MANAGE_API_TOKEN` env var is **ignored** unless the top-level `--allow-env-manage-token` flag is passed. Default-deny closes the AI-exfiltration risk where any subprocess (including the AI agent itself) inherits the manage token via env. CI/CD callers must opt in explicitly.
+12. **Manage token security**: never persisted, never passed as CLI argument, never logged. Default-deny since 0.29.0: only via interactive hidden prompt; the `KBC_MANAGE_API_TOKEN` env var is **ignored** unless the top-level `--allow-env-manage-token` flag is passed. Default-deny closes the AI-exfiltration risk where any subprocess (including the AI agent itself) inherits the manage token via env. CI/CD callers must opt in explicitly.
 
 13. **Idempotency**: `org setup` skips already-registered projects by matching `project_id`. Safe to re-run.
 

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -30,11 +30,15 @@ description: >
   data-app create, data-app deploy, data-app password, data-app start,
   app proxy, simpleAuth, app auto-suspend, configVersion, redeploy contract,
   Data Science API, /apps endpoint, app password, KBC::Project ciphertext,
-  local workspace, project directory, kbagent init.
+  data-app secrets, app secrets, app runtime secrets, secrets-set,
+  secrets-list, secrets-get, secrets-remove, encrypt app secret,
+  app environment variable, validate repo, validate-repo,
+  data-app golden rule, pre-flight repo check, repo structure check,
   local workspace, project directory, kbagent init,
   invite user, invite member, project invitation, manage members,
   list members, remove member, change role, project role,
-  bulk invite, invite from CSV, project access, member management.
+  bulk invite, invite from CSV, project access, member management,
+  manage token prompt, --allow-env-manage-token, KBC_MANAGE_API_TOKEN.
 ---
 
 # kbagent -- Keboola Agent CLI


### PR DESCRIPTION
## Summary

Post-release audit against `CONTRIBUTING.md` 'Plugin synchronization map' caught three small drift items that slipped past the v0.29.0 release. No code or behavior changes — pure documentation.

## Findings

| # | File | Fix |
|---|------|-----|
| **D-1** | `CLAUDE.md:198` | Convention #12 said 'Default-deny since 0.28.0' — stale label from the bulk relabel sweep. Bumped to 0.29.0 (where the change actually shipped). |
| **D-2** | `SKILL.md` description | Missing trigger keywords for the three new 0.29.0 topic areas: data-app secrets (secrets-set/list/get/remove, encrypt app secret), validate-repo (golden rule, pre-flight repo check), and the manage-token default-deny flag. Without these, description-based auto-trigger won't fire when users mention these features by name. |
| **D-3** | `SKILL.md` description | Removed a duplicated 'local workspace, project directory, kbagent init.' line. |

## Why these are silent-drift

`CONTRIBUTING.md` flags both files as 'NO CI check'. The auto-generated SKILL.md decision table is checked, but the hand-written `description:` block above it isn't. CLAUDE.md isn't either. Lint passes, tests pass, but an AI agent loaded with the stale description quietly misses three feature areas at trigger time.

Caught by manual audit using the Plugin synchronization map; an explicit reminder that the per-release checklist (steps 5-8 in CONTRIBUTING.md 'Releasing a new version') is the only safety net for these surfaces.

## Test plan

- [x] `make check` passes (lint + format + skill freshness + version-sync + changelog + 2620 unit tests)
- [x] No production-code touches; diff is +7/-3 across two markdown files