### PR TITLE
fix(self-update): preserve [server] extras across kbagent update (0.40.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.40.2",
+      "version": "0.40.3",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.40.1",
+      "version": "0.40.2",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.40.1"
+version = "0.40.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.40.2"
+version = "0.40.3"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.40.2": [
+        "UX: `kbagent serve --ui` startup banner now prints copy-paste-able `export KBAGENT_SERVE_URL=... ; export KBAGENT_SERVE_TOKEN=...` lines so you can call `kbagent http get /projects` from another terminal without grepping the previous banner for the token. The plain `kbagent serve` (no `--ui`) banner gets the same hint. Closes a paper-cut where `kbagent http` printed `requires KBAGENT_SERVE_URL and KBAGENT_SERVE_TOKEN env vars` but the serve banner didn't tell you how to set them.",
+    ],
     "0.40.1": [
         "Fix: `kbagent serve --ui` now shows a friendly install hint instead of a Python traceback when the optional 'server' extras (FastAPI, uvicorn) are missing. The 0.40.0 guard only caught the `uvicorn` import; the FastAPI import inside `server/__init__.py` would still surface as a raw `ModuleNotFoundError: No module named 'fastapi'`. Both imports are now wrapped in a single guard that names the missing module and prints the correct reinstall command for both `uv tool install` (end users) and `uv pip install -e` (development).",
     ],

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.40.3": [
+        "Fix: `kbagent update` (and the startup auto-update hook) now preserves the optional `[server]` extras across upgrades. Previously `_update_kbagent` ran `uv tool install --upgrade git+...` with no `--with` flag, so the FastAPI + uvicorn extras a user originally installed with `--with 'keboola-agent-cli[server]'` were silently dropped on every upgrade -- a user who ran `kbagent serve --ui` happily yesterday got `ModuleNotFoundError: No module named 'fastapi'` after auto-update today. Now `_update_kbagent` probes `importlib.util.find_spec('fastapi')` (a reliable proxy for the `[server]` extra, which is the only thing that drags FastAPI in) and, when present, runs `uv tool install --force --with 'keboola-agent-cli[server]' git+...` instead. `--force` is paired with `--with` because uv rejects `--upgrade --with` if the additional spec resolves to a different version than the existing tool environment; `--force` is uv's documented way to reapply both flags in one shot. Pip fallback uses the PEP 508 `keboola-agent-cli[server] @ git+...` spec syntax. CLI-only users (no `[server]` extras installed) see no change.",
+    ],
     "0.40.2": [
         "UX: `kbagent serve --ui` startup banner now prints copy-paste-able `export KBAGENT_SERVE_URL=... ; export KBAGENT_SERVE_TOKEN=...` lines so you can call `kbagent http get /projects` from another terminal without grepping the previous banner for the token. The plain `kbagent serve` (no `--ui`) banner gets the same hint. Closes a paper-cut where `kbagent http` printed `requires KBAGENT_SERVE_URL and KBAGENT_SERVE_TOKEN env vars` but the serve banner didn't tell you how to set them.",
     ],

--- a/src/keboola_agent_cli/commands/serve.py
+++ b/src/keboola_agent_cli/commands/serve.py
@@ -204,6 +204,10 @@ def serve_command(
             "  set on GET /. Token never enters the JS heap or the URL.\n"
             f"  For curl / scripts: Authorization: Bearer {auth_token}\n"
             "\n"
+            "  For `kbagent http` in another terminal (bash/zsh):\n"
+            f"    export KBAGENT_SERVE_URL=http://{host}:{port}\n"
+            f"    export KBAGENT_SERVE_TOKEN={auth_token}\n"
+            "\n"
         )
     else:
         sys.stdout.write(
@@ -216,6 +220,10 @@ def serve_command(
             "\n"
             f"  Set {ENV_AUTH_TOKEN}={auth_token} for the Node BFF.\n"
             "  Tip: `kbagent serve --ui` mounts the React SPA on the same port.\n"
+            "\n"
+            "  For `kbagent http` in another terminal (bash/zsh):\n"
+            f"    export KBAGENT_SERVE_URL=http://{host}:{port}\n"
+            f"    export KBAGENT_SERVE_TOKEN={auth_token}\n"
             "\n"
         )
     sys.stdout.flush()

--- a/src/keboola_agent_cli/services/version_service.py
+++ b/src/keboola_agent_cli/services/version_service.py
@@ -542,6 +542,26 @@ class VersionService:
         return " | ".join(parts)
 
     @staticmethod
+    def _has_server_extras() -> bool:
+        """Detect whether the current install was created with ``[server]`` extras.
+
+        The detection probe is ``importlib.util.find_spec('fastapi')``: FastAPI
+        is pulled in *only* by the optional ``[server]`` extra (declared in
+        ``pyproject.toml``'s ``[project.optional-dependencies]`` table), so its
+        presence is a reliable proxy for "user originally installed with
+        ``--with 'keboola-agent-cli[server]'``".
+
+        Without this check, ``uv tool install --upgrade git+...`` re-resolves
+        the tool environment from scratch and drops anything the original
+        ``--with`` introduced -- which is how a user who ran ``kbagent serve
+        --ui`` happily yesterday gets ``ModuleNotFoundError: No module named
+        'fastapi'`` after an auto-update today.
+        """
+        import importlib.util
+
+        return importlib.util.find_spec("fastapi") is not None
+
+    @staticmethod
     def _update_kbagent() -> dict[str, Any]:
         """Run the kbagent self-upgrade subprocess (or short-circuit)."""
         old_version = __version__
@@ -556,21 +576,52 @@ class VersionService:
                 "message": f"kbagent v{old_version} is already up to date.",
             }
 
-        # Try uv tool install --upgrade first, fall back to pip.
+        # Preserve [server] extras across upgrades. ``uv tool install --upgrade``
+        # re-resolves the tool environment from the source spec alone, so unless
+        # ``--with 'keboola-agent-cli[server]'`` is passed each time, the FastAPI
+        # + uvicorn extras the user originally installed get silently dropped.
+        # We pair ``--with`` with ``--force`` (rather than ``--upgrade``) because
+        # ``uv tool install`` rejects ``--upgrade`` together with ``--with`` when
+        # the additional spec resolves to a different version than the existing
+        # tool environment -- ``--force`` is the documented way to reapply both.
+        has_server = VersionService._has_server_extras()
         uv_path = shutil.which("uv")
         if uv_path:
-            cmd = [uv_path, "tool", "install", "--upgrade", KBAGENT_INSTALL_SOURCE]
+            if has_server:
+                cmd = [
+                    uv_path,
+                    "tool",
+                    "install",
+                    "--force",
+                    "--with",
+                    "keboola-agent-cli[server]",
+                    KBAGENT_INSTALL_SOURCE,
+                ]
+            else:
+                cmd = [uv_path, "tool", "install", "--upgrade", KBAGENT_INSTALL_SOURCE]
         else:
             pip_path = shutil.which("pip")
             if pip_path is None:
+                with_flag = "--with 'keboola-agent-cli[server]' " if has_server else ""
                 return {
                     "updated": False,
                     "current_version": old_version,
                     "latest_version": kbagent_latest,
-                    "message": "Neither 'uv' nor 'pip' found on PATH. "
-                    f"Install manually: uv tool install --upgrade {KBAGENT_INSTALL_SOURCE}",
+                    "message": (
+                        "Neither 'uv' nor 'pip' found on PATH. "
+                        f"Install manually: uv tool install --upgrade {with_flag}"
+                        f"{KBAGENT_INSTALL_SOURCE}"
+                    ),
                 }
-            cmd = [pip_path, "install", "--upgrade", KBAGENT_INSTALL_SOURCE]
+            # pip extras syntax: the [server] suffix attaches to the project
+            # name in the PEP 508 spec; for git+ URLs we wrap with the project
+            # name on the left of the URL.
+            install_spec = (
+                f"keboola-agent-cli[server] @ {KBAGENT_INSTALL_SOURCE}"
+                if has_server
+                else KBAGENT_INSTALL_SOURCE
+            )
+            cmd = [pip_path, "install", "--upgrade", install_spec]
 
         try:
             result = subprocess.run(

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.40.1"
+version = "0.40.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.40.2"
+version = "0.40.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Patch release **0.40.3**. Closes a compounding UX regression on every kbagent self-update.

**Before:** every \`kbagent update\` (and the silent auto-update on startup) silently strips the optional \`[server]\` extras off the tool install, so a user who ran \`kbagent serve --ui\` yesterday gets a \`ModuleNotFoundError: No module named 'fastapi'\` after auto-update today. The friendly error from 0.40.1 was a band-aid; this is the actual fix.

**After:** \`_update_kbagent\` probes for FastAPI (the only thing the \`[server]\` extra drags in) and, when present, runs

\`\`\`
uv tool install --force --with 'keboola-agent-cli[server]' git+...
\`\`\`

instead of the bare \`--upgrade\`. CLI-only users (no \`[server]\` installed) see no behaviour change.

## Why \`--force\` instead of \`--upgrade\`

\`uv tool install\` rejects \`--upgrade\` together with \`--with\` when the additional spec resolves to a different version than the existing tool environment. \`--force\` is uv's documented way to reapply both flags in one shot. Pip fallback uses PEP 508 spec syntax: \`keboola-agent-cli[server] @ git+...\`.

## Verification

- \`make check\`: **3087 passed**
- Sanity probe: \`VersionService._has_server_extras()\` → True in my dev env (has [server] installed)
- Detection method: \`importlib.util.find_spec('fastapi')\` — reliable proxy because FastAPI is in \`[project.optional-dependencies][server]\` only

## Compound effect

This + 0.40.1 (friendly error) + 0.40.2 (banner exports) together close the full \`serve --ui\` paper-cut cycle: install is forgiving, banner is copy-paste-able, and upgrades preserve the original install shape. After this lands, the only way a user hits \`No module named 'fastapi'\` is by installing without \`--with\` in the first place — at which point the 0.40.1 hint tells them how to fix it.