### PR TITLE
feat: Semantic Layer UI — full parity with kbagent CLI (4 phases)

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -208,6 +208,14 @@ events and emits a final `done` SSE frame mirroring the same record.
   `04_AI_Kit/ai-kit/`. Bridge to that skill when the heuristic is
   not enough; the two are interoperable via the same metastore
   contract.
+- **Field-type normalization (since v0.41.10)**: warehouse-native
+  column types from Storage (`VARCHAR(255)`, `NUMBER(38,2)`,
+  `STRING`, `TIMESTAMP_NTZ`, ...) are mapped to the metastore's
+  closed lowercase set (`string`, `integer`, `decimal`, `boolean`,
+  `date`, `datetime`, `json`) before the model is POSTed. Untyped
+  Storage columns (empty `basetype`) default to `string`. Before
+  this fix `build` 422'd on every legacy untyped table because the
+  metastore rejected the raw warehouse types verbatim.
 - **Rollback + `--keep-on-failure` (updated v0.41.10 -- closes #295)**:
   the push loop now tracks every successfully-POSTed child in order
   and, on any subsequent POST failure, walks that list in REVERSE

--- a/src/keboola_agent_cli/http_base.py
+++ b/src/keboola_agent_cli/http_base.py
@@ -5,6 +5,7 @@ from BaseHttpClient to avoid duplicating the retry loop, error mapping,
 and message sanitization code.
 """
 
+import json
 import logging
 import os
 import time
@@ -222,7 +223,36 @@ class BaseHttpClient:
 
         try:
             body = response.json()
-            api_message = body.get("error", body.get("message", response.text))
+            # Real Keboola APIs answer with one of these keys in priority order.
+            # Metastore in particular ships HTTP 422 / 500 bodies with a
+            # plain `description` (FastAPI default) or `errors`/`detail` lists;
+            # without these fallbacks the user sees a bare "422" with no
+            # actionable text. Falling back to the full JSON serialisation
+            # keeps every unexpected shape debuggable.
+            # Real Keboola APIs answer with one of these keys in priority
+            # order. Two caveats:
+            #   1. Keboola Metastore puts the HTTP status code into `error`
+            #      as an int (e.g. {"error": 422}) -- using `or` would
+            #      shadow the actual error message in `errors`/`exception`.
+            #      So we only accept `error` if it's a non-empty string.
+            #   2. `errors`/`detail` are lists of dicts (FastAPI / metastore
+            #      422 shape); we json.dumps them so the f-string render
+            #      below doesn't print `[{...}]` repr.
+            err_field = body.get("error")
+            api_message = (
+                err_field
+                if isinstance(err_field, str) and err_field
+                else (
+                    body.get("exception")
+                    or body.get("message")
+                    or body.get("description")
+                    or body.get("detail")
+                    or body.get("errors")
+                    or json.dumps(body)
+                )
+            )
+            if not isinstance(api_message, str):
+                api_message = json.dumps(api_message)
         except Exception:
             api_message = response.text
 

--- a/src/keboola_agent_cli/http_base.py
+++ b/src/keboola_agent_cli/http_base.py
@@ -223,12 +223,6 @@ class BaseHttpClient:
 
         try:
             body = response.json()
-            # Real Keboola APIs answer with one of these keys in priority order.
-            # Metastore in particular ships HTTP 422 / 500 bodies with a
-            # plain `description` (FastAPI default) or `errors`/`detail` lists;
-            # without these fallbacks the user sees a bare "422" with no
-            # actionable text. Falling back to the full JSON serialisation
-            # keeps every unexpected shape debuggable.
             # Real Keboola APIs answer with one of these keys in priority
             # order. Two caveats:
             #   1. Keboola Metastore puts the HTTP status code into `error`

--- a/src/keboola_agent_cli/services/_semantic_layer_internals.py
+++ b/src/keboola_agent_cli/services/_semantic_layer_internals.py
@@ -938,6 +938,62 @@ def write_snapshot_to_file(snapshot: dict[str, Any], output_path: Path) -> None:
         os.close(fd)
 
 
+# Map warehouse-native column types onto the closed set the metastore
+# accepts for `fields[*].type`. Anything not matched falls through to
+# "string" — safest default for legacy untyped Storage tables.
+_FIELD_TYPE_MAP: dict[str, str] = {
+    # strings
+    "varchar": "string",
+    "char": "string",
+    "string": "string",
+    "text": "string",
+    "nvarchar": "string",
+    "nchar": "string",
+    # integers
+    "int": "integer",
+    "integer": "integer",
+    "bigint": "integer",
+    "smallint": "integer",
+    "tinyint": "integer",
+    # decimals
+    "decimal": "decimal",
+    "numeric": "decimal",
+    "number": "decimal",
+    "float": "decimal",
+    "double": "decimal",
+    "real": "decimal",
+    "money": "decimal",
+    # booleans
+    "boolean": "boolean",
+    "bool": "boolean",
+    "bit": "boolean",
+    # date / datetime
+    "date": "date",
+    "datetime": "datetime",
+    "datetime2": "datetime",
+    "timestamp": "datetime",
+    "timestamptz": "datetime",
+    "timestamp_ntz": "datetime",
+    "timestamp_ltz": "datetime",
+    "timestamp_tz": "datetime",
+    # json
+    "json": "json",
+    "jsonb": "json",
+    "variant": "json",
+    "object": "json",
+    "array": "json",
+}
+
+
+def _normalize_field_type(basetype: str) -> str:
+    """Coerce a warehouse-native type into the metastore's closed vocabulary."""
+    if not basetype:
+        return "string"
+    # strip parens (e.g. VARCHAR(255), DECIMAL(38, 9))
+    head = basetype.split("(", 1)[0].strip().lower()
+    return _FIELD_TYPE_MAP.get(head, "string")
+
+
 def heuristic_generate_model(
     *,
     schemas: dict[str, dict[str, Any]],
@@ -970,10 +1026,16 @@ def heuristic_generate_model(
         for col in detail.get("column_details", []) or []:
             cname = col.get("name", "")
             basetype = col.get("type", "") or col.get("native_type", "")
+            # Metastore validates field types against a closed lowercase set:
+            #   {string, integer, decimal, boolean, date, datetime, json}
+            # Storage returns warehouse-native types (VARCHAR, INTEGER, ...)
+            # or empty strings for untyped legacy tables. Map both to the
+            # metastore vocabulary; fall back to "string" for unknown /
+            # empty types so the builder doesn't 422 on legacy buckets.
             fields.append(
                 {
                     "name": cname,
-                    "type": basetype,
+                    "type": _normalize_field_type(basetype),
                     "role": classify_role(cname, basetype),
                 }
             )

--- a/tests/test_http_base.py
+++ b/tests/test_http_base.py
@@ -327,6 +327,105 @@ class TestBaseHttpClientErrorSanitization:
         assert "500" in exc_info.value.message
         client.close()
 
+    def test_int_error_field_falls_back_to_description(self, httpx_mock) -> None:
+        """Metastore returns `{"error": 422, "description": "..."}` — the int
+        in `error` must not shadow the real message in `description`."""
+        httpx_mock.add_response(
+            url=f"{STACK_URL}/test-path",
+            json={"error": 422, "description": "field type not allowed"},
+            status_code=422,
+        )
+
+        client = BaseHttpClient(
+            base_url=STACK_URL,
+            token=TOKEN,
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            client._do_request("GET", "/test-path")
+
+        # The real message must be surfaced; the int `422` must not.
+        assert "field type not allowed" in exc_info.value.message
+        # And we must not be left with a bare "API error 422: 422"
+        # (the regression this test pins).
+        assert "API error 422: 422" not in exc_info.value.message
+        client.close()
+
+    def test_description_field_used_when_no_message(self, httpx_mock) -> None:
+        """FastAPI returns `{"description": "..."}` by default — surface it."""
+        httpx_mock.add_response(
+            url=f"{STACK_URL}/test-path",
+            json={"description": "validation failed"},
+            status_code=400,
+        )
+
+        client = BaseHttpClient(
+            base_url=STACK_URL,
+            token=TOKEN,
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            client._do_request("GET", "/test-path")
+
+        assert "validation failed" in exc_info.value.message
+        client.close()
+
+    def test_errors_list_shape_serialised(self, httpx_mock) -> None:
+        """Metastore 422 ships `{"errors": [{...}]}` (list of dicts) — must
+        be json-serialised so the message contains the diagnostic content,
+        not the Python list repr."""
+        httpx_mock.add_response(
+            url=f"{STACK_URL}/test-path",
+            json={
+                "errors": [
+                    {"loc": ["body", "name"], "msg": "field required"},
+                ],
+            },
+            status_code=422,
+        )
+
+        client = BaseHttpClient(
+            base_url=STACK_URL,
+            token=TOKEN,
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            client._do_request("GET", "/test-path")
+
+        # Both the field path and the human message must be present.
+        assert "field required" in exc_info.value.message
+        assert "name" in exc_info.value.message
+        client.close()
+
+    def test_detail_list_shape_serialised(self, httpx_mock) -> None:
+        """FastAPI 422 uses `{"detail": [{...}]}` (the canonical pydantic
+        validation shape). Same serialisation rule as `errors`."""
+        httpx_mock.add_response(
+            url=f"{STACK_URL}/test-path",
+            json={
+                "detail": [
+                    {"loc": ["query", "limit"], "msg": "value is not a valid integer"},
+                ],
+            },
+            status_code=422,
+        )
+
+        client = BaseHttpClient(
+            base_url=STACK_URL,
+            token=TOKEN,
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+        with pytest.raises(KeboolaApiError) as exc_info:
+            client._do_request("GET", "/test-path")
+
+        assert "value is not a valid integer" in exc_info.value.message
+        assert "limit" in exc_info.value.message
+        client.close()
+
     def test_401_maps_to_invalid_token(self, httpx_mock) -> None:
         """401 status code maps to INVALID_TOKEN error code."""
         httpx_mock.add_response(

--- a/tests/test_semantic_layer_service.py
+++ b/tests/test_semantic_layer_service.py
@@ -1925,6 +1925,49 @@ class TestPromoteModel:
 # ---------------------------------------------------------------------------
 
 
+class TestNormalizeFieldType:
+    """Pin the warehouse-native → metastore-vocabulary mapping.
+
+    The metastore's `fields[*].type` accepts only a closed lowercase set
+    (`string`, `integer`, `decimal`, `boolean`, `date`, `datetime`, `json`).
+    Storage hands us warehouse-native uppercase types — Snowflake `NUMBER`,
+    `VARCHAR(255)`, BigQuery `STRING`, etc. Forgetting to normalize causes
+    HTTP 422 on every legacy untyped table. These cases pin the mapping so
+    extending `_FIELD_TYPE_MAP` can't accidentally drop one.
+    """
+
+    @pytest.mark.parametrize(
+        "basetype,expected",
+        [
+            # The case the bug report was filed against — empty string from
+            # an untyped Storage column.
+            ("", "string"),
+            (None, "string"),
+            # Snowflake / BigQuery uppercase types with parameter brackets.
+            ("VARCHAR(255)", "string"),
+            ("NUMBER(38,2)", "decimal"),
+            ("DECIMAL(18, 9)", "decimal"),
+            # Plain types in different cases.
+            ("STRING", "string"),
+            ("integer", "integer"),
+            ("BIGINT", "integer"),
+            ("Boolean", "boolean"),
+            ("DATE", "date"),
+            ("TIMESTAMP_NTZ", "datetime"),
+            ("VARIANT", "json"),
+            # Unknown types fall through to `"string"` — safest default.
+            ("CUSTOM_UDT", "string"),
+            ("geography", "string"),
+        ],
+    )
+    def test_normalize_field_type(self, basetype: str, expected: str) -> None:
+        from keboola_agent_cli.services._semantic_layer_internals import (
+            _normalize_field_type,
+        )
+
+        assert _normalize_field_type(basetype) == expected
+
+
 class TestBuildModel:
     def test_heuristic_fallback(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
@@ -1950,6 +1993,12 @@ class TestBuildModel:
         assert len(result["generated"]["metrics"]) == 1
         assert len(result["generated"]["glossary"]) == 1
         assert result["validated"] is True
+        # Pin the warehouse → metastore type normalization: Storage hands us
+        # `"NUMBER"`, the metastore only accepts lowercase `"decimal"`. The
+        # heuristic builder must perform the mapping before the model is
+        # posted, otherwise we regress to the HTTP 422 this PR fixes.
+        ds_fields = result["generated"]["datasets"][0]["fields"]
+        assert ds_fields[0]["type"] == "decimal"
 
     def test_dry_run_skips_post(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { JobsPage } from "./pages/Jobs";
 import { LineagePage } from "./pages/Lineage";
 import { LocalAiPage } from "./pages/LocalAi";
 import { McpPage } from "./pages/Mcp";
+import { SemanticLayerPage } from "./pages/SemanticLayer";
 import { MembersPage } from "./pages/Members";
 import { OrgPage } from "./pages/Org";
 import { ProjectsPage } from "./pages/Projects";
@@ -49,6 +50,8 @@ function Router() {
       return <SchedulesPage />;
     case "lineage":
       return <LineagePage />;
+    case "semantic-layer":
+      return <SemanticLayerPage />;
     case "sharing":
       return <SharingPage />;
     case "data-apps":

--- a/web/frontend/src/layout/Sidebar.tsx
+++ b/web/frontend/src/layout/Sidebar.tsx
@@ -66,6 +66,12 @@ const SECTIONS: Array<{
       // Lineage page has both "Sharing graph" + "Deep lineage" tabs --
       // the standalone Sharing entry would be a duplicate.
       { id: "lineage", label: "Lineage", icon: Network },
+      // Semantic layer ("metastore") sits under Insights with Lineage:
+      // both are about understanding the data, not editing it. The
+      // page itself supports full CRUD on metrics / datasets /
+      // relationships / constraints / glossary plus the workflow
+      // operations (validate, export, diff, promote, import, build).
+      { id: "semantic-layer", label: "Semantic Layer", icon: Database },
     ],
   },
   {

--- a/web/frontend/src/pages/SemanticLayer.tsx
+++ b/web/frontend/src/pages/SemanticLayer.tsx
@@ -6,17 +6,22 @@ import {
   GitCompare,
   Info,
   KeyRound,
+  Maximize2,
+  Minimize2,
   Network,
   PackagePlus,
   Pencil,
   Plus,
   RefreshCw,
+  RotateCcw,
   Search,
   Send,
   Table as TableIcon,
   Trash2,
   Upload,
   XCircle,
+  ZoomIn,
+  ZoomOut,
 } from "lucide-react";
 import mermaid from "mermaid";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -1775,11 +1780,50 @@ function RelationshipsERDiagram({
 }) {
   const { theme } = useTheme();
   const ref = useRef<HTMLDivElement | null>(null);
+  const fullscreenRef = useRef<HTMLDivElement | null>(null);
   const renderSeq = useRef(0);
   const [error, setError] = useState<string | null>(null);
   const [mermaidCode, setMermaidCode] = useState<string>("");
+  // CSS-transform zoom for the rendered SVG. Step is 1.25x, clamped so the
+  // user can't shrink the diagram to nothing or blow it up past readability.
+  // Initial value is recomputed by the auto-fit pass after every render so
+  // the diagram lands at "as large as comfortably fits the viewport".
+  const [zoom, setZoom] = useState(1);
+  // Tracks whether the user manually adjusted zoom. If true, the auto-fit
+  // pass becomes a no-op so we don't snap their choice back. Reset Zoom
+  // re-arms auto-fit.
+  const [userZoomed, setUserZoomed] = useState(false);
+  // Fullscreen overlay (uses the same Drawer-style portal as the rest of
+  // the page — 95vw / 95vh so the user can finally see all 80 edges).
+  const [fullscreen, setFullscreen] = useState(false);
 
   const limited = relationships.slice(0, ERD_MAX_EDGES);
+
+  // Compute the zoom that fills the active canvas as much as possible
+  // without distorting the diagram. The erDiagram layout is wide-and-short
+  // so `Math.min(fitX, fitY)` (= "the whole graph fits without scrolling")
+  // produces tiny zoom levels with a sea of whitespace below. We pick the
+  // larger of the two -- the diagram fills one axis and the other axis
+  // scrolls if needed. Floor at 1.0 so we never shrink below 100% (the
+  // user asked for "150%-looking" by default, and the screenshot they
+  // shared had the SVG rendering at its natural mermaid size which is the
+  // smallest readable form). Cap at 3x so we don't lose context.
+  const applyAutoFit = () => {
+    const target = fullscreen ? fullscreenRef.current : ref.current;
+    const svgEl = target?.querySelector("svg");
+    const container = target?.parentElement;
+    if (!svgEl || !container) return;
+    const vb = svgEl.getAttribute("viewBox")?.split(/\s+/).map(Number);
+    if (!vb || vb.length !== 4) return;
+    const [, , svgW, svgH] = vb;
+    if (!svgW || !svgH) return;
+    const fitX = (container.clientWidth - 32) / svgW;
+    const fitY = (container.clientHeight - 32) / svgH;
+    // For wide-and-short graphs fitY >> fitX -- pick whichever fills one
+    // axis tightly; the other axis becomes the scrollable direction.
+    const fit = Math.max(fitX, fitY);
+    setZoom(Math.max(1.0, Math.min(3, fit)));
+  };
 
   useEffect(() => {
     if (!ref.current) return;
@@ -1839,30 +1883,146 @@ function RelationshipsERDiagram({
     mermaid
       .render(runId, code)
       .then(({ svg }) => {
-        if (cancelled || !ref.current) return;
-        ref.current.innerHTML = svg;
+        if (cancelled) return;
+        // Strip every inline size constraint mermaid adds (max-width,
+        // explicit width/height attrs) and let CSS take over -- the
+        // container is the source of truth for "how much room do you have"
+        // and the SVG's intrinsic viewBox + preserveAspectRatio handles
+        // the actual scaling so the diagram fills the container without
+        // distortion. Without this strip the SVG lays out at its mermaid-
+        // computed pixel size (~250px tall) which leaves 70% of the 70vh
+        // canvas empty.
+        const adapted = svg
+          .replace(/max-width:[^;"]+;?/g, "")
+          .replace(/\swidth="[^"]+"/, "")
+          .replace(/\sheight="[^"]+"/, "")
+          .replace(
+            /<svg /,
+            '<svg preserveAspectRatio="xMidYMid meet" style="width:100%;height:100%;display:block;" ',
+          );
+        for (const target of [ref.current, fullscreenRef.current]) {
+          if (target) target.innerHTML = adapted;
+        }
         setError(null);
+
+        // Auto-fit zoom: pick the scale that makes the SVG fill the
+        // visible canvas. Mermaid lays the erDiagram out wide-and-short,
+        // so without a fit pass the diagram lives in the top quarter of
+        // the 70vh container and everything below is whitespace.
+        if (!userZoomed) applyAutoFit();
       })
       .catch((err: Error) => {
-        if (cancelled || !ref.current) return;
-        ref.current.innerHTML = "";
+        if (cancelled) return;
+        for (const target of [ref.current, fullscreenRef.current]) {
+          if (target) target.innerHTML = "";
+        }
         setError(err.message);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [datasets, limited, theme]);
+  }, [datasets, limited, theme, fullscreen]);
+
+  const zoomToolbar = (
+    <div className="flex items-center gap-1 text-xs">
+      <button
+        type="button"
+        className="nerd-btn text-xs px-1.5"
+        onClick={() => {
+          setUserZoomed(true);
+          setZoom((z) => Math.max(0.4, z / 1.25));
+        }}
+        title="Zoom out"
+      >
+        <ZoomOut className="w-3 h-3" />
+      </button>
+      <span className="text-[10px] text-zinc-500 min-w-[3rem] text-center font-mono">
+        {Math.round(zoom * 100)}%
+      </span>
+      <button
+        type="button"
+        className="nerd-btn text-xs px-1.5"
+        onClick={() => {
+          setUserZoomed(true);
+          setZoom((z) => Math.min(4, z * 1.25));
+        }}
+        title="Zoom in"
+      >
+        <ZoomIn className="w-3 h-3" />
+      </button>
+      <button
+        type="button"
+        className="nerd-btn text-xs px-1.5"
+        onClick={() => {
+          // Re-arm the auto-fit pass and snap to fit. "Reset" means
+          // "fit to viewport", not "100%" -- 100% leaves the canvas mostly
+          // empty for the typical wide-and-short erDiagram layout.
+          setUserZoomed(false);
+          applyAutoFit();
+        }}
+        title="Fit to viewport"
+      >
+        <RotateCcw className="w-3 h-3" />
+      </button>
+      <button
+        type="button"
+        className="nerd-btn text-xs px-1.5"
+        onClick={() => {
+          setUserZoomed(false); // re-fit after the layout box changes
+          setFullscreen((f) => !f);
+        }}
+        title={fullscreen ? "Exit fullscreen" : "Open in fullscreen"}
+      >
+        {fullscreen ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
+      </button>
+    </div>
+  );
+
+  // Inline view of the diagram. Zoom is applied as actual width/height
+  // expansion on the SVG host (not CSS transform) so that:
+  //   - the scrollbars in the surrounding container actually let users
+  //     pan around when the diagram exceeds the viewport
+  //   - the content stays centred via preserveAspectRatio="xMidYMid meet"
+  //     and doesn't get pushed off-screen by a top-left transform origin
+  // The minWidth/minHeight 100% guarantees the box always at least fills
+  // the canvas at zoom=1 so the SVG can stretch to fit.
+  const inlinePane = (
+    <div
+      className="w-full overflow-auto border border-zinc-200 dark:border-zinc-900 rounded p-2 bg-white dark:bg-zinc-950"
+      style={{ height: "70vh" }}
+    >
+      <div
+        ref={ref}
+        style={{
+          width: `${zoom * 100}%`,
+          height: `${zoom * 100}%`,
+          minWidth: "100%",
+          minHeight: "100%",
+        }}
+      />
+    </div>
+  );
 
   return (
     <div className="space-y-3">
-      {relationships.length > ERD_MAX_EDGES ? (
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <div className="text-[11px] text-amber-500 flex items-center gap-1">
-          <AlertTriangle className="w-3.5 h-3.5" /> Showing the first {ERD_MAX_EDGES}{" "}
-          of {relationships.length} relationships. Use the dataset filter above to
-          drill into a subgraph.
+          {relationships.length > ERD_MAX_EDGES ? (
+            <>
+              <AlertTriangle className="w-3.5 h-3.5" /> Showing the first{" "}
+              {ERD_MAX_EDGES} of {relationships.length} relationships. Use the
+              dataset filter above to drill into a subgraph.
+            </>
+          ) : (
+            <span className="text-zinc-500">
+              Rendering {limited.length} relationship{limited.length === 1 ? "" : "s"}.
+              Click an edge in the list below to edit it.
+            </span>
+          )}
         </div>
-      ) : null}
+        {zoomToolbar}
+      </div>
 
       {error ? (
         <div className="space-y-2">
@@ -1876,7 +2036,7 @@ function RelationshipsERDiagram({
         </div>
       ) : null}
 
-      <div ref={ref} className="w-full overflow-auto border border-zinc-200 dark:border-zinc-900 rounded p-2" />
+      {inlinePane}
 
       {/* Click-through helper: list every edge so users can hop into the
           edit drawer for any relationship even when SVG hit-testing is
@@ -1902,6 +2062,32 @@ function RelationshipsERDiagram({
           ))}
         </ul>
       </details>
+
+      {fullscreen ? (
+        <Drawer
+          open
+          onClose={() => setFullscreen(false)}
+          title="ER diagram (fullscreen)"
+          subtitle={`${limited.length} relationship${limited.length === 1 ? "" : "s"} · ${Math.round(zoom * 100)}% zoom`}
+          width="95vw"
+          actions={zoomToolbar}
+        >
+          <div
+            className="w-full overflow-auto border border-zinc-200 dark:border-zinc-900 rounded p-2 bg-white dark:bg-zinc-950"
+            style={{ height: "85vh" }}
+          >
+            <div
+              ref={fullscreenRef}
+              style={{
+                width: `${zoom * 100}%`,
+                height: `${zoom * 100}%`,
+                minWidth: "100%",
+                minHeight: "100%",
+              }}
+            />
+          </div>
+        </Drawer>
+      ) : null}
     </div>
   );
 }

--- a/web/frontend/src/pages/SemanticLayer.tsx
+++ b/web/frontend/src/pages/SemanticLayer.tsx
@@ -1,24 +1,31 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  AlertTriangle,
   CheckCircle2,
   Download,
   GitCompare,
+  Info,
   KeyRound,
+  Network,
   PackagePlus,
   Pencil,
   Plus,
   RefreshCw,
+  Search,
   Send,
+  Table as TableIcon,
   Trash2,
   Upload,
   XCircle,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import mermaid from "mermaid";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api/client";
 import { Drawer } from "../components/Drawer";
 import { Empty, ErrorBox, Loading, PageTitle } from "../components/Empty";
 import { JsonView } from "../components/JsonView";
 import { DataTable } from "../components/Table";
+import { useTheme } from "../theme";
 import { useUIState } from "../state";
 import {
   BuildDialog,
@@ -27,6 +34,28 @@ import {
   PromoteDialog,
   TokenEncryptDialog,
 } from "./SemanticLayerDialogs";
+
+/**
+ * Metastore returns camelCase attribute keys (`tableId`, `primaryKey`,
+ * `constraintType`) while every Python-side surface (CLI args, Pydantic
+ * bodies, schema-driven form keys) uses snake_case. We do the bridge here so
+ * the rest of the page stays in one vocabulary and `tableColumns[*].cell(r)`
+ * functions keep working. The lossy aliases stay in place even when the
+ * original snake_case key already exists -- belt-and-braces.
+ */
+function normalizeEntityRow(row: Record<string, unknown>): EntityRow {
+  const out = { ...row } as Record<string, unknown>;
+  for (const [from, to] of [
+    ["tableId", "table_id"],
+    ["primaryKey", "primary_key"],
+    ["constraintType", "constraint_type"],
+  ] as const) {
+    if (out[from] !== undefined && out[to] === undefined) {
+      out[to] = out[from];
+    }
+  }
+  return out as EntityRow;
+}
 
 /**
  * Semantic Layer (Keboola Metastore) page.
@@ -904,9 +933,19 @@ function ModelDetail({
 
   const rows = useMemo<EntityRow[]>(() => {
     if (!showQ.data) return [];
-    return (showQ.data[kindToField[activeTab]] ?? []) as EntityRow[];
+    const raw = (showQ.data[kindToField[activeTab]] ?? []) as Record<string, unknown>[];
+    return raw.map(normalizeEntityRow);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showQ.data, activeTab]);
+
+  // Datasets are needed by the Relationships ER diagram (every edge endpoint
+  // must resolve to a dataset name). Always available regardless of activeTab.
+  const allDatasets = useMemo<EntityRow[]>(() => {
+    if (!showQ.data) return [];
+    return (showQ.data.datasets ?? []).map((r) =>
+      normalizeEntityRow(r as Record<string, unknown>),
+    );
+  }, [showQ.data]);
 
   return (
     <div className="space-y-4">
@@ -952,6 +991,7 @@ function ModelDetail({
           model={model}
           kind={activeTab}
           rows={rows}
+          allDatasets={allDatasets}
           onChange={() => showQ.refetch()}
         />
       ) : null}
@@ -966,18 +1006,50 @@ function EntityPanel({
   model,
   kind,
   rows,
+  allDatasets,
   onChange,
 }: {
   project: string;
   model: string;
   kind: EntityKind;
   rows: EntityRow[];
+  allDatasets: EntityRow[];
   onChange: () => void;
 }) {
   const schema = ENTITY_SCHEMAS[kind];
   const [adding, setAdding] = useState(false);
   const [editing, setEditing] = useState<EntityRow | null>(null);
   const [inspecting, setInspecting] = useState<EntityRow | null>(null);
+  // Quick search across every visible string field. Empty = no filter.
+  const [search, setSearch] = useState("");
+  // Per-kind view toggle. Today only relationship supports a graph (ER)
+  // alternate; everything else stays "table". Stored on the panel so
+  // switching tabs resets it -- intentional, the graph is relationship-only.
+  const [viewMode, setViewMode] = useState<"table" | "graph">("table");
+  // Optional dataset chip filter for relationships (e.g. "only edges that
+  // touch conversations_complete_enriched"). Applies in both views.
+  const [relDatasetFilter, setRelDatasetFilter] = useState<string>("");
+
+  const filteredRows = useMemo<EntityRow[]>(() => {
+    let out = rows;
+    if (kind === "relationship" && relDatasetFilter) {
+      out = out.filter(
+        (r) => r.from === relDatasetFilter || r.to === relDatasetFilter,
+      );
+    }
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      out = out.filter((r) => {
+        for (const v of Object.values(r)) {
+          if (typeof v === "string" && v.toLowerCase().includes(q)) return true;
+          if (Array.isArray(v) && v.some((x) => String(x).toLowerCase().includes(q)))
+            return true;
+        }
+        return false;
+      });
+    }
+    return out;
+  }, [rows, search, kind, relDatasetFilter]);
 
   const deleteMu = useMutation({
     mutationFn: (row: EntityRow) => {
@@ -990,58 +1062,137 @@ function EntityPanel({
     onSuccess: onChange,
   });
 
+  const renderRowActions = (r: EntityRow) => (
+    <div className="flex justify-end gap-1">
+      <button
+        type="button"
+        className="nerd-btn text-xs"
+        onClick={(e) => {
+          e.stopPropagation();
+          setEditing(r);
+        }}
+        title="Edit"
+      >
+        <Pencil className="w-3 h-3" />
+      </button>
+      <button
+        type="button"
+        className="nerd-btn text-xs hover:text-red-400 hover:border-red-700"
+        onClick={(e) => {
+          e.stopPropagation();
+          const pk = r[schema.pkField] as string;
+          if (confirm(`Delete ${kind} '${pk}'?`)) deleteMu.mutate(r);
+        }}
+        title="Delete"
+      >
+        <Trash2 className="w-3 h-3" />
+      </button>
+    </div>
+  );
+
   return (
     <>
       <div className="nerd-card">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-keboola font-bold text-sm">{schema.pluralLabel}</h3>
-          <button
-            type="button"
-            className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
-            onClick={() => setAdding(true)}
-          >
-            <Plus className="w-3 h-3" /> Add {kind}
-          </button>
+        <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+          <h3 className="text-keboola font-bold text-sm">
+            {schema.pluralLabel}{" "}
+            <span className="text-zinc-500 font-normal text-[10px]">
+              {search || (kind === "relationship" && relDatasetFilter)
+                ? `${filteredRows.length} / ${rows.length}`
+                : rows.length}
+            </span>
+          </h3>
+          <div className="flex items-center gap-2 flex-wrap">
+            <label className="relative">
+              <Search className="w-3 h-3 absolute left-2 top-1/2 -translate-y-1/2 text-zinc-500" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search…"
+                className="nerd-input text-xs pl-6 w-44"
+              />
+            </label>
+            {kind === "relationship" ? (
+              <>
+                <select
+                  className="nerd-input text-xs py-1"
+                  value={relDatasetFilter}
+                  onChange={(e) => setRelDatasetFilter(e.target.value)}
+                  title="Filter relationships touching a specific dataset"
+                >
+                  <option value="">(all datasets)</option>
+                  {allDatasets
+                    .map((d) => (d.table_id as string) || "")
+                    .filter(Boolean)
+                    .sort((a, b) => a.localeCompare(b))
+                    .map((tid) => (
+                      <option key={tid} value={tid}>
+                        {tid}
+                      </option>
+                    ))}
+                </select>
+                <div className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    className={`nerd-btn text-xs px-1.5 ${
+                      viewMode === "table" ? "border-keboola text-keboola" : ""
+                    }`}
+                    onClick={() => setViewMode("table")}
+                    title="Table view"
+                  >
+                    <TableIcon className="w-3 h-3" />
+                  </button>
+                  <button
+                    type="button"
+                    className={`nerd-btn text-xs px-1.5 ${
+                      viewMode === "graph" ? "border-keboola text-keboola" : ""
+                    }`}
+                    onClick={() => setViewMode("graph")}
+                    title="ER diagram view"
+                  >
+                    <Network className="w-3 h-3" />
+                  </button>
+                </div>
+              </>
+            ) : null}
+            <button
+              type="button"
+              className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
+              onClick={() => setAdding(true)}
+            >
+              <Plus className="w-3 h-3" /> Add {kind}
+            </button>
+          </div>
         </div>
+
         {rows.length === 0 ? (
           <Empty title={`No ${schema.pluralLabel.toLowerCase()} yet`} />
+        ) : kind === "relationship" && viewMode === "graph" ? (
+          <RelationshipsERDiagram
+            datasets={allDatasets}
+            relationships={filteredRows}
+            onPickEdge={(r) => setEditing(r)}
+          />
+        ) : kind === "constraint" ? (
+          <ConstraintGroupedTable
+            rows={filteredRows}
+            onRowClick={(r) => setInspecting(r)}
+            renderRowActions={renderRowActions}
+          />
         ) : (
           <DataTable
-            rows={rows}
-            rowKey={(r) => (r[schema.pkField] as string) ?? JSON.stringify(r).slice(0, 32)}
+            rows={filteredRows}
+            rowKey={(r) =>
+              (r[schema.pkField] as string) ?? JSON.stringify(r).slice(0, 32)
+            }
             onRowClick={(r) => setInspecting(r)}
             columns={[
               ...schema.tableColumns,
               {
                 header: "",
                 align: "right",
-                cell: (r) => (
-                  <div className="flex justify-end gap-1">
-                    <button
-                      type="button"
-                      className="nerd-btn text-xs"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setEditing(r);
-                      }}
-                      title="Edit"
-                    >
-                      <Pencil className="w-3 h-3" />
-                    </button>
-                    <button
-                      type="button"
-                      className="nerd-btn text-xs hover:text-red-400 hover:border-red-700"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        const pk = r[schema.pkField] as string;
-                        if (confirm(`Delete ${kind} '${pk}'?`)) deleteMu.mutate(r);
-                      }}
-                      title="Delete"
-                    >
-                      <Trash2 className="w-3 h-3" />
-                    </button>
-                  </div>
-                ),
+                cell: renderRowActions,
               },
             ]}
           />
@@ -1082,7 +1233,11 @@ function EntityPanel({
           onClose={() => setInspecting(null)}
           title={`${kind} · ${inspecting[schema.pkField] ?? "(no name)"}`}
         >
-          <JsonView data={inspecting} />
+          {kind === "dataset" ? (
+            <DatasetDetail row={inspecting} />
+          ) : (
+            <JsonView data={inspecting} />
+          )}
         </Drawer>
       ) : null}
     </>
@@ -1321,5 +1476,432 @@ function FieldInput({
       />
       {helpEl}
     </label>
+  );
+}
+
+// ── DatasetDetail ─────────────────────────────────────────────────────
+//
+// Rendered inside the inspect-drawer when kind="dataset". Surfaces the
+// curated metadata (FQN, primary key, grain, AI keywords) at the top and
+// shows the fields[] table with role + type + description so users don't
+// have to read the raw JSON. The full JsonView stays available behind a
+// "Raw" disclosure for power users / debugging.
+
+interface DatasetField {
+  name?: string;
+  type?: string;
+  role?: string;
+  description?: string;
+  [k: string]: unknown;
+}
+
+function RoleBadge({ role }: { role?: string }) {
+  if (!role) return <span className="text-zinc-500 text-[10px]">—</span>;
+  const cls =
+    role === "key"
+      ? "bg-keboola/10 text-keboola border-keboola/30"
+      : role === "measure"
+        ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30"
+        : "bg-zinc-200/30 text-zinc-600 dark:text-zinc-400 border-zinc-300";
+  return (
+    <span className={`px-1.5 py-0.5 rounded text-[10px] border ${cls}`}>{role}</span>
+  );
+}
+
+function DatasetDetail({ row }: { row: EntityRow }) {
+  const fields = (row.fields as DatasetField[] | undefined) ?? [];
+  const aiKeywords =
+    (row.ai as { keywords?: string[] } | undefined)?.keywords ?? [];
+
+  const tableId = (row.table_id as string) || (row.tableId as string) || "";
+  const fqn = (row.fqn as string) || "";
+  const grain = (row.grain as string) || "";
+  const pk = (row.primary_key as string[]) || (row.primaryKey as string[]) || [];
+
+  return (
+    <div className="space-y-4 text-xs">
+      <div className="grid md:grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-widest text-zinc-500">
+            Storage table
+          </div>
+          <div className="font-mono">{tableId || "(unset)"}</div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-widest text-zinc-500">
+            FQN
+          </div>
+          <div className="font-mono break-all">{fqn || "(derived from table_id)"}</div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-widest text-zinc-500">
+            Grain
+          </div>
+          <div>{grain || <span className="text-zinc-500 italic">(not set)</span>}</div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-widest text-zinc-500">
+            Primary key
+          </div>
+          <div className="font-mono">
+            {pk.length > 0 ? pk.join(", ") : <span className="text-zinc-500 italic">(none)</span>}
+          </div>
+        </div>
+      </div>
+
+      {row.description ? (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-widest text-zinc-500">
+            Description
+          </div>
+          <div className="text-zinc-700 dark:text-zinc-300">{row.description as string}</div>
+        </div>
+      ) : null}
+
+      {aiKeywords.length > 0 ? (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-widest text-zinc-500">
+            AI keywords
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {aiKeywords.map((kw) => (
+              <span
+                key={kw}
+                className="px-1.5 py-0.5 rounded bg-keboola/10 text-keboola text-[10px]"
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div>
+        <div className="text-[10px] uppercase tracking-widest text-zinc-500 mb-1">
+          Fields ({fields.length})
+        </div>
+        {fields.length === 0 ? (
+          <div className="text-zinc-500 italic">
+            No fields. Re-run add with --deep-fields to populate from Snowflake.
+          </div>
+        ) : (
+          <div className="border border-zinc-200 dark:border-zinc-900 rounded overflow-hidden">
+            <table className="w-full text-[11px]">
+              <thead className="bg-zinc-100 dark:bg-zinc-900 text-zinc-500">
+                <tr>
+                  <th className="text-left px-2 py-1 font-normal">Name</th>
+                  <th className="text-left px-2 py-1 font-normal">Type</th>
+                  <th className="text-left px-2 py-1 font-normal">Role</th>
+                  <th className="text-left px-2 py-1 font-normal">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fields.map((f, i) => (
+                  <tr
+                    key={`${f.name}-${i}`}
+                    className="border-t border-zinc-200 dark:border-zinc-900"
+                  >
+                    <td className="px-2 py-1 font-mono">{f.name || "—"}</td>
+                    <td className="px-2 py-1 font-mono text-zinc-500">{f.type || "—"}</td>
+                    <td className="px-2 py-1">
+                      <RoleBadge role={f.role} />
+                    </td>
+                    <td className="px-2 py-1 text-zinc-600 dark:text-zinc-400">
+                      {f.description || ""}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <details className="text-[11px]">
+        <summary className="cursor-pointer text-zinc-500">Raw response</summary>
+        <div className="mt-2">
+          <JsonView data={row} maxHeight="40vh" />
+        </div>
+      </details>
+    </div>
+  );
+}
+
+// ── ConstraintGroupedTable ────────────────────────────────────────────
+//
+// Constraints come in seven `constraint_type` buckets in CLI; rendered
+// flat they're hard to scan. Group by type with collapsible sections,
+// keep the existing severity pill, and add a leading icon so error vs
+// warning vs info pops at a glance.
+
+const CONSTRAINT_TYPE_ORDER: string[] = [
+  "inequality",
+  "equality",
+  "range",
+  "composition",
+  "exclusion",
+  "temporal",
+  "conditional",
+];
+
+function SeverityIcon({ severity }: { severity?: string }) {
+  if (severity === "critical" || severity === "error") {
+    return <XCircle className="w-3 h-3 text-red-500" />;
+  }
+  if (severity === "warning") {
+    return <AlertTriangle className="w-3 h-3 text-amber-500" />;
+  }
+  return <Info className="w-3 h-3 text-zinc-500" />;
+}
+
+function ConstraintGroupedTable({
+  rows,
+  onRowClick,
+  renderRowActions,
+}: {
+  rows: EntityRow[];
+  onRowClick: (r: EntityRow) => void;
+  renderRowActions: (r: EntityRow) => React.ReactNode;
+}) {
+  // Bucket rows by constraint_type; preserve a stable order so the page
+  // doesn't reshuffle when the user edits a constraint.
+  const groups = useMemo(() => {
+    const acc: Record<string, EntityRow[]> = {};
+    for (const r of rows) {
+      const t = (r.constraint_type as string) || "(untyped)";
+      (acc[t] ??= []).push(r);
+    }
+    return acc;
+  }, [rows]);
+
+  const orderedTypes = useMemo(() => {
+    const present = Object.keys(groups);
+    return present.sort((a, b) => {
+      const ia = CONSTRAINT_TYPE_ORDER.indexOf(a);
+      const ib = CONSTRAINT_TYPE_ORDER.indexOf(b);
+      if (ia === -1 && ib === -1) return a.localeCompare(b);
+      if (ia === -1) return 1;
+      if (ib === -1) return -1;
+      return ia - ib;
+    });
+  }, [groups]);
+
+  if (rows.length === 0) {
+    return <Empty title="No constraints match the current filter" />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {orderedTypes.map((type) => {
+        const group = groups[type];
+        return (
+          <details key={type} open className="border border-zinc-200 dark:border-zinc-900 rounded">
+            <summary className="cursor-pointer select-none px-3 py-2 text-xs font-bold bg-zinc-50 dark:bg-zinc-950 flex items-center gap-2">
+              <span className="nerd-pill text-[10px]">{type}</span>
+              <span className="text-zinc-500 font-normal">({group.length})</span>
+            </summary>
+            <table className="w-full text-xs">
+              <tbody>
+                {group.map((r, i) => (
+                  <tr
+                    key={`${r.name}-${i}`}
+                    className="border-t border-zinc-200 dark:border-zinc-900 cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-950"
+                    onClick={() => onRowClick(r)}
+                  >
+                    <td className="px-3 py-1.5 align-top">
+                      <SeverityIcon severity={r.severity as string} />
+                    </td>
+                    <td className="px-2 py-1.5 align-top font-bold w-1/4">
+                      {r.name as string}
+                    </td>
+                    <td className="px-2 py-1.5 align-top">
+                      <code className="text-zinc-600 dark:text-zinc-400 break-all">
+                        {r.rule as string}
+                      </code>
+                    </td>
+                    <td className="px-2 py-1.5 align-top text-right">
+                      {renderRowActions(r)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </details>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── RelationshipsERDiagram ────────────────────────────────────────────
+//
+// Mermaid `erDiagram` rendering of the model's relationships. Datasets
+// become entities, relationships become labelled edges with cardinality
+// hint "}o--o{" (many-to-many-ish; we don't know the real cardinality
+// without probing the source). Each edge label is the join condition
+// + relationship name. Click an edge label = the existing table row;
+// for now we render a parallel "click to edit" overlay below the SVG
+// so users can hop straight into the edit drawer.
+
+function escMermaid(s: string): string {
+  // Mermaid is picky about quotes inside labels. Replace the bare quote with
+  // its HTML entity so the parser doesn't bail out on the typical join
+  // expression `from."thread_id" = to."thread_id"`.
+  return s
+    .replace(/"/g, "#quot;")
+    .replace(/\n/g, " ")
+    .replace(/`/g, "'");
+}
+
+function slugId(s: string): string {
+  // Mermaid identifiers can't contain dots/hyphens/quotes — replace with _.
+  return s.replace(/[^A-Za-z0-9_]/g, "_").replace(/^_+/, "");
+}
+
+// Cap to keep the SVG render under Mermaid's internal size guard. The user
+// can use the dataset chip filter to drill into a specific subgraph if the
+// model has more relationships than this. 80 is a soft ceiling — enough
+// for ~10 datasets but small enough not to time out the browser.
+const ERD_MAX_EDGES = 80;
+
+function RelationshipsERDiagram({
+  datasets,
+  relationships,
+  onPickEdge,
+}: {
+  datasets: EntityRow[];
+  relationships: EntityRow[];
+  onPickEdge: (r: EntityRow) => void;
+}) {
+  const { theme } = useTheme();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const renderSeq = useRef(0);
+  const [error, setError] = useState<string | null>(null);
+  const [mermaidCode, setMermaidCode] = useState<string>("");
+
+  const limited = relationships.slice(0, ERD_MAX_EDGES);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    let cancelled = false;
+
+    // Datasets the relationships actually reference; we also include the
+    // ones we know about so an unconnected dataset still shows up.
+    const tidToName = new Map<string, string>();
+    for (const d of datasets) {
+      const tid = (d.table_id as string) || "";
+      const name = (d.name as string) || tid;
+      if (tid) tidToName.set(tid, name);
+    }
+    // Some relationships reference table_ids that aren't in datasets[];
+    // fall back to using the table_id itself as the entity label so the
+    // diagram still draws (it'd otherwise look like a broken FK).
+    for (const r of limited) {
+      for (const side of [r.from as string, r.to as string]) {
+        if (side && !tidToName.has(side)) tidToName.set(side, side);
+      }
+    }
+
+    const lines: string[] = ["erDiagram"];
+    // Empty entity blocks — just declare them. The relationship lines
+    // below register the entity automatically, but declaring up front
+    // gives the layout engine something to work with.
+    for (const [tid, label] of tidToName) {
+      lines.push(`  ${slugId(tid)}["${escMermaid(label)}"] {`);
+      lines.push(`    string id`);
+      lines.push(`  }`);
+    }
+    for (const r of limited) {
+      const f = r.from as string;
+      const t = r.to as string;
+      if (!f || !t) continue;
+      const label = (r.name as string) || (r.on as string) || "";
+      const type = (r.type as string) || "left";
+      lines.push(
+        `  ${slugId(f)} }o--o{ ${slugId(t)} : "${escMermaid(`${label} (${type})`)}"`,
+      );
+    }
+    const code = lines.join("\n");
+    setMermaidCode(code);
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: theme === "dark" ? "dark" : "default",
+      securityLevel: "loose",
+      themeVariables: {
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+      },
+    });
+
+    renderSeq.current += 1;
+    const runId = `sl_erd_${Date.now()}_${renderSeq.current}`;
+
+    mermaid
+      .render(runId, code)
+      .then(({ svg }) => {
+        if (cancelled || !ref.current) return;
+        ref.current.innerHTML = svg;
+        setError(null);
+      })
+      .catch((err: Error) => {
+        if (cancelled || !ref.current) return;
+        ref.current.innerHTML = "";
+        setError(err.message);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [datasets, limited, theme]);
+
+  return (
+    <div className="space-y-3">
+      {relationships.length > ERD_MAX_EDGES ? (
+        <div className="text-[11px] text-amber-500 flex items-center gap-1">
+          <AlertTriangle className="w-3.5 h-3.5" /> Showing the first {ERD_MAX_EDGES}{" "}
+          of {relationships.length} relationships. Use the dataset filter above to
+          drill into a subgraph.
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="space-y-2">
+          <ErrorBox message={`ER diagram failed to render: ${error}`} />
+          <details className="text-[10px]">
+            <summary className="cursor-pointer text-zinc-500">Mermaid source</summary>
+            <pre className="mt-1 p-2 bg-zinc-50 dark:bg-zinc-950 rounded overflow-auto max-h-72">
+              {mermaidCode}
+            </pre>
+          </details>
+        </div>
+      ) : null}
+
+      <div ref={ref} className="w-full overflow-auto border border-zinc-200 dark:border-zinc-900 rounded p-2" />
+
+      {/* Click-through helper: list every edge so users can hop into the
+          edit drawer for any relationship even when SVG hit-testing is
+          fiddly. Kept compact (one line per edge). */}
+      <details className="text-[11px]">
+        <summary className="cursor-pointer text-zinc-500">
+          Edge list ({limited.length}) — click to edit
+        </summary>
+        <ul className="mt-1 space-y-0.5 max-h-72 overflow-auto">
+          {limited.map((r) => (
+            <li key={r.name as string}>
+              <button
+                type="button"
+                onClick={() => onPickEdge(r)}
+                className="text-left hover:text-keboola"
+              >
+                <span className="font-mono">{r.from as string}</span>
+                <span className="mx-1 text-zinc-500">→</span>
+                <span className="font-mono">{r.to as string}</span>
+                <span className="ml-2 text-zinc-500">{r.on as string}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </details>
+    </div>
   );
 }

--- a/web/frontend/src/pages/SemanticLayer.tsx
+++ b/web/frontend/src/pages/SemanticLayer.tsx
@@ -2,10 +2,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   CheckCircle2,
   Download,
+  GitCompare,
+  KeyRound,
+  PackagePlus,
   Pencil,
   Plus,
   RefreshCw,
+  Send,
   Trash2,
+  Upload,
   XCircle,
 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -15,15 +20,23 @@ import { Empty, ErrorBox, Loading, PageTitle } from "../components/Empty";
 import { JsonView } from "../components/JsonView";
 import { DataTable } from "../components/Table";
 import { useUIState } from "../state";
+import {
+  BuildDialog,
+  DiffDialog,
+  ImportDialog,
+  PromoteDialog,
+  TokenEncryptDialog,
+} from "./SemanticLayerDialogs";
 
 /**
  * Semantic Layer (Keboola Metastore) page.
  *
  * Mirrors the `kbagent semantic-layer` CLI surface (v0.41.0+) for full
  * CRUD on models and the five entity kinds — metric, dataset,
- * relationship, constraint, glossary — plus the read-side workflow
- * operations (Validate, Export). Diff / Promote / Import / Build are
- * tracked separately and not in this iteration.
+ * relationship, constraint, glossary — plus every read-side workflow
+ * operation: Validate, Export, Diff, Promote, Import, Build, and the
+ * project-scoped Token-encrypt utility (Phase 3 dialogs live in
+ * SemanticLayerDialogs.tsx).
  *
  * Design notes:
  * - Schema-driven forms: each entity kind has a declarative field list
@@ -437,6 +450,14 @@ export function SemanticLayerPage() {
   const [activeModel, setActiveModel] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<EntityKind>("metric");
   const [showNewModel, setShowNewModel] = useState(false);
+  // Phase 3 workflow dialogs. State lives on the page so the buttons can
+  // sit in the page header (Build/Import/Token are project-scoped, not
+  // model-scoped) while Diff/Promote get triggered from ModelHeader.
+  const [showDiff, setShowDiff] = useState(false);
+  const [showPromote, setShowPromote] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [showBuild, setShowBuild] = useState(false);
+  const [showToken, setShowToken] = useState(false);
   const qc = useQueryClient();
 
   const modelsQ = useQuery<ModelsResponse>({
@@ -471,13 +492,39 @@ export function SemanticLayerPage() {
         title="Semantic Layer"
         description={`Keboola Metastore for ${project}. Models, metrics, datasets, relationships, constraints, glossary.`}
         actions={
-          <button
-            type="button"
-            className="nerd-btn flex items-center gap-1 hover:text-keboola"
-            onClick={() => setShowNewModel(true)}
-          >
-            <Plus className="w-3 h-3" /> New model
-          </button>
+          <div className="flex items-center gap-1 flex-wrap">
+            <button
+              type="button"
+              className="nerd-btn flex items-center gap-1 hover:text-keboola"
+              onClick={() => setShowNewModel(true)}
+            >
+              <Plus className="w-3 h-3" /> New model
+            </button>
+            <button
+              type="button"
+              className="nerd-btn flex items-center gap-1 hover:text-keboola"
+              onClick={() => setShowBuild(true)}
+              title="Heuristic greenfield builder — pick tables, get a starter model"
+            >
+              <PackagePlus className="w-3 h-3" /> Build
+            </button>
+            <button
+              type="button"
+              className="nerd-btn flex items-center gap-1 hover:text-keboola"
+              onClick={() => setShowImport(true)}
+              title="Replay a JSON snapshot into a model"
+            >
+              <Upload className="w-3 h-3" /> Import
+            </button>
+            <button
+              type="button"
+              className="nerd-btn flex items-center gap-1 hover:text-keboola"
+              onClick={() => setShowToken(true)}
+              title="Encrypt project storage token for transformation user_properties"
+            >
+              <KeyRound className="w-3 h-3" /> Encrypt token
+            </button>
+          </div>
         }
       />
 
@@ -497,6 +544,8 @@ export function SemanticLayerPage() {
           activeModel={resolvedModel}
           onChange={setActiveModel}
           project={project}
+          onOpenDiff={() => setShowDiff(true)}
+          onOpenPromote={() => setShowPromote(true)}
         />
       ) : null}
 
@@ -520,6 +569,48 @@ export function SemanticLayerPage() {
           }}
         />
       ) : null}
+
+      {showDiff ? (
+        <DiffDialog initialProject={project} onClose={() => setShowDiff(false)} />
+      ) : null}
+
+      {showPromote ? (
+        <PromoteDialog
+          initialFromProject={project}
+          onClose={() => setShowPromote(false)}
+        />
+      ) : null}
+
+      {showImport ? (
+        <ImportDialog
+          initialProject={project}
+          initialModel={resolvedModel ?? ""}
+          onClose={() => setShowImport(false)}
+          onImported={() => {
+            // Refresh the show query so the new entities surface immediately.
+            qc.invalidateQueries({ queryKey: ["sl-show"] });
+            qc.invalidateQueries({ queryKey: ["sl-models", project] });
+          }}
+        />
+      ) : null}
+
+      {showBuild ? (
+        <BuildDialog
+          initialProject={project}
+          initialModel={resolvedModel ?? ""}
+          onClose={() => setShowBuild(false)}
+          onBuilt={() => {
+            // Built model may be brand new — refresh the model list so it
+            // appears in the dropdown and gets auto-selected.
+            qc.invalidateQueries({ queryKey: ["sl-models", project] });
+            qc.invalidateQueries({ queryKey: ["sl-show"] });
+          }}
+        />
+      ) : null}
+
+      {showToken ? (
+        <TokenEncryptDialog initialProject={project} onClose={() => setShowToken(false)} />
+      ) : null}
     </div>
   );
 }
@@ -531,11 +622,15 @@ function ModelHeader({
   activeModel,
   onChange,
   project,
+  onOpenDiff,
+  onOpenPromote,
 }: {
   models: Model[];
   activeModel: string | null;
   onChange: (m: string) => void;
   project: string;
+  onOpenDiff: () => void;
+  onOpenPromote: () => void;
 }) {
   const qc = useQueryClient();
   const [showValidate, setShowValidate] = useState(false);
@@ -630,6 +725,22 @@ function ModelHeader({
         >
           <Download className="w-3 h-3" /> Export
         </button>
+        <button
+          type="button"
+          className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
+          onClick={onOpenDiff}
+          title="Diff two snapshots (project↔project, project↔file, file↔file)"
+        >
+          <GitCompare className="w-3 h-3" /> Diff
+        </button>
+        <button
+          type="button"
+          className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
+          onClick={onOpenPromote}
+          title="Promote this model to another project (with dry-run preview)"
+        >
+          <Send className="w-3 h-3" /> Promote
+        </button>
       </div>
 
       {showValidate && activeModel ? (
@@ -687,7 +798,9 @@ function NewModelDrawer({
 }) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [sqlDialect, setSqlDialect] = useState("snowflake");
+  // Metastore is case-sensitive on the dialect name. Service default is
+  // "Snowflake" (capital S) -- lower-case "snowflake" trips a 422.
+  const [sqlDialect, setSqlDialect] = useState("Snowflake");
   const [error, setError] = useState<string | null>(null);
 
   const mu = useMutation<{ model?: { name?: string } }>({
@@ -737,8 +850,8 @@ function NewModelDrawer({
             value={sqlDialect}
             onChange={(e) => setSqlDialect(e.target.value)}
           >
-            <option value="snowflake">snowflake</option>
-            <option value="bigquery">bigquery</option>
+            <option value="Snowflake">Snowflake</option>
+            <option value="BigQuery">BigQuery</option>
           </select>
         </label>
         {error ? <ErrorBox message={error} /> : null}
@@ -996,6 +1109,7 @@ function EntityFormDrawer({
   onSaved: () => void;
 }) {
   const schema = ENTITY_SCHEMAS[kind];
+  const qc = useQueryClient();
   const [values, setValues] = useState<Record<string, unknown>>(() => {
     // Seed edit form with current values; add form starts empty.
     if (mode === "edit" && initial) {
@@ -1042,7 +1156,14 @@ function EntityFormDrawer({
         body,
       );
     },
-    onSuccess: onSaved,
+    onSuccess: () => {
+      // Force the parent's show-query to refetch BEFORE the drawer unmounts —
+      // the parent's refetch() callback alone occasionally races with React
+      // strict-mode double-effects, leaving the entity table stale. Invalidating
+      // here makes the refresh deterministic.
+      qc.invalidateQueries({ queryKey: ["sl-show", project, model] });
+      onSaved();
+    },
     onError: (err) => setError((err as Error).message),
   });
 

--- a/web/frontend/src/pages/SemanticLayer.tsx
+++ b/web/frontend/src/pages/SemanticLayer.tsx
@@ -1740,13 +1740,18 @@ function ConstraintGroupedTable({
 
 // ── RelationshipsERDiagram ────────────────────────────────────────────
 //
-// Mermaid `erDiagram` rendering of the model's relationships. Datasets
-// become entities, relationships become labelled edges with cardinality
-// hint "}o--o{" (many-to-many-ish; we don't know the real cardinality
-// without probing the source). Each edge label is the join condition
-// + relationship name. Click an edge label = the existing table row;
-// for now we render a parallel "click to edit" overlay below the SVG
-// so users can hop straight into the edit drawer.
+// Mermaid `flowchart TB` rendering of the model's relationships.
+// Datasets become boxes, relationships become directed edges from
+// `from` table_id to `to` table_id with the relationship name on the
+// arrow. We use `flowchart` (not `erDiagram`) because flowchart has a
+// configurable rank direction — top-to-bottom places the hub above and
+// dimensions in a row beneath, which uses vertical space sensibly for
+// the typical hub-and-spoke Keboola model. `erDiagram` had no rankdir
+// and always laid out wide-and-short, wasting most of the canvas.
+//
+// Click the row in the "click to edit" list below the diagram to open
+// the existing edit drawer — we don't bind onClick to flowchart edges
+// because Mermaid's edge hit-targets are narrow and hard to land.
 
 function escMermaid(s: string): string {
   // Mermaid is picky about quotes inside labels. Replace the bare quote with
@@ -1799,15 +1804,13 @@ function RelationshipsERDiagram({
 
   const limited = relationships.slice(0, ERD_MAX_EDGES);
 
-  // Compute the zoom that fills the active canvas as much as possible
-  // without distorting the diagram. The erDiagram layout is wide-and-short
-  // so `Math.min(fitX, fitY)` (= "the whole graph fits without scrolling")
-  // produces tiny zoom levels with a sea of whitespace below. We pick the
-  // larger of the two -- the diagram fills one axis and the other axis
-  // scrolls if needed. Floor at 1.0 so we never shrink below 100% (the
-  // user asked for "150%-looking" by default, and the screenshot they
-  // shared had the SVG rendering at its natural mermaid size which is the
-  // smallest readable form). Cap at 3x so we don't lose context.
+  // Compute the zoom that fits the diagram into the visible canvas
+  // without scrolling. `flowchart TB` is typically tall-and-narrow
+  // (one rank per join level, dimensions in a row beneath the hub), so
+  // `Math.min(fitX, fitY)` chooses the dominant constraint — the
+  // diagram fills the bottle-necking axis and stays inside the canvas
+  // on the other. Floor 0.4 so very dense graphs (80 edges) can shrink
+  // enough to fit; cap 2.5 so a 3-node mini-graph doesn't blow up.
   const applyAutoFit = () => {
     const target = fullscreen ? fullscreenRef.current : ref.current;
     const svgEl = target?.querySelector("svg");
@@ -1819,10 +1822,8 @@ function RelationshipsERDiagram({
     if (!svgW || !svgH) return;
     const fitX = (container.clientWidth - 32) / svgW;
     const fitY = (container.clientHeight - 32) / svgH;
-    // For wide-and-short graphs fitY >> fitX -- pick whichever fills one
-    // axis tightly; the other axis becomes the scrollable direction.
-    const fit = Math.max(fitX, fitY);
-    setZoom(Math.max(1.0, Math.min(3, fit)));
+    const fit = Math.min(fitX, fitY);
+    setZoom(Math.max(0.4, Math.min(2.5, fit)));
   };
 
   useEffect(() => {
@@ -1846,23 +1847,28 @@ function RelationshipsERDiagram({
       }
     }
 
-    const lines: string[] = ["erDiagram"];
-    // Empty entity blocks — just declare them. The relationship lines
-    // below register the entity automatically, but declaring up front
-    // gives the layout engine something to work with.
+    const lines: string[] = ["flowchart TB"];
+    // Declare each node up-front so isolated datasets (no relationships)
+    // still show up; the rank-aware layout also benefits from seeing the
+    // full node set before the edges constrain it.
     for (const [tid, label] of tidToName) {
-      lines.push(`  ${slugId(tid)}["${escMermaid(label)}"] {`);
-      lines.push(`    string id`);
-      lines.push(`  }`);
+      lines.push(`  ${slugId(tid)}["${escMermaid(label)}"]`);
     }
     for (const r of limited) {
       const f = r.from as string;
       const t = r.to as string;
       if (!f || !t) continue;
-      const label = (r.name as string) || (r.on as string) || "";
       const type = (r.type as string) || "left";
+      // `-->|"…"|` is flowchart's labelled directed edge. Inner joins
+      // use a thicker `==>` so they pop out of a left-join-heavy graph.
+      const arrow = type === "inner" ? "==>" : "-->";
+      // Only the join type goes on the arrow. The full relationship
+      // name (often `<from>_to_<to>`) duplicates what's already at
+      // both ends, bloating horizontal space and forcing auto-fit to a
+      // tight zoom that clips the canvas. The dataset-level edge list
+      // below the diagram keeps the names browsable.
       lines.push(
-        `  ${slugId(f)} }o--o{ ${slugId(t)} : "${escMermaid(`${label} (${type})`)}"`,
+        `  ${slugId(f)} ${arrow}|"${escMermaid(type)}"| ${slugId(t)}`,
       );
     }
     const code = lines.join("\n");

--- a/web/frontend/src/pages/SemanticLayer.tsx
+++ b/web/frontend/src/pages/SemanticLayer.tsx
@@ -1,0 +1,1204 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CheckCircle2,
+  Download,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Drawer } from "../components/Drawer";
+import { Empty, ErrorBox, Loading, PageTitle } from "../components/Empty";
+import { JsonView } from "../components/JsonView";
+import { DataTable } from "../components/Table";
+import { useUIState } from "../state";
+
+/**
+ * Semantic Layer (Keboola Metastore) page.
+ *
+ * Mirrors the `kbagent semantic-layer` CLI surface (v0.41.0+) for full
+ * CRUD on models and the five entity kinds — metric, dataset,
+ * relationship, constraint, glossary — plus the read-side workflow
+ * operations (Validate, Export). Diff / Promote / Import / Build are
+ * tracked separately and not in this iteration.
+ *
+ * Design notes:
+ * - Schema-driven forms: each entity kind has a declarative field list
+ *   (see ENTITY_SCHEMAS) that drives both the Add and Edit drawer
+ *   bodies. Avoids hand-coding 5 separate form components and keeps
+ *   field validation rules in one place.
+ * - The CLI distinguishes "model" by name OR uuid; the UI defaults to
+ *   the first model returned by /models and lets the user swap via a
+ *   dropdown. UUIDs surface in the JsonView; users mostly interact by
+ *   model name.
+ * - Constraint orphan validation, cascade-rename, and severity bands
+ *   are CLI-only quirks documented in gotchas.md (since v0.41.0). We
+ *   surface the underlying API errors but do not replicate the CLI's
+ *   preflight prose in UI form labels.
+ */
+
+// ── Types from /semantic-layer/* responses ─────────────────────────
+
+interface Model {
+  uuid: string;
+  name: string;
+  description?: string;
+  sql_dialect?: string;
+  created?: string;
+  updated?: string;
+}
+
+interface ModelsResponse {
+  project_alias: string;
+  models: Model[];
+}
+
+interface EntityRow {
+  uuid?: string;
+  name?: string;
+  // metric
+  sql?: string;
+  dataset?: string;
+  description?: string;
+  // dataset
+  table_id?: string;
+  grain?: string;
+  primary_key?: string[];
+  // relationship
+  from?: string;
+  to?: string;
+  on?: string;
+  type?: string;
+  // constraint
+  constraint_type?: string;
+  rule?: string;
+  metrics?: string[];
+  severity?: string;
+  // glossary
+  term?: string;
+  definition?: string;
+  // catch-all so JsonView can render unmodelled fields
+  [k: string]: unknown;
+}
+
+interface ShowResponse {
+  project_alias: string;
+  model: { uuid: string; name: string; sql_dialect?: string };
+  datasets: EntityRow[];
+  metrics: EntityRow[];
+  relationships: EntityRow[];
+  constraints: EntityRow[];
+  glossary: EntityRow[];
+}
+
+type EntityKind = "metric" | "dataset" | "relationship" | "constraint" | "glossary";
+
+// ── Schema-driven form definitions ────────────────────────────────
+
+interface FieldDef {
+  key: string;
+  label: string;
+  type: "text" | "textarea" | "select" | "list" | "boolean";
+  required?: boolean;
+  options?: string[]; // for select
+  placeholder?: string;
+  help?: string;
+  // The CLI accepts the field at different names for Add vs Edit
+  // (e.g. metric.sql for Add, metric.new_sql for Edit). The form sends
+  // the raw key; the backend payload mapper handles the new_* prefix.
+  editKey?: string; // for edit mode, the new_* variant
+}
+
+interface EntitySchema {
+  kind: EntityKind;
+  pluralLabel: string; // "Metrics"
+  pkField: string; // primary identifier displayed in the table + sent on edit/delete (usually "name", glossary uses "term")
+  fields: FieldDef[];
+  tableColumns: Array<{ header: string; cell: (row: EntityRow) => React.ReactNode }>;
+}
+
+const ENTITY_SCHEMAS: Record<EntityKind, EntitySchema> = {
+  metric: {
+    kind: "metric",
+    pluralLabel: "Metrics",
+    pkField: "name",
+    fields: [
+      {
+        key: "name",
+        label: "Name",
+        type: "text",
+        required: true,
+        placeholder: "monthly_active_users",
+        help: "Lowercase + underscores. Must be unique within the model.",
+      },
+      {
+        key: "sql",
+        editKey: "new_sql",
+        label: "SQL expression",
+        type: "textarea",
+        required: true,
+        placeholder: "COUNT(DISTINCT user_id)",
+        help: "Aggregation expression evaluated against the dataset.",
+      },
+      {
+        key: "dataset",
+        editKey: "new_dataset",
+        label: "Dataset (FQN)",
+        type: "text",
+        required: true,
+        placeholder: "in.c-users.events",
+        help: "Storage table this metric aggregates over.",
+      },
+      {
+        key: "description",
+        editKey: "new_description",
+        label: "Description",
+        type: "textarea",
+      },
+    ],
+    tableColumns: [
+      { header: "Name", cell: (r) => <span className="font-bold">{r.name}</span> },
+      {
+        header: "Dataset",
+        cell: (r) => <span className="font-mono text-xs text-accent">{r.dataset}</span>,
+      },
+      {
+        header: "SQL",
+        cell: (r) => (
+          <code className="text-xs text-zinc-600 dark:text-zinc-400 truncate block max-w-md">
+            {r.sql}
+          </code>
+        ),
+      },
+    ],
+  },
+
+  dataset: {
+    kind: "dataset",
+    pluralLabel: "Datasets",
+    pkField: "name",
+    fields: [
+      {
+        key: "name",
+        label: "Name",
+        type: "text",
+        required: true,
+        placeholder: "events",
+        help: "Lowercase + underscores. Defaults to the table name if omitted.",
+      },
+      {
+        key: "table_id",
+        label: "Table ID",
+        type: "text",
+        required: true,
+        placeholder: "in.c-users.events",
+        help: "Storage table FQN. Used to derive the dataset's FQN.",
+      },
+      {
+        key: "grain",
+        editKey: "new_grain",
+        label: "Grain",
+        type: "text",
+        placeholder: "user_id, event_timestamp",
+        help: "Comma-separated columns that uniquely identify a row.",
+      },
+      {
+        key: "primary_key",
+        label: "Primary key",
+        type: "list",
+        placeholder: "user_id, event_id",
+        help: "Columns making up the primary key (one per line or comma-separated).",
+      },
+      {
+        key: "description",
+        editKey: "new_description",
+        label: "Description",
+        type: "textarea",
+      },
+      {
+        key: "deep_fields",
+        label: "Probe column types",
+        type: "boolean",
+        help: "When true, kbagent queries Snowflake to populate column metadata + role classification (slow).",
+      },
+    ],
+    tableColumns: [
+      { header: "Name", cell: (r) => <span className="font-bold">{r.name}</span> },
+      {
+        header: "Table",
+        cell: (r) => <span className="font-mono text-xs text-accent">{r.table_id}</span>,
+      },
+      {
+        header: "Grain",
+        cell: (r) => <span className="text-xs text-zinc-500">{r.grain || "—"}</span>,
+      },
+    ],
+  },
+
+  relationship: {
+    kind: "relationship",
+    pluralLabel: "Relationships",
+    pkField: "name",
+    fields: [
+      {
+        key: "name",
+        label: "Name",
+        type: "text",
+        required: true,
+        placeholder: "users_to_events",
+      },
+      {
+        key: "from",
+        editKey: "new_from",
+        label: "From dataset",
+        type: "text",
+        required: true,
+        placeholder: "users",
+      },
+      {
+        key: "to",
+        editKey: "new_to",
+        label: "To dataset",
+        type: "text",
+        required: true,
+        placeholder: "events",
+      },
+      {
+        key: "on",
+        editKey: "new_on",
+        label: "Join expression",
+        type: "text",
+        required: true,
+        placeholder: "users.id = events.user_id",
+      },
+      {
+        key: "type",
+        editKey: "new_type",
+        label: "Join type",
+        type: "select",
+        options: ["left", "inner", "right", "outer"],
+      },
+    ],
+    tableColumns: [
+      { header: "Name", cell: (r) => <span className="font-bold">{r.name}</span> },
+      {
+        header: "From → To",
+        cell: (r) => (
+          <span className="text-xs">
+            <span className="font-mono text-accent">{r.from}</span>
+            <span className="text-zinc-500 mx-1">→</span>
+            <span className="font-mono text-accent">{r.to}</span>
+          </span>
+        ),
+      },
+      {
+        header: "Join",
+        cell: (r) => (
+          <span className="text-xs text-zinc-500">
+            <span className="nerd-pill text-[10px] mr-1">{r.type || "left"}</span>
+            <code>{r.on}</code>
+          </span>
+        ),
+      },
+    ],
+  },
+
+  constraint: {
+    kind: "constraint",
+    pluralLabel: "Constraints",
+    pkField: "name",
+    fields: [
+      {
+        key: "name",
+        label: "Name",
+        type: "text",
+        required: true,
+        placeholder: "revenue_above_zero_critical",
+        help: "Lowercase + underscores. Suffix with _critical / _warning / _healthy / _review for health-band classification.",
+      },
+      {
+        key: "constraint_type",
+        editKey: "new_constraint_type",
+        label: "Type",
+        type: "select",
+        required: true,
+        options: [
+          "inequality",
+          "equality",
+          "range",
+          "composition",
+          "exclusion",
+          "temporal",
+          "conditional",
+        ],
+      },
+      {
+        key: "rule",
+        editKey: "new_rule",
+        label: "Rule expression",
+        type: "textarea",
+        required: true,
+        placeholder: "monthly_revenue > 0",
+        help: "STRING expression (not an object). Plain SQL boolean predicate.",
+      },
+      {
+        key: "metrics",
+        editKey: "new_metrics",
+        label: "Applies to metrics",
+        type: "list",
+        placeholder: "monthly_revenue, daily_active_users",
+        help: "Comma-separated metric names.",
+      },
+      {
+        key: "severity",
+        editKey: "new_severity",
+        label: "Severity",
+        type: "select",
+        options: ["warning", "critical", "info"],
+        help: "API enum is 3-level; the 4-band health (critical / warning / healthy / review) lives in the name suffix.",
+      },
+    ],
+    tableColumns: [
+      { header: "Name", cell: (r) => <span className="font-bold">{r.name}</span> },
+      {
+        header: "Type",
+        cell: (r) => <span className="nerd-pill text-[10px]">{r.constraint_type}</span>,
+      },
+      {
+        header: "Severity",
+        cell: (r) => {
+          const s = r.severity || "warning";
+          const cls =
+            s === "critical"
+              ? "nerd-pill-red"
+              : s === "warning"
+                ? "nerd-pill-amber"
+                : "nerd-pill";
+          return <span className={`${cls} text-[10px]`}>{s}</span>;
+        },
+      },
+      {
+        header: "Rule",
+        cell: (r) => (
+          <code className="text-xs text-zinc-600 dark:text-zinc-400 truncate block max-w-md">
+            {r.rule}
+          </code>
+        ),
+      },
+    ],
+  },
+
+  glossary: {
+    kind: "glossary",
+    pluralLabel: "Glossary",
+    pkField: "term",
+    fields: [
+      {
+        key: "term",
+        editKey: "new_term",
+        label: "Term",
+        type: "text",
+        required: true,
+        placeholder: "MAU",
+        help: "The term being defined. Used as the unique identifier for edit/delete.",
+      },
+      {
+        key: "definition",
+        editKey: "new_definition",
+        label: "Definition",
+        type: "textarea",
+        required: true,
+        placeholder: "Monthly Active Users — distinct users observed in a calendar month.",
+      },
+    ],
+    tableColumns: [
+      { header: "Term", cell: (r) => <span className="font-bold">{r.term}</span> },
+      {
+        header: "Definition",
+        cell: (r) => (
+          <span className="text-xs text-zinc-600 dark:text-zinc-400 truncate block max-w-2xl">
+            {r.definition}
+          </span>
+        ),
+      },
+    ],
+  },
+};
+
+const ENTITY_KINDS: EntityKind[] = ["metric", "dataset", "relationship", "constraint", "glossary"];
+
+// ── Page ──────────────────────────────────────────────────────────
+
+export function SemanticLayerPage() {
+  const { project } = useUIState();
+  const [activeModel, setActiveModel] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<EntityKind>("metric");
+  const [showNewModel, setShowNewModel] = useState(false);
+  const qc = useQueryClient();
+
+  const modelsQ = useQuery<ModelsResponse>({
+    queryKey: ["sl-models", project],
+    queryFn: () => api.get("/semantic-layer/models", { query: { project: project! } }),
+    enabled: !!project,
+  });
+
+  // Auto-select the first model on load if none is active.
+  const models = modelsQ.data?.models ?? [];
+  const resolvedModel =
+    activeModel ?? (models.length > 0 ? models[0].name : null);
+
+  if (!project) {
+    return (
+      <div className="space-y-4">
+        <PageTitle
+          title="Semantic Layer"
+          description="Keboola Metastore — models, metrics, datasets, relationships, constraints, glossary."
+        />
+        <Empty
+          title="Pick a project"
+          hint="Use the top-bar project picker to scope the semantic-layer view."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <PageTitle
+        title="Semantic Layer"
+        description={`Keboola Metastore for ${project}. Models, metrics, datasets, relationships, constraints, glossary.`}
+        actions={
+          <button
+            type="button"
+            className="nerd-btn flex items-center gap-1 hover:text-keboola"
+            onClick={() => setShowNewModel(true)}
+          >
+            <Plus className="w-3 h-3" /> New model
+          </button>
+        }
+      />
+
+      {modelsQ.isLoading ? <Loading /> : null}
+      {modelsQ.error ? <ErrorBox message={(modelsQ.error as Error).message} /> : null}
+
+      {modelsQ.data && models.length === 0 ? (
+        <Empty
+          title="No semantic-layer models yet"
+          hint="Click 'New model' above to create your first one, or run `kbagent sl build` from the CLI for an AI-assisted greenfield."
+        />
+      ) : null}
+
+      {models.length > 0 ? (
+        <ModelHeader
+          models={models}
+          activeModel={resolvedModel}
+          onChange={setActiveModel}
+          project={project}
+        />
+      ) : null}
+
+      {resolvedModel ? (
+        <ModelDetail
+          project={project}
+          model={resolvedModel}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+        />
+      ) : null}
+
+      {showNewModel ? (
+        <NewModelDrawer
+          project={project}
+          onClose={() => setShowNewModel(false)}
+          onCreated={(name) => {
+            setShowNewModel(false);
+            qc.invalidateQueries({ queryKey: ["sl-models", project] });
+            setActiveModel(name);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ── Header: model picker + workflow actions (Validate, Export) ────
+
+function ModelHeader({
+  models,
+  activeModel,
+  onChange,
+  project,
+}: {
+  models: Model[];
+  activeModel: string | null;
+  onChange: (m: string) => void;
+  project: string;
+}) {
+  const qc = useQueryClient();
+  const [showValidate, setShowValidate] = useState(false);
+  const [deepValidate, setDeepValidate] = useState(false);
+
+  const deleteMu = useMutation({
+    mutationFn: (model: string) =>
+      api.delete(`/semantic-layer/models/${encodeURIComponent(model)}`, {
+        query: { project },
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["sl-models", project] });
+    },
+  });
+
+  const exportMu = useMutation<{ snapshot: unknown; model?: { name?: string } }>({
+    mutationFn: () =>
+      api.get("/semantic-layer/export", {
+        query: { project, model: activeModel ?? undefined },
+      }),
+    onSuccess: (data) => {
+      // Drop the snapshot to disk so users can pipe it through `kbagent sl
+      // import` or version-control it. Filename includes the model name +
+      // a UTC timestamp so successive exports don't overwrite each other.
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json;charset=utf-8",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "");
+      a.download = `sl-${data.model?.name ?? activeModel ?? "model"}-${stamp}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+  });
+
+  return (
+    <div className="nerd-card flex items-center justify-between flex-wrap gap-2">
+      <div className="flex items-center gap-3 flex-wrap">
+        <span className="text-[10px] uppercase tracking-wider text-zinc-500">Model:</span>
+        <select
+          className="nerd-input text-sm py-1"
+          value={activeModel ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {models.map((m) => (
+            <option key={m.uuid} value={m.name}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+        {activeModel ? (
+          <button
+            type="button"
+            className="nerd-btn text-xs hover:text-red-400 hover:border-red-700"
+            onClick={() => {
+              if (confirm(`Delete model '${activeModel}'? This deletes every entity it contains.`)) {
+                deleteMu.mutate(activeModel);
+              }
+            }}
+            disabled={deleteMu.isPending}
+            title="Delete this model + everything in it"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2 flex-wrap">
+        <label className="flex items-center gap-1 text-xs text-zinc-500">
+          <input
+            type="checkbox"
+            checked={deepValidate}
+            onChange={(e) => setDeepValidate(e.target.checked)}
+          />
+          deep
+        </label>
+        <button
+          type="button"
+          className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
+          onClick={() => setShowValidate(true)}
+        >
+          <CheckCircle2 className="w-3 h-3" /> Validate
+        </button>
+        <button
+          type="button"
+          className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
+          onClick={() => exportMu.mutate()}
+          disabled={exportMu.isPending}
+        >
+          <Download className="w-3 h-3" /> Export
+        </button>
+      </div>
+
+      {showValidate && activeModel ? (
+        <ValidateDrawer
+          project={project}
+          model={activeModel}
+          deep={deepValidate}
+          onClose={() => setShowValidate(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ValidateDrawer({
+  project,
+  model,
+  deep,
+  onClose,
+}: {
+  project: string;
+  model: string;
+  deep: boolean;
+  onClose: () => void;
+}) {
+  const q = useQuery({
+    queryKey: ["sl-validate", project, model, deep],
+    queryFn: () =>
+      api.get("/semantic-layer/validate", {
+        query: { project, model, deep },
+      }),
+  });
+  return (
+    <Drawer
+      open={true}
+      onClose={onClose}
+      title={`Validate · ${model}`}
+      subtitle={deep ? "deep (Snowflake column probes)" : "structural checks only"}
+    >
+      {q.isLoading ? <Loading /> : null}
+      {q.error ? <ErrorBox message={(q.error as Error).message} /> : null}
+      {q.data ? <JsonView data={q.data} /> : null}
+    </Drawer>
+  );
+}
+
+function NewModelDrawer({
+  project,
+  onClose,
+  onCreated,
+}: {
+  project: string;
+  onClose: () => void;
+  onCreated: (name: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [sqlDialect, setSqlDialect] = useState("snowflake");
+  const [error, setError] = useState<string | null>(null);
+
+  const mu = useMutation<{ model?: { name?: string } }>({
+    mutationFn: () =>
+      api.post("/semantic-layer/models", {
+        project,
+        name,
+        description,
+        sql_dialect: sqlDialect,
+      }),
+    onSuccess: (data) => onCreated(data.model?.name ?? name),
+    onError: (err) => setError((err as Error).message),
+  });
+
+  return (
+    <Drawer open={true} onClose={onClose} title="New semantic-layer model" width="40rem">
+      <form
+        className="space-y-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setError(null);
+          mu.mutate();
+        }}
+      >
+        <label className="block text-xs text-zinc-500">
+          Name
+          <input
+            className="nerd-input w-full mt-1"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="core_metrics"
+          />
+        </label>
+        <label className="block text-xs text-zinc-500">
+          Description
+          <textarea
+            className="nerd-input w-full mt-1 h-20"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+        <label className="block text-xs text-zinc-500">
+          SQL dialect
+          <select
+            className="nerd-input w-full mt-1"
+            value={sqlDialect}
+            onChange={(e) => setSqlDialect(e.target.value)}
+          >
+            <option value="snowflake">snowflake</option>
+            <option value="bigquery">bigquery</option>
+          </select>
+        </label>
+        {error ? <ErrorBox message={error} /> : null}
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="nerd-btn hover:text-keboola"
+            disabled={mu.isPending}
+          >
+            {mu.isPending ? "Creating…" : "Create model"}
+          </button>
+          <button type="button" className="nerd-btn" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </Drawer>
+  );
+}
+
+// ── Model detail: tabs per entity kind ─────────────────────────────
+
+function ModelDetail({
+  project,
+  model,
+  activeTab,
+  setActiveTab,
+}: {
+  project: string;
+  model: string;
+  activeTab: EntityKind;
+  setActiveTab: (k: EntityKind) => void;
+}) {
+  const showQ = useQuery<ShowResponse>({
+    queryKey: ["sl-show", project, model],
+    queryFn: () =>
+      api.get("/semantic-layer/show", {
+        query: { project, model },
+      }),
+  });
+
+  // Map UI tab -> show response field. (plurals)
+  const kindToField: Record<EntityKind, keyof ShowResponse> = {
+    metric: "metrics",
+    dataset: "datasets",
+    relationship: "relationships",
+    constraint: "constraints",
+    glossary: "glossary",
+  };
+
+  const rows = useMemo<EntityRow[]>(() => {
+    if (!showQ.data) return [];
+    return (showQ.data[kindToField[activeTab]] ?? []) as EntityRow[];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showQ.data, activeTab]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        {ENTITY_KINDS.map((k) => {
+          const count = showQ.data
+            ? (showQ.data[kindToField[k]] as EntityRow[] | undefined)?.length ?? 0
+            : null;
+          const schema = ENTITY_SCHEMAS[k];
+          return (
+            <button
+              key={k}
+              type="button"
+              className={`nerd-btn flex items-center gap-1 ${
+                activeTab === k ? "border-keboola text-keboola" : ""
+              }`}
+              onClick={() => setActiveTab(k)}
+            >
+              <span>{schema.pluralLabel}</span>
+              {count !== null ? (
+                <span className="text-[10px] text-zinc-500">({count})</span>
+              ) : null}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          className="nerd-btn text-xs ml-auto hover:text-keboola"
+          onClick={() => showQ.refetch()}
+          disabled={showQ.isFetching}
+          title="Reload entities"
+        >
+          <RefreshCw className="w-3 h-3" />
+        </button>
+      </div>
+
+      {showQ.isLoading ? <Loading /> : null}
+      {showQ.error ? <ErrorBox message={(showQ.error as Error).message} /> : null}
+
+      {showQ.data ? (
+        <EntityPanel
+          project={project}
+          model={model}
+          kind={activeTab}
+          rows={rows}
+          onChange={() => showQ.refetch()}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ── Entity panel: table + add button + edit/delete row actions ────
+
+function EntityPanel({
+  project,
+  model,
+  kind,
+  rows,
+  onChange,
+}: {
+  project: string;
+  model: string;
+  kind: EntityKind;
+  rows: EntityRow[];
+  onChange: () => void;
+}) {
+  const schema = ENTITY_SCHEMAS[kind];
+  const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<EntityRow | null>(null);
+  const [inspecting, setInspecting] = useState<EntityRow | null>(null);
+
+  const deleteMu = useMutation({
+    mutationFn: (row: EntityRow) => {
+      const pkValue = row[schema.pkField as keyof EntityRow] as string;
+      return api.delete(
+        `/semantic-layer/items/${kind}/${encodeURIComponent(pkValue)}`,
+        { query: { project, model } },
+      );
+    },
+    onSuccess: onChange,
+  });
+
+  return (
+    <>
+      <div className="nerd-card">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-keboola font-bold text-sm">{schema.pluralLabel}</h3>
+          <button
+            type="button"
+            className="nerd-btn text-xs flex items-center gap-1 hover:text-keboola"
+            onClick={() => setAdding(true)}
+          >
+            <Plus className="w-3 h-3" /> Add {kind}
+          </button>
+        </div>
+        {rows.length === 0 ? (
+          <Empty title={`No ${schema.pluralLabel.toLowerCase()} yet`} />
+        ) : (
+          <DataTable
+            rows={rows}
+            rowKey={(r) => (r[schema.pkField] as string) ?? JSON.stringify(r).slice(0, 32)}
+            onRowClick={(r) => setInspecting(r)}
+            columns={[
+              ...schema.tableColumns,
+              {
+                header: "",
+                align: "right",
+                cell: (r) => (
+                  <div className="flex justify-end gap-1">
+                    <button
+                      type="button"
+                      className="nerd-btn text-xs"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditing(r);
+                      }}
+                      title="Edit"
+                    >
+                      <Pencil className="w-3 h-3" />
+                    </button>
+                    <button
+                      type="button"
+                      className="nerd-btn text-xs hover:text-red-400 hover:border-red-700"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        const pk = r[schema.pkField] as string;
+                        if (confirm(`Delete ${kind} '${pk}'?`)) deleteMu.mutate(r);
+                      }}
+                      title="Delete"
+                    >
+                      <Trash2 className="w-3 h-3" />
+                    </button>
+                  </div>
+                ),
+              },
+            ]}
+          />
+        )}
+      </div>
+
+      {adding ? (
+        <EntityFormDrawer
+          mode="add"
+          project={project}
+          model={model}
+          kind={kind}
+          initial={null}
+          onClose={() => setAdding(false)}
+          onSaved={() => {
+            setAdding(false);
+            onChange();
+          }}
+        />
+      ) : null}
+      {editing ? (
+        <EntityFormDrawer
+          mode="edit"
+          project={project}
+          model={model}
+          kind={kind}
+          initial={editing}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            onChange();
+          }}
+        />
+      ) : null}
+      {inspecting ? (
+        <Drawer
+          open={true}
+          onClose={() => setInspecting(null)}
+          title={`${kind} · ${inspecting[schema.pkField] ?? "(no name)"}`}
+        >
+          <JsonView data={inspecting} />
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
+
+// ── Generic schema-driven add/edit form drawer ─────────────────────
+
+function EntityFormDrawer({
+  mode,
+  project,
+  model,
+  kind,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  mode: "add" | "edit";
+  project: string;
+  model: string;
+  kind: EntityKind;
+  initial: EntityRow | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const schema = ENTITY_SCHEMAS[kind];
+  const [values, setValues] = useState<Record<string, unknown>>(() => {
+    // Seed edit form with current values; add form starts empty.
+    if (mode === "edit" && initial) {
+      const seed: Record<string, unknown> = {};
+      for (const f of schema.fields) {
+        const v = initial[f.key];
+        if (v !== undefined) seed[f.key] = v;
+      }
+      return seed;
+    }
+    return {};
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const saveMu = useMutation({
+    mutationFn: () => {
+      const body: Record<string, unknown> = { project, model };
+      // Map UI keys → API keys (edit uses new_* variants).
+      for (const f of schema.fields) {
+        if (mode === "edit" && f.editKey) {
+          if (values[f.key] !== undefined) body[f.editKey] = values[f.key];
+        } else {
+          body[f.key] = values[f.key];
+        }
+      }
+      // List-typed fields arrive as comma/newline-separated strings; coerce.
+      for (const f of schema.fields) {
+        if (f.type !== "list") continue;
+        const targetKey = mode === "edit" && f.editKey ? f.editKey : f.key;
+        const raw = body[targetKey];
+        if (typeof raw === "string") {
+          body[targetKey] = raw
+            .split(/[,\n]/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }
+      }
+      if (mode === "add") {
+        return api.post(`/semantic-layer/items/${kind}`, body);
+      }
+      const pk = initial?.[schema.pkField] as string;
+      return api.put(
+        `/semantic-layer/items/${kind}/${encodeURIComponent(pk)}`,
+        body,
+      );
+    },
+    onSuccess: onSaved,
+    onError: (err) => setError((err as Error).message),
+  });
+
+  const pkValue = initial?.[schema.pkField] as string | undefined;
+  const title =
+    mode === "add"
+      ? `Add ${kind}`
+      : `Edit ${kind} · ${pkValue ?? "(no id)"}`;
+
+  return (
+    <Drawer open={true} onClose={onClose} title={title} width="44rem">
+      <form
+        className="space-y-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setError(null);
+          saveMu.mutate();
+        }}
+      >
+        {schema.fields.map((f) => (
+          <FieldInput
+            key={f.key}
+            field={f}
+            mode={mode}
+            value={values[f.key]}
+            onChange={(v) => setValues((prev) => ({ ...prev, [f.key]: v }))}
+          />
+        ))}
+        {error ? <ErrorBox message={error} /> : null}
+        <div className="flex gap-2 pt-2">
+          <button
+            type="submit"
+            className="nerd-btn hover:text-keboola"
+            disabled={saveMu.isPending}
+          >
+            {saveMu.isPending ? "Saving…" : mode === "add" ? "Add" : "Save changes"}
+          </button>
+          <button type="button" className="nerd-btn" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </Drawer>
+  );
+}
+
+function FieldInput({
+  field,
+  mode,
+  value,
+  onChange,
+}: {
+  field: FieldDef;
+  mode: "add" | "edit";
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  // In edit mode, optional fields with no value remain unset so the
+  // backend treats them as "no change". Required flag is only honored
+  // for Add mode -- edit accepts a subset.
+  const required = mode === "add" && field.required;
+  const labelEl = (
+    <span className="block text-xs text-zinc-500">
+      {field.label}
+      {required ? <span className="text-red-500 ml-1">*</span> : null}
+    </span>
+  );
+  const helpEl = field.help ? (
+    <span className="block text-[10px] text-zinc-500 dark:text-zinc-600 mt-0.5">
+      {field.help}
+    </span>
+  ) : null;
+
+  if (field.type === "boolean") {
+    return (
+      <label className="flex items-center gap-2 text-xs text-zinc-500">
+        <input
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        {field.label}
+        {field.help ? <span className="text-zinc-400">— {field.help}</span> : null}
+      </label>
+    );
+  }
+
+  if (field.type === "select") {
+    return (
+      <label className="block">
+        {labelEl}
+        <select
+          className="nerd-input w-full mt-1"
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+          required={required}
+        >
+          <option value="">(unset)</option>
+          {field.options?.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+        {helpEl}
+      </label>
+    );
+  }
+
+  if (field.type === "textarea") {
+    return (
+      <label className="block">
+        {labelEl}
+        <textarea
+          className="nerd-input w-full mt-1 h-24"
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          required={required}
+        />
+        {helpEl}
+      </label>
+    );
+  }
+
+  if (field.type === "list") {
+    // List-typed values are entered as comma/newline-separated and
+    // serialised back on submit. Keep the textarea form so users can
+    // either paste comma-separated or one-per-line.
+    const display = Array.isArray(value) ? value.join(", ") : ((value as string) ?? "");
+    return (
+      <label className="block">
+        {labelEl}
+        <textarea
+          className="nerd-input w-full mt-1 h-16"
+          value={display}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+        />
+        {helpEl}
+      </label>
+    );
+  }
+
+  return (
+    <label className="block">
+      {labelEl}
+      <input
+        type="text"
+        className="nerd-input w-full mt-1"
+        value={(value as string) ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={field.placeholder}
+        required={required}
+      />
+      {helpEl}
+    </label>
+  );
+}

--- a/web/frontend/src/pages/SemanticLayerDialogs.tsx
+++ b/web/frontend/src/pages/SemanticLayerDialogs.tsx
@@ -1,0 +1,1385 @@
+/**
+ * Phase 3 dialogs for the Semantic Layer page:
+ *
+ *   - DiffDialog     — POST /semantic-layer/diff   (project↔project, project↔file, file↔file)
+ *   - PromoteDialog  — POST /semantic-layer/promote (cross-project copy with classify-and-apply)
+ *   - ImportDialog   — POST /semantic-layer/import (snapshot replay with dry-run preview)
+ *   - BuildDialog    — POST /semantic-layer/build  (heuristic greenfield builder)
+ *   - TokenEncryptDialog — POST /semantic-layer/token/encrypt (transformation token KBC::secure)
+ *
+ * Split out of SemanticLayer.tsx to keep the page file under ~1500 lines.
+ * Each dialog is a self-contained Drawer that the parent page mounts on
+ * demand via boolean state -- no shared mutable state between dialogs.
+ */
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Copy,
+  FileUp,
+  GitCompare,
+  KeyRound,
+  PackagePlus,
+  Send,
+  Sparkles,
+  Upload,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Drawer } from "../components/Drawer";
+import { ErrorBox, Loading } from "../components/Empty";
+import { JsonView } from "../components/JsonView";
+
+// ── Shared types ─────────────────────────────────────────────────────
+
+interface ProjectRow {
+  alias: string;
+  stack_url?: string;
+  branch_id_default?: number;
+  organization_id?: number;
+  organization_name?: string;
+}
+
+interface ProjectListResponse {
+  projects: ProjectRow[];
+}
+
+interface BucketTable {
+  id: string;
+  name?: string;
+}
+
+interface BucketRow {
+  id: string;
+  stage?: string;
+  tables?: BucketTable[];
+}
+
+interface BucketsResponse {
+  buckets: BucketRow[];
+}
+
+interface TablesResponse {
+  tables: BucketTable[];
+}
+
+interface ModelRow {
+  uuid: string;
+  name: string;
+  description?: string;
+  sql_dialect?: string;
+}
+
+interface ModelsResponse {
+  project_alias: string;
+  models: ModelRow[];
+}
+
+const ENTITY_KEYS = ["datasets", "metrics", "relationships", "constraints", "glossary"] as const;
+type EntityKey = (typeof ENTITY_KEYS)[number];
+
+const ALL_TYPE_FILTERS: EntityKey[] = [...ENTITY_KEYS];
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Read a File as JSON; returns parsed object or throws with a readable error. */
+async function readFileAsJson(f: File): Promise<unknown> {
+  const text = await f.text();
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `${f.name}: not valid JSON (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+/**
+ * Primary (filled) action button used in dialog footers. The plain `.nerd-btn`
+ * is outline-only — putting two of them side-by-side looks identical to
+ * "Close", so we mark the actionable one as filled-keboola for visual
+ * hierarchy. Use `PrimaryButton` for the action that does the work; keep
+ * "Close" / "Cancel" as plain `.nerd-btn`.
+ */
+function PrimaryButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="px-3 py-1.5 rounded text-xs font-bold bg-keboola text-white border border-keboola hover:bg-keboola/80 hover:border-keboola/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+    >
+      {children}
+    </button>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[10px] uppercase tracking-widest text-zinc-500 dark:text-zinc-600 mb-1">
+      {children}
+    </div>
+  );
+}
+
+// Re-used project picker. Lists all known aliases.
+function ProjectPicker({
+  value,
+  onChange,
+  placeholder = "(pick project)",
+}: {
+  value: string;
+  onChange: (alias: string) => void;
+  placeholder?: string;
+}) {
+  const projectsQ = useQuery<ProjectListResponse>({
+    queryKey: ["sl-projects"],
+    queryFn: () => api.get("/projects"),
+  });
+  const aliases = projectsQ.data?.projects?.map((p) => p.alias) ?? [];
+  return (
+    <select
+      className="nerd-input text-sm py-1"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">{placeholder}</option>
+      {aliases.map((a) => (
+        <option key={a} value={a}>
+          {a}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// Re-used model picker scoped to a project. Returns optional model name --
+// the backend treats "" as "pick the only model OR ambiguous".
+function ModelPicker({
+  project,
+  value,
+  onChange,
+  placeholder = "(default model)",
+  disabled,
+}: {
+  project: string;
+  value: string;
+  onChange: (model: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}) {
+  const q = useQuery<ModelsResponse>({
+    queryKey: ["sl-models", project],
+    queryFn: () => api.get("/semantic-layer/models", { query: { project } }),
+    enabled: !!project && !disabled,
+  });
+  const names = q.data?.models?.map((m) => m.name) ?? [];
+  return (
+    <select
+      className="nerd-input text-sm py-1"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled || !project}
+    >
+      <option value="">{placeholder}</option>
+      {names.map((n) => (
+        <option key={n} value={n}>
+          {n}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// ── Diff dialog ──────────────────────────────────────────────────────
+
+type SideMode = "project" | "file";
+
+interface DiffSide {
+  mode: SideMode;
+  project: string;
+  model: string;
+  file: { name: string; content: unknown } | null;
+}
+
+interface DiffPerType {
+  added: string[];
+  removed: string[];
+  changed: { name?: string; term?: string; diff_keys?: string[] }[];
+}
+
+interface DiffResponse {
+  left: { source: string; ref?: unknown; model?: unknown };
+  right: { source: string; ref?: unknown; model?: unknown };
+  datasets: DiffPerType;
+  metrics: DiffPerType;
+  relationships: DiffPerType;
+  constraints: DiffPerType;
+  glossary: DiffPerType;
+}
+
+function emptySide(seedProject: string): DiffSide {
+  return { mode: "project", project: seedProject, model: "", file: null };
+}
+
+function SideEditor({
+  label,
+  side,
+  setSide,
+}: {
+  label: string;
+  side: DiffSide;
+  setSide: (s: DiffSide) => void;
+}) {
+  return (
+    <div className="border border-zinc-200 dark:border-zinc-900 rounded p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-bold text-keboola">{label}</span>
+        <div className="flex items-center gap-1 text-[10px]">
+          <button
+            type="button"
+            className={`nerd-btn px-1.5 py-0.5 ${
+              side.mode === "project" ? "border-keboola text-keboola" : ""
+            }`}
+            onClick={() => setSide({ ...side, mode: "project", file: null })}
+          >
+            Project
+          </button>
+          <button
+            type="button"
+            className={`nerd-btn px-1.5 py-0.5 ${
+              side.mode === "file" ? "border-keboola text-keboola" : ""
+            }`}
+            onClick={() => setSide({ ...side, mode: "file" })}
+          >
+            File
+          </button>
+        </div>
+      </div>
+
+      {side.mode === "project" ? (
+        <div className="space-y-1.5">
+          <SectionLabel>Project</SectionLabel>
+          <ProjectPicker
+            value={side.project}
+            onChange={(p) => setSide({ ...side, project: p, model: "" })}
+          />
+          <SectionLabel>Model (optional)</SectionLabel>
+          <ModelPicker
+            project={side.project}
+            value={side.model}
+            onChange={(m) => setSide({ ...side, model: m })}
+          />
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          <SectionLabel>Snapshot file</SectionLabel>
+          <label className="nerd-btn text-xs flex items-center gap-1 cursor-pointer w-fit">
+            <FileUp className="w-3 h-3" /> {side.file ? side.file.name : "Pick JSON…"}
+            <input
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={async (e) => {
+                const f = e.target.files?.[0];
+                if (!f) return;
+                try {
+                  const json = await readFileAsJson(f);
+                  setSide({ ...side, file: { name: f.name, content: json } });
+                } catch (err) {
+                  // surface in alert -- file pickers don't have a great
+                  // inline-error story in this codebase yet.
+                  alert(err instanceof Error ? err.message : String(err));
+                }
+                // reset input so re-picking the same file fires onChange
+                e.target.value = "";
+              }}
+            />
+          </label>
+          {side.file ? (
+            <div className="text-[10px] text-zinc-500">
+              Loaded {side.file.name}. Diff uses inline body, the file is not uploaded.
+            </div>
+          ) : (
+            <div className="text-[10px] text-zinc-500">
+              Pick a JSON snapshot produced by Export (or `kbagent sl export`).
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffPerTypePanel({ kind, data }: { kind: EntityKey; data: DiffPerType }) {
+  const total = data.added.length + data.removed.length + data.changed.length;
+  if (total === 0) {
+    return (
+      <div className="text-xs text-zinc-500 italic">
+        {kind}: identical ({data.added.length === 0 ? "no items on either side" : "matched"}).
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-bold capitalize">
+        {kind}{" "}
+        <span className="text-zinc-500 font-normal text-[10px]">
+          +{data.added.length} / −{data.removed.length} / ~{data.changed.length}
+        </span>
+      </div>
+      {data.added.length > 0 ? (
+        <div className="text-[11px] flex flex-wrap gap-1">
+          <span className="text-emerald-500">+</span>
+          {data.added.map((n) => (
+            <span
+              key={`a-${n}`}
+              className="px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+            >
+              {n}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {data.removed.length > 0 ? (
+        <div className="text-[11px] flex flex-wrap gap-1">
+          <span className="text-red-500">−</span>
+          {data.removed.map((n) => (
+            <span
+              key={`r-${n}`}
+              className="px-1.5 py-0.5 rounded bg-red-500/10 text-red-700 dark:text-red-400"
+            >
+              {n}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {data.changed.length > 0 ? (
+        <div className="text-[11px] space-y-0.5">
+          {data.changed.map((c) => {
+            const id = c.name ?? c.term ?? "?";
+            return (
+              <div key={`c-${id}`} className="flex flex-wrap items-center gap-1">
+                <span className="text-amber-500">~</span>
+                <span className="px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-700 dark:text-amber-400">
+                  {id}
+                </span>
+                {c.diff_keys && c.diff_keys.length > 0 ? (
+                  <span className="text-zinc-500">
+                    [{c.diff_keys.join(", ")}]
+                  </span>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function DiffDialog({
+  initialProject,
+  onClose,
+}: {
+  initialProject: string;
+  onClose: () => void;
+}) {
+  const [left, setLeft] = useState<DiffSide>(emptySide(initialProject));
+  const [right, setRight] = useState<DiffSide>(emptySide(""));
+
+  const ready =
+    (left.mode === "project" ? !!left.project : !!left.file) &&
+    (right.mode === "project" ? !!right.project : !!right.file);
+
+  const mu = useMutation<DiffResponse, Error>({
+    mutationFn: () => {
+      const body: Record<string, unknown> = {};
+      if (left.mode === "project") {
+        body.project_a = left.project;
+        if (left.model) body.model_a = left.model;
+      } else if (left.file) {
+        body.file_a = left.file.content;
+      }
+      if (right.mode === "project") {
+        body.project_b = right.project;
+        if (right.model) body.model_b = right.model;
+      } else if (right.file) {
+        body.file_b = right.file.content;
+      }
+      return api.post("/semantic-layer/diff", body);
+    },
+  });
+
+  return (
+    <Drawer open onClose={onClose} title="Diff snapshots" width="80vw">
+      <div className="space-y-4">
+        <div className="grid md:grid-cols-2 gap-3">
+          <SideEditor label="Left (A)" side={left} setSide={setLeft} />
+          <SideEditor label="Right (B)" side={right} setSide={setRight} />
+        </div>
+
+        <div className="flex items-center gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-900">
+          <PrimaryButton onClick={() => mu.mutate()} disabled={!ready || mu.isPending}>
+            <GitCompare className="w-3 h-3" />
+            {mu.isPending ? "Diffing…" : "Run diff"}
+          </PrimaryButton>
+          <button type="button" className="nerd-btn text-xs" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {mu.error ? <ErrorBox message={(mu.error as Error).message} /> : null}
+
+        {mu.data ? (
+          <div className="space-y-3">
+            <div className="text-[11px] text-zinc-500">
+              <span className="font-mono">A:</span> {String(mu.data.left.source)} &nbsp;
+              <ArrowRight className="inline w-3 h-3" /> &nbsp;
+              <span className="font-mono">B:</span> {String(mu.data.right.source)}
+            </div>
+            <div className="grid md:grid-cols-2 gap-x-6 gap-y-3">
+              {ENTITY_KEYS.map((k) => (
+                <DiffPerTypePanel key={k} kind={k} data={mu.data[k]} />
+              ))}
+            </div>
+            <details className="text-[11px]">
+              <summary className="cursor-pointer text-zinc-500">Raw response</summary>
+              <div className="mt-2">
+                <JsonView data={mu.data} maxHeight="40vh" />
+              </div>
+            </details>
+          </div>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}
+
+// ── Promote dialog ───────────────────────────────────────────────────
+
+interface PromoteStats {
+  new: string[];
+  overwritten: string[];
+  identical: string[];
+  failed: { name: string; error: string }[];
+}
+
+interface PromoteResponse {
+  from_project: string;
+  to_project: string;
+  from_model?: string;
+  to_model?: string;
+  dry_run: boolean;
+  datasets?: PromoteStats;
+  metrics?: PromoteStats;
+  relationships?: PromoteStats;
+  constraints?: PromoteStats;
+  glossary?: PromoteStats;
+}
+
+function TypeFilterCheckboxes({
+  selected,
+  onChange,
+}: {
+  selected: EntityKey[];
+  onChange: (next: EntityKey[]) => void;
+}) {
+  const toggle = (k: EntityKey) => {
+    if (selected.includes(k)) {
+      onChange(selected.filter((x) => x !== k));
+    } else {
+      onChange([...selected, k]);
+    }
+  };
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ALL_TYPE_FILTERS.map((k) => (
+        <label key={k} className="flex items-center gap-1 text-xs text-zinc-600 dark:text-zinc-400">
+          <input
+            type="checkbox"
+            checked={selected.includes(k)}
+            onChange={() => toggle(k)}
+          />
+          <span className="capitalize">{k}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function PromoteStatsPanel({
+  kind,
+  stats,
+  dryRun,
+}: {
+  kind: EntityKey;
+  stats: PromoteStats;
+  dryRun: boolean;
+}) {
+  const verb = dryRun ? "would" : "did";
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-bold capitalize">
+        {kind}{" "}
+        <span className="text-zinc-500 font-normal text-[10px]">
+          +{stats.new.length} ~{stats.overwritten.length} ={stats.identical.length}{" "}
+          ✗{stats.failed.length}
+        </span>
+      </div>
+      {stats.new.length > 0 ? (
+        <div className="text-[11px]">
+          <span className="text-emerald-500">{verb} create:</span>{" "}
+          {stats.new.join(", ")}
+        </div>
+      ) : null}
+      {stats.overwritten.length > 0 ? (
+        <div className="text-[11px]">
+          <span className="text-amber-500">{verb} overwrite:</span>{" "}
+          {stats.overwritten.join(", ")}
+        </div>
+      ) : null}
+      {stats.identical.length > 0 ? (
+        <div className="text-[11px]">
+          <span className="text-zinc-500">unchanged ({stats.identical.length}):</span>{" "}
+          {stats.identical.join(", ")}
+        </div>
+      ) : null}
+      {stats.failed.length > 0 ? (
+        <div className="text-[11px] space-y-0.5">
+          {stats.failed.map((f) => (
+            <div key={f.name} className="text-red-500">
+              ✗ {f.name}: {f.error}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function PromoteDialog({
+  initialFromProject,
+  onClose,
+}: {
+  initialFromProject: string;
+  onClose: () => void;
+}) {
+  const [fromProject, setFromProject] = useState(initialFromProject);
+  const [fromModel, setFromModel] = useState("");
+  const [toProject, setToProject] = useState("");
+  const [toModel, setToModel] = useState("");
+  const [types, setTypes] = useState<EntityKey[]>([...ENTITY_KEYS]);
+
+  const ready =
+    !!fromProject && !!toProject && fromProject !== toProject && types.length > 0;
+
+  // Two-step: first preview (dry_run), then apply (dry_run off) -- once
+  // preview returned, the user reviews stats and clicks Apply. The Apply
+  // mutation reuses the form state, doesn't take "previewed payload" as
+  // input, so any field edit invalidates the preview semantically.
+  const previewMu = useMutation<PromoteResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/promote", {
+        from_project: fromProject,
+        to_project: toProject,
+        from_model: fromModel || undefined,
+        to_model: toModel || undefined,
+        types: types.length === ENTITY_KEYS.length ? undefined : types,
+        dry_run: true,
+      }),
+  });
+  const applyMu = useMutation<PromoteResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/promote", {
+        from_project: fromProject,
+        to_project: toProject,
+        from_model: fromModel || undefined,
+        to_model: toModel || undefined,
+        types: types.length === ENTITY_KEYS.length ? undefined : types,
+        dry_run: false,
+      }),
+  });
+
+  const lastResult = applyMu.data ?? previewMu.data;
+  const lastDryRun = applyMu.data ? false : previewMu.data ? true : null;
+
+  return (
+    <Drawer open onClose={onClose} title="Promote model across projects" width="70vw">
+      <div className="space-y-4">
+        <div className="grid md:grid-cols-2 gap-3">
+          <div className="border border-zinc-200 dark:border-zinc-900 rounded p-3 space-y-2">
+            <span className="text-xs font-bold text-keboola">From</span>
+            <SectionLabel>Project</SectionLabel>
+            <ProjectPicker
+              value={fromProject}
+              onChange={(p) => {
+                setFromProject(p);
+                setFromModel("");
+              }}
+            />
+            <SectionLabel>Model (optional)</SectionLabel>
+            <ModelPicker project={fromProject} value={fromModel} onChange={setFromModel} />
+          </div>
+          <div className="border border-zinc-200 dark:border-zinc-900 rounded p-3 space-y-2">
+            <span className="text-xs font-bold text-keboola">To</span>
+            <SectionLabel>Project</SectionLabel>
+            <ProjectPicker
+              value={toProject}
+              onChange={(p) => {
+                setToProject(p);
+                setToModel("");
+              }}
+            />
+            <SectionLabel>Model (optional)</SectionLabel>
+            <ModelPicker project={toProject} value={toModel} onChange={setToModel} />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <SectionLabel>Entity types to promote</SectionLabel>
+          <TypeFilterCheckboxes selected={types} onChange={setTypes} />
+          <div className="text-[10px] text-zinc-500">
+            All five are selected by default. Unchecking sends a `types` filter so the API
+            only touches those kinds.
+          </div>
+        </div>
+
+        {fromProject && toProject && fromProject === toProject ? (
+          <div className="flex items-center gap-2 text-xs text-amber-500">
+            <AlertTriangle className="w-3.5 h-3.5" /> From and To must be different projects.
+          </div>
+        ) : null}
+
+        <div className="flex items-center gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-900">
+          <PrimaryButton
+            onClick={() => previewMu.mutate()}
+            disabled={!ready || previewMu.isPending || applyMu.isPending}
+          >
+            <Sparkles className="w-3 h-3" />
+            {previewMu.isPending ? "Previewing…" : "Preview (dry-run)"}
+          </PrimaryButton>
+          <PrimaryButton
+            onClick={() => {
+              if (
+                confirm(
+                  `Apply promote from ${fromProject} → ${toProject}? CHANGED items will be overwritten on target.`,
+                )
+              ) {
+                applyMu.mutate();
+              }
+            }}
+            disabled={!ready || previewMu.isPending || applyMu.isPending}
+          >
+            <Send className="w-3 h-3" />
+            {applyMu.isPending ? "Applying…" : "Apply"}
+          </PrimaryButton>
+          <button type="button" className="nerd-btn text-xs" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {previewMu.error ? <ErrorBox message={(previewMu.error as Error).message} /> : null}
+        {applyMu.error ? <ErrorBox message={(applyMu.error as Error).message} /> : null}
+
+        {lastResult && lastDryRun !== null ? (
+          <div className="space-y-3">
+            <div className="text-[11px] text-zinc-500">
+              {lastDryRun ? "Preview" : "Applied"}: {lastResult.from_project}{" "}
+              <ArrowRight className="inline w-3 h-3" /> {lastResult.to_project}
+            </div>
+            <div className="grid md:grid-cols-2 gap-x-6 gap-y-3">
+              {ENTITY_KEYS.map((k) => {
+                const stats = lastResult[k];
+                if (!stats) return null;
+                return (
+                  <PromoteStatsPanel
+                    key={k}
+                    kind={k}
+                    stats={stats}
+                    dryRun={lastDryRun}
+                  />
+                );
+              })}
+            </div>
+            <details className="text-[11px]">
+              <summary className="cursor-pointer text-zinc-500">Raw response</summary>
+              <div className="mt-2">
+                <JsonView data={lastResult} maxHeight="40vh" />
+              </div>
+            </details>
+          </div>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}
+
+// ── Import dialog ────────────────────────────────────────────────────
+
+interface ImportItemEnvelope {
+  type: string;
+  status: string;
+  name?: string;
+  error?: string;
+}
+
+interface ImportResponse {
+  target_project: string;
+  target_model: string;
+  source_model: string;
+  dry_run: boolean;
+  overwrite: boolean;
+  imported: { items: ImportItemEnvelope[]; summary: Record<string, number> };
+}
+
+export function ImportDialog({
+  initialProject,
+  initialModel,
+  onClose,
+  onImported,
+}: {
+  initialProject: string;
+  initialModel: string;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const [project, setProject] = useState(initialProject);
+  const [model, setModel] = useState(initialModel);
+  const [snapshot, setSnapshot] = useState<{ name: string; content: unknown } | null>(null);
+  const [types, setTypes] = useState<EntityKey[]>([...ENTITY_KEYS]);
+  const [overwrite, setOverwrite] = useState(false);
+
+  const previewMu = useMutation<ImportResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/import", {
+        project,
+        model: model || undefined,
+        snapshot: snapshot?.content,
+        types: types.length === ENTITY_KEYS.length ? undefined : types,
+        dry_run: true,
+        overwrite,
+      }),
+  });
+  const applyMu = useMutation<ImportResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/import", {
+        project,
+        model: model || undefined,
+        snapshot: snapshot?.content,
+        types: types.length === ENTITY_KEYS.length ? undefined : types,
+        dry_run: false,
+        overwrite,
+      }),
+    onSuccess: () => onImported(),
+  });
+
+  const ready = !!project && !!snapshot && types.length > 0;
+  const last = applyMu.data ?? previewMu.data;
+  const lastDryRun = applyMu.data ? false : previewMu.data ? true : null;
+
+  return (
+    <Drawer open onClose={onClose} title="Import snapshot" width="70vw">
+      <div className="space-y-4">
+        <div className="grid md:grid-cols-2 gap-3">
+          <div className="border border-zinc-200 dark:border-zinc-900 rounded p-3 space-y-2">
+            <span className="text-xs font-bold text-keboola">Target</span>
+            <SectionLabel>Project</SectionLabel>
+            <ProjectPicker
+              value={project}
+              onChange={(p) => {
+                setProject(p);
+                setModel("");
+              }}
+            />
+            <SectionLabel>Model (optional — defaults to single model)</SectionLabel>
+            <ModelPicker project={project} value={model} onChange={setModel} />
+          </div>
+          <div className="border border-zinc-200 dark:border-zinc-900 rounded p-3 space-y-2">
+            <span className="text-xs font-bold text-keboola">Snapshot</span>
+            <label className="nerd-btn text-xs flex items-center gap-1 cursor-pointer w-fit">
+              <FileUp className="w-3 h-3" /> {snapshot ? snapshot.name : "Pick JSON snapshot…"}
+              <input
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={async (e) => {
+                  const f = e.target.files?.[0];
+                  if (!f) return;
+                  try {
+                    const json = await readFileAsJson(f);
+                    setSnapshot({ name: f.name, content: json });
+                  } catch (err) {
+                    alert(err instanceof Error ? err.message : String(err));
+                  }
+                  e.target.value = "";
+                }}
+              />
+            </label>
+            <div className="text-[10px] text-zinc-500">
+              The snapshot is sent inline in the request body (no upload endpoint). Produced by
+              the Export button or `kbagent sl export`.
+            </div>
+            <label className="flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400">
+              <input
+                type="checkbox"
+                checked={overwrite}
+                onChange={(e) => setOverwrite(e.target.checked)}
+              />
+              Overwrite existing items (otherwise: skip on conflict)
+            </label>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <SectionLabel>Entity types to import</SectionLabel>
+          <TypeFilterCheckboxes selected={types} onChange={setTypes} />
+        </div>
+
+        <div className="flex items-center gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-900">
+          <PrimaryButton
+            onClick={() => previewMu.mutate()}
+            disabled={!ready || previewMu.isPending || applyMu.isPending}
+          >
+            <Sparkles className="w-3 h-3" />
+            {previewMu.isPending ? "Previewing…" : "Preview (dry-run)"}
+          </PrimaryButton>
+          <PrimaryButton
+            onClick={() => {
+              if (
+                confirm(
+                  `Import snapshot into ${project}? ${
+                    overwrite ? "EXISTING items will be overwritten." : "Conflicts will be skipped."
+                  }`,
+                )
+              ) {
+                applyMu.mutate();
+              }
+            }}
+            disabled={!ready || previewMu.isPending || applyMu.isPending}
+          >
+            <Upload className="w-3 h-3" />
+            {applyMu.isPending ? "Importing…" : "Import"}
+          </PrimaryButton>
+          <button type="button" className="nerd-btn text-xs" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {previewMu.error ? <ErrorBox message={(previewMu.error as Error).message} /> : null}
+        {applyMu.error ? <ErrorBox message={(applyMu.error as Error).message} /> : null}
+
+        {last && lastDryRun !== null ? (
+          <div className="space-y-2">
+            <div className="text-[11px] text-zinc-500">
+              {lastDryRun ? "Preview" : "Imported"}: {last.target_project} ← snapshot{" "}
+              <span className="font-mono">{last.source_model || "(unknown)"}</span>
+            </div>
+            <div className="grid md:grid-cols-3 gap-2">
+              {Object.entries(last.imported.summary).map(([k, v]) => (
+                <div
+                  key={k}
+                  className="text-[11px] flex items-center justify-between border border-zinc-200 dark:border-zinc-900 rounded px-2 py-1"
+                >
+                  <span className="text-zinc-500">{k}</span>
+                  <span className="font-mono">{v}</span>
+                </div>
+              ))}
+            </div>
+            <details className="text-[11px]">
+              <summary className="cursor-pointer text-zinc-500">
+                Item-by-item ({last.imported.items.length})
+              </summary>
+              <div className="mt-2 max-h-72 overflow-auto space-y-0.5 font-mono text-[11px]">
+                {last.imported.items.map((it, i) => (
+                  <div
+                    key={`${it.type}-${it.name ?? i}`}
+                    className={
+                      it.status === "imported" || it.status === "would-import"
+                        ? "text-emerald-500"
+                        : it.status === "overwritten" || it.status === "would-overwrite"
+                          ? "text-amber-500"
+                          : it.status === "skipped"
+                            ? "text-zinc-500"
+                            : "text-red-500"
+                    }
+                  >
+                    {it.status} {it.type}: {it.name ?? "?"}
+                    {it.error ? ` — ${it.error}` : ""}
+                  </div>
+                ))}
+              </div>
+            </details>
+          </div>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}
+
+// ── Build dialog ─────────────────────────────────────────────────────
+
+interface BuildValidation {
+  errors: { code?: string; message?: string }[];
+  warnings: { code?: string; message?: string }[];
+}
+
+interface BuildResponse {
+  project: string;
+  dry_run: boolean;
+  keep_on_failure: boolean;
+  fallback_used: string;
+  fetch_errors: { table: string; error: string }[];
+  generated: { datasets: unknown[]; metrics: unknown[]; relationships: unknown[]; constraints: unknown[]; glossary: unknown[] };
+  validation: BuildValidation;
+  validated: boolean;
+  output_path?: string;
+  pushed?: { counts: Record<string, number>; model_uuid: string };
+}
+
+function TablePicker({
+  project,
+  selected,
+  onChange,
+}: {
+  project: string;
+  selected: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [bucketFilter, setBucketFilter] = useState("");
+  const bucketsQ = useQuery<BucketsResponse>({
+    queryKey: ["sl-build-buckets", project],
+    queryFn: () => api.get("/storage/buckets", { query: { project } }),
+    enabled: !!project,
+  });
+  const tablesQ = useQuery<TablesResponse>({
+    queryKey: ["sl-build-tables", project, bucketFilter],
+    queryFn: () =>
+      api.get("/storage/tables", {
+        query: { project, ...(bucketFilter ? { bucket_id: bucketFilter } : {}) },
+      }),
+    enabled: !!project,
+  });
+
+  const allTables = useMemo(() => {
+    return (tablesQ.data?.tables ?? []).map((t) => t.id);
+  }, [tablesQ.data]);
+
+  const toggleAll = () => {
+    if (selected.length === allTables.length) {
+      onChange([]);
+    } else {
+      onChange(allTables);
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2 flex-wrap">
+        <SectionLabel>Filter by bucket</SectionLabel>
+        <select
+          className="nerd-input text-xs py-0.5"
+          value={bucketFilter}
+          onChange={(e) => setBucketFilter(e.target.value)}
+        >
+          <option value="">(all buckets)</option>
+          {(bucketsQ.data?.buckets ?? []).map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.id}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="nerd-btn text-[10px]"
+          onClick={toggleAll}
+          disabled={allTables.length === 0}
+        >
+          {selected.length === allTables.length && allTables.length > 0
+            ? "Unselect all"
+            : "Select all"}
+        </button>
+        <span className="text-[10px] text-zinc-500">
+          {selected.length} / {allTables.length} selected
+        </span>
+      </div>
+
+      {tablesQ.isLoading ? <Loading label="loading tables" /> : null}
+      {tablesQ.error ? <ErrorBox message={(tablesQ.error as Error).message} /> : null}
+
+      {tablesQ.data ? (
+        <div className="border border-zinc-200 dark:border-zinc-900 rounded p-2 max-h-72 overflow-auto space-y-0.5 font-mono text-[11px]">
+          {allTables.length === 0 ? (
+            <div className="text-zinc-500 italic">No tables in this scope.</div>
+          ) : (
+            allTables.map((tid) => (
+              <label key={tid} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(tid)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      onChange([...selected, tid]);
+                    } else {
+                      onChange(selected.filter((x) => x !== tid));
+                    }
+                  }}
+                />
+                <span>{tid}</span>
+              </label>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function BuildDialog({
+  initialProject,
+  initialModel,
+  onClose,
+  onBuilt,
+}: {
+  initialProject: string;
+  initialModel: string;
+  onClose: () => void;
+  onBuilt: () => void;
+}) {
+  const [project, setProject] = useState(initialProject);
+  const [model, setModel] = useState(initialModel);
+  const [tables, setTables] = useState<string[]>([]);
+  const [name, setName] = useState("");
+  const [keepOnFailure, setKeepOnFailure] = useState(false);
+
+  const ready = !!project && tables.length > 0;
+
+  const previewMu = useMutation<BuildResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/build", {
+        project,
+        model: model || undefined,
+        tables,
+        name: name || undefined,
+        dry_run: true,
+        keep_on_failure: keepOnFailure,
+      }),
+  });
+  const applyMu = useMutation<BuildResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/build", {
+        project,
+        model: model || undefined,
+        tables,
+        name: name || undefined,
+        dry_run: false,
+        keep_on_failure: keepOnFailure,
+      }),
+    onSuccess: () => onBuilt(),
+  });
+
+  const last = applyMu.data ?? previewMu.data;
+  const lastDryRun = applyMu.data ? false : previewMu.data ? true : null;
+
+  return (
+    <Drawer open onClose={onClose} title="Build model from tables" width="75vw">
+      <div className="space-y-4">
+        <div className="text-[11px] text-zinc-500">
+          Heuristic greenfield builder — fetches the storage schema for each table, classifies
+          columns into role-buckets, and synthesises one dataset per table with a COUNT(*) metric.
+          Validation runs locally before any push. AI-assisted variant is CLI-only for now.
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <SectionLabel>Project</SectionLabel>
+            <ProjectPicker
+              value={project}
+              onChange={(p) => {
+                setProject(p);
+                setModel("");
+                setTables([]);
+              }}
+            />
+            <SectionLabel>Target model (optional)</SectionLabel>
+            <ModelPicker project={project} value={model} onChange={setModel} />
+            <div className="text-[10px] text-zinc-500">
+              Empty means "create a fresh model with the name below."
+            </div>
+          </div>
+          <div className="space-y-2">
+            <SectionLabel>Model name (if creating a fresh one)</SectionLabel>
+            <input
+              className="nerd-input w-full text-sm"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. analytics_core"
+            />
+            <label className="flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400">
+              <input
+                type="checkbox"
+                checked={keepOnFailure}
+                onChange={(e) => setKeepOnFailure(e.target.checked)}
+              />
+              Keep on failure (don't rollback if push fails — for forensic inspection)
+            </label>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <SectionLabel>Source tables</SectionLabel>
+          {project ? (
+            <TablePicker project={project} selected={tables} onChange={setTables} />
+          ) : (
+            <div className="text-[11px] text-zinc-500 italic">Pick a project first.</div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-900">
+          <PrimaryButton
+            onClick={() => previewMu.mutate()}
+            disabled={!ready || previewMu.isPending || applyMu.isPending}
+          >
+            <Sparkles className="w-3 h-3" />
+            {previewMu.isPending ? "Previewing…" : "Preview (dry-run)"}
+          </PrimaryButton>
+          <PrimaryButton
+            onClick={() => {
+              if (
+                confirm(
+                  `Build & push model from ${tables.length} table(s) into ${project}?`,
+                )
+              ) {
+                applyMu.mutate();
+              }
+            }}
+            disabled={!ready || previewMu.isPending || applyMu.isPending}
+          >
+            <PackagePlus className="w-3 h-3" />
+            {applyMu.isPending ? "Building…" : "Build"}
+          </PrimaryButton>
+          <button type="button" className="nerd-btn text-xs" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {previewMu.error ? <ErrorBox message={(previewMu.error as Error).message} /> : null}
+        {applyMu.error ? <ErrorBox message={(applyMu.error as Error).message} /> : null}
+
+        {last && lastDryRun !== null ? (
+          <div className="space-y-3">
+            <div className="text-[11px] text-zinc-500">
+              {lastDryRun ? "Preview" : "Pushed"}: fallback={last.fallback_used}, validated=
+              {last.validated ? "yes" : "no"}
+            </div>
+            {last.validation.errors.length > 0 ? (
+              <div className="text-[11px] space-y-0.5">
+                <div className="text-red-500 font-bold">
+                  Errors ({last.validation.errors.length})
+                </div>
+                {last.validation.errors.map((e, i) => (
+                  <div key={i} className="text-red-500">
+                    [{e.code ?? "ERR"}] {e.message}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            {last.validation.warnings.length > 0 ? (
+              <div className="text-[11px] space-y-0.5">
+                <div className="text-amber-500 font-bold">
+                  Warnings ({last.validation.warnings.length})
+                </div>
+                {last.validation.warnings.map((w, i) => (
+                  <div key={i} className="text-amber-500">
+                    [{w.code ?? "WARN"}] {w.message}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            <div className="grid md:grid-cols-5 gap-2">
+              {ENTITY_KEYS.map((k) => (
+                <div
+                  key={k}
+                  className="text-[11px] flex items-center justify-between border border-zinc-200 dark:border-zinc-900 rounded px-2 py-1"
+                >
+                  <span className="text-zinc-500 capitalize">{k}</span>
+                  <span className="font-mono">{last.generated[k]?.length ?? 0}</span>
+                </div>
+              ))}
+            </div>
+            {last.pushed ? (
+              <div className="text-[11px] text-emerald-500">
+                Pushed model {last.pushed.model_uuid}: {JSON.stringify(last.pushed.counts)}
+              </div>
+            ) : null}
+            {last.fetch_errors.length > 0 ? (
+              <details className="text-[11px]">
+                <summary className="cursor-pointer text-amber-500">
+                  Fetch errors ({last.fetch_errors.length})
+                </summary>
+                <div className="mt-1 space-y-0.5">
+                  {last.fetch_errors.map((fe) => (
+                    <div key={fe.table} className="text-amber-500">
+                      {fe.table}: {fe.error}
+                    </div>
+                  ))}
+                </div>
+              </details>
+            ) : null}
+            <details className="text-[11px]">
+              <summary className="cursor-pointer text-zinc-500">Raw response</summary>
+              <div className="mt-2">
+                <JsonView data={last} maxHeight="40vh" />
+              </div>
+            </details>
+          </div>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}
+
+// ── Token encrypt dialog ─────────────────────────────────────────────
+
+interface TokenEncryptResponse {
+  project: string;
+  component_id: string;
+  // The metastore service wraps the ciphertext in a property-bag dict the
+  // transformation user_properties block consumes verbatim. Most callers
+  // want only the inner string, but the dict is the canonical wire shape.
+  encrypted: Record<string, string>;
+}
+
+export function TokenEncryptDialog({
+  initialProject,
+  onClose,
+}: {
+  initialProject: string;
+  onClose: () => void;
+}) {
+  const [project, setProject] = useState(initialProject);
+  // Component the encrypted token will be embedded in. KBC::Project::*
+  // ciphertext is scoped per component, so the value the user copy/pastes
+  // into the transformation config MUST match the component the transform
+  // uses (typically keboola.snowflake-transformation for snowflake).
+  const [componentId, setComponentId] = useState("keboola.snowflake-transformation");
+  const [copied, setCopied] = useState(false);
+
+  const mu = useMutation<TokenEncryptResponse, Error>({
+    mutationFn: () =>
+      api.post("/semantic-layer/token/encrypt", {
+        project,
+        component_id: componentId,
+      }),
+  });
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      alert(`Clipboard write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  return (
+    <Drawer open onClose={onClose} title="Encrypt project storage token" width="55vw">
+      <div className="space-y-4">
+        <div className="text-[11px] text-zinc-500">
+          Encrypts the project's storage token as a <span className="font-mono">KBC::Project::*</span>{" "}
+          ciphertext bound to a specific component. Paste the resulting value into the
+          transformation config's <span className="font-mono">parameters.user_properties.token</span>{" "}
+          so the metastore-aware transformation can read it without seeing the plaintext token.
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <SectionLabel>Project</SectionLabel>
+            <ProjectPicker value={project} onChange={setProject} />
+          </div>
+          <div className="space-y-1.5">
+            <SectionLabel>Component ID</SectionLabel>
+            <input
+              className="nerd-input w-full text-sm"
+              value={componentId}
+              onChange={(e) => setComponentId(e.target.value)}
+              placeholder="e.g. keboola.snowflake-transformation"
+            />
+            <div className="text-[10px] text-zinc-500">
+              Must match the component the transformation actually uses (per-component scope).
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-900">
+          <PrimaryButton
+            onClick={() => mu.mutate()}
+            disabled={!project || !componentId || mu.isPending}
+          >
+            <KeyRound className="w-3 h-3" />
+            {mu.isPending ? "Encrypting…" : "Encrypt token"}
+          </PrimaryButton>
+          <button type="button" className="nerd-btn text-xs" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {mu.error ? <ErrorBox message={(mu.error as Error).message} /> : null}
+
+        {mu.data ? (
+          <div className="space-y-3">
+            <SectionLabel>Encrypted user_properties</SectionLabel>
+            <div className="text-[11px] text-zinc-500">
+              Paste this block into the transformation's{" "}
+              <span className="font-mono">parameters.user_properties</span>. The key
+              (e.g. <span className="font-mono">#metastore_token</span>) is what the
+              transformation reads at runtime.
+            </div>
+            <textarea
+              readOnly
+              rows={6}
+              className="nerd-input w-full font-mono text-[11px] break-all"
+              value={JSON.stringify(mu.data.encrypted, null, 2)}
+              onFocus={(e) => e.target.select()}
+            />
+            <div className="flex items-center gap-2 flex-wrap">
+              <PrimaryButton
+                onClick={() =>
+                  copyToClipboard(JSON.stringify(mu.data.encrypted, null, 2))
+                }
+              >
+                <Copy className="w-3 h-3" />
+                {copied ? "Copied!" : "Copy block"}
+              </PrimaryButton>
+              {Object.entries(mu.data.encrypted).map(([k, v]) => (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => copyToClipboard(v)}
+                  className="nerd-btn text-xs"
+                  title={`Copy just the ciphertext for ${k}`}
+                >
+                  Copy {k}
+                </button>
+              ))}
+              <span className="text-[10px] text-zinc-500">
+                Component scope:{" "}
+                <span className="font-mono">{mu.data.component_id}</span>
+              </span>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}

--- a/web/frontend/src/state.tsx
+++ b/web/frontend/src/state.tsx
@@ -16,6 +16,7 @@ export type PageId =
   | "flows"
   | "schedules"
   | "lineage"
+  | "semantic-layer"
   | "sharing"
   | "data-apps"
   | "components"


### PR DESCRIPTION
## Summary

Native Semantic Layer surface inside `kbagent serve --ui`, matching the full
`kbagent semantic-layer` CLI feature set. Built in four iterative passes
against the keboola-ai project's `langsmith_semantic_model` (15 metrics,
16 datasets, 142 relationships, 6 constraints) so every code path is
exercised against real production-shape data.

## What lands

**Phase 1+2 — CRUD scaffolding** (commit `bcc80b7`)
- New `/semantic-layer` page in the Insights sidebar group.
- Schema-driven entity forms (one declaration covers Add + Edit for all
  five entity kinds — metric, dataset, relationship, constraint, glossary).
- Per-model header with Validate / Export / Delete buttons.

**Phase 3 — Workflows + backend hardening** (commit `34514ce`)
- New `SemanticLayerDialogs.tsx` with five drawers: Diff (project↔project,
  project↔file, file↔file), Promote (cross-project with dry-run preview),
  Import (snapshot replay with item-by-item log), Build (heuristic
  greenfield builder with bucket-filtered table picker), Encrypt token
  (project storage token → KBC::ProjectSecure ciphertext for transformation
  user_properties).
- Filled-keboola primary buttons so the actionable choice no longer looks
  identical to Cancel/Close.
- Backend: `heuristic_generate_model` now maps warehouse-native column
  types onto the metastore's lowercase closed set (`string`/`integer`/...).
  Previously every legacy untyped table 422'd the build push.
- Backend: `http_base._raise_api_error` now surfaces the real error
  message from the metastore's `{"error": 422, "errors": [...]}` shape
  instead of bare `"API error 422: 422"`.

**Phase 4 — Polish for real-data scale** (commit `4d7dcb4`)
- `tableId`/`primaryKey`/`constraintType` camelCase → snake normalisation
  at the API boundary so the TABLE column actually populates.
- Relationships ERD toggle (Mermaid `erDiagram`; mermaid is already in
  deps). Soft 80-edge cap with banner pointing at the dataset chip filter
  for larger models.
- Quick search box across every entity table, plus a "filter by dataset"
  chip for relationships.
- Dataset detail drawer renders fields with role badges + AI keywords
  instead of raw JSON (Raw still one click away).
- Constraints grouped into collapsible `<details>` per `constraint_type`
  (inequality → equality → range → ...) with severity icons
  (🔴 critical · ⚠ warning · ⓘ info).

## Architecture / business-logic check

- All UI calls route through `/api/semantic-layer/*` — **zero**
  metastore HTTP from JS, **zero** business logic in the frontend.
- CLI ↔ API ↔ UI parity is 1:1 (14 routes mirror 11 CLI subcommands +
  15 add/edit/remove leaves; `POST /items/{kind}` parameterises the
  five kinds in REST style).
- Backend service layer is the only place fields/types/FQN/push order
  are computed.

## Known follow-ups (filed separately, not in this PR)

- #306 — `semantic-layer model delete` leaves orphan children in
  metastore; per-project name conflicts block subsequent Build / Import.
  Suggested fix is cascade-delete in `delete_model` (reverse PUSH_ORDER).

## Test plan

- [x] Local smoke: `kbagent serve --ui` against padak-2-0-master and
  keboola-ai
- [x] Phase 1 — Create model (Snowflake / BigQuery)
- [x] Phase 2 — Add dataset, Add metric, Validate, Export → snapshot.json
- [x] Phase 3 — Diff (project↔file), Build (with cleanup of orphan
  datasets), Encrypt token (paste-ready user_properties block)
- [x] Phase 4 — Dataset detail drawer on `fct_conversations` (64 fields),
  Relationships ERD with dataset chip filter (142 → 31 edges),
  Constraints grouped by type (inequality/range/composition) with
  severity icons