### PR TITLE
fix(local-ai): codex --skip-git-repo-check + surface non-timeout CLI errors

### DIFF
--- a/src/keboola_agent_cli/server/agent_runner.py
+++ b/src/keboola_agent_cli/server/agent_runner.py
@@ -731,7 +731,13 @@ _AI_CLI_RECIPES: dict[str, Any] = {
     # Anthropic Claude Code: -p PROMPT runs in headless / non-interactive mode.
     "claude": lambda prompt, extra: ["claude", "-p", prompt, *extra],
     # OpenAI Codex CLI: `codex exec PROMPT` runs once and exits.
-    "codex": lambda prompt, extra: ["codex", "exec", *extra, prompt],
+    # `--skip-git-repo-check` is mandatory for headless invocation: codex 0.131+
+    # refuses to run in any directory it has not been interactively "trusted"
+    # via the first-run dialog, which a subprocess never sees. Without the flag
+    # the CLI exits 1 with "Not inside a trusted directory" before reading the
+    # prompt -- that is the failure path that surfaced as "AI chat failed" in
+    # the Local AI dashboard tile.
+    "codex": lambda prompt, extra: ["codex", "exec", "--skip-git-repo-check", *extra, prompt],
     # Google Gemini CLI: `gemini -p PROMPT` for non-interactive single prompt.
     "gemini": lambda prompt, extra: ["gemini", "-p", prompt, *extra],
 }
@@ -816,7 +822,11 @@ _AI_CLI_STREAM_RECIPES: dict[str, Any] = {
         ],
         True,  # jsonl
     ),
-    "codex": lambda prompt, extra: (["codex", "exec", *extra, prompt], False),
+    # See _AI_CLI_RECIPES above for the `--skip-git-repo-check` rationale.
+    "codex": lambda prompt, extra: (
+        ["codex", "exec", "--skip-git-repo-check", *extra, prompt],
+        False,
+    ),
     "gemini": lambda prompt, extra: (["gemini", "-p", prompt, *extra], False),
 }
 
@@ -995,6 +1005,18 @@ async def stream_ai_agent_events(
     }
     if timed_out:
         final["error"] = f"AI CLI '{cli_name}' timed out after {timeout}s"
+    elif status == "error":
+        # Non-timeout failure (CLI exited with non-zero rc). Surface a
+        # human-readable error so the UI does not fall back to a generic
+        # "AI chat failed" placeholder -- the stderr tail almost always
+        # explains the failure (e.g. codex "Not inside a trusted directory",
+        # claude auth errors, network blips). Cap tail length so a chatty
+        # CLI cannot blow up the SSE frame.
+        tail_lines = [s for s in stderr_chunks if s.strip()][-8:]
+        tail = "\n".join(tail_lines)[-800:].strip()
+        final["error"] = f"AI CLI '{cli_name}' exited with code {proc.returncode}." + (
+            f"\nstderr (tail):\n{tail}" if tail else ""
+        )
     yield {"event": "done", "data": final}
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -327,3 +327,149 @@ class TestUpstreamEnvAndPrompt:
         assert "upstream task" in prefix
         # AI must know how to fetch the upstream output via HTTP.
         assert f"/agents/A/runs/{run.run_id}" in prefix
+
+
+# ---------------------------------------------------------------------------
+# Codex headless invocation guard + non-timeout error surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestCodexHeadlessRecipe:
+    """Codex CLI 0.131+ refuses to run in any directory the user has not
+    interactively "trusted". A subprocess never sees that dialog, so the
+    `--skip-git-repo-check` flag is the only way to keep `codex exec`
+    usable from `kbagent serve` / scheduled agent runs. Without it codex
+    exits 1 with "Not inside a trusted directory" before reading the
+    prompt — and the failure surfaces as a generic "AI chat failed" in
+    the dashboard. Pin the flag in BOTH recipe tables so a future refactor
+    cannot silently drop it.
+    """
+
+    def test_one_shot_recipe_includes_skip_git_repo_check(self) -> None:
+        from keboola_agent_cli.server.agent_runner import _AI_CLI_RECIPES
+
+        argv = _AI_CLI_RECIPES["codex"]("hi", [])
+        assert argv[0] == "codex"
+        assert argv[1] == "exec"
+        assert "--skip-git-repo-check" in argv
+        # The prompt must remain the LAST positional argument, otherwise
+        # codex would interpret following tokens as part of the prompt.
+        assert argv[-1] == "hi"
+
+    def test_stream_recipe_includes_skip_git_repo_check(self) -> None:
+        from keboola_agent_cli.server.agent_runner import _AI_CLI_STREAM_RECIPES
+
+        argv, jsonl = _AI_CLI_STREAM_RECIPES["codex"]("hi", [])
+        assert argv[0] == "codex"
+        assert argv[1] == "exec"
+        assert "--skip-git-repo-check" in argv
+        assert argv[-1] == "hi"
+        # codex does not support a structured JSONL stream today.
+        assert jsonl is False
+
+    def test_codex_extra_args_land_before_prompt(self) -> None:
+        """User-supplied extra_args must not push the prompt out of its
+        terminal position (otherwise codex would treat the prompt as a
+        subcommand or eat extra_args as part of it).
+        """
+        from keboola_agent_cli.server.agent_runner import (
+            _AI_CLI_RECIPES,
+            _AI_CLI_STREAM_RECIPES,
+        )
+
+        argv = _AI_CLI_RECIPES["codex"]("THE PROMPT", ["--sandbox", "read-only"])
+        assert argv[-3:] == ["--sandbox", "read-only", "THE PROMPT"]
+
+        argv2, _ = _AI_CLI_STREAM_RECIPES["codex"]("THE PROMPT", ["--sandbox", "read-only"])
+        assert argv2[-3:] == ["--sandbox", "read-only", "THE PROMPT"]
+
+
+class _FailingProc:
+    """Stand-in for asyncio.subprocess.Process that exits non-zero.
+
+    Mirrors _FakeProc above but lets the test choose ``returncode`` so we
+    can exercise the non-timeout error path of ``stream_ai_agent_events``.
+    """
+
+    def __init__(self, stdout_bytes: bytes, stderr_bytes: bytes, exit_code: int) -> None:
+        loop = asyncio.get_event_loop()
+        self.stdout = asyncio.StreamReader(loop=loop)
+        self.stderr = asyncio.StreamReader(loop=loop)
+        self.stdout.feed_data(stdout_bytes)
+        self.stdout.feed_eof()
+        self.stderr.feed_data(stderr_bytes)
+        self.stderr.feed_eof()
+        self._exit_code = exit_code
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = self._exit_code
+        return self._exit_code
+
+    def kill(self) -> None:
+        pass
+
+
+class TestStreamErrorSurfacing:
+    """When a CLI exits with non-zero rc (not a timeout), the done event
+    must carry an ``error`` field so the UI does not fall back to a
+    generic "AI chat failed" placeholder. The stderr tail is the most
+    useful diagnostic (codex trust check, claude auth, network blip).
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_timeout_failure_populates_error_with_stderr_tail(
+        self, tmp_path: Path
+    ) -> None:
+        from keboola_agent_cli.server.agent_runner import stream_ai_agent_events
+
+        registry = _make_registry(tmp_path)
+        scripted_stderr = (
+            b"Reading additional input from stdin...\n"
+            b"Not inside a trusted directory and "
+            b"--skip-git-repo-check was not specified.\n"
+        )
+        proc = _FailingProc(b"", scripted_stderr, exit_code=1)
+        with patch(
+            "keboola_agent_cli.server.agent_runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ):
+            events = []
+            async for evt in stream_ai_agent_events(registry, {"cli": "codex", "prompt": "test"}):
+                events.append(evt)
+
+        done = events[-1]
+        assert done["event"] == "done"
+        data = done["data"]
+        assert data["status"] == "error"
+        assert data["exit_code"] == 1
+        # The error field is what the React side reads; it MUST be present
+        # so the placeholder fallback ("AI chat failed") never wins.
+        assert "error" in data
+        assert "exited with code 1" in data["error"]
+        # Stderr tail surfaces the root cause verbatim.
+        assert "trusted directory" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_successful_run_does_not_set_error_field(self, tmp_path: Path) -> None:
+        from keboola_agent_cli.server.agent_runner import stream_ai_agent_events
+
+        registry = _make_registry(tmp_path)
+        # Reuse the existing _FakeProc (exit 0) — but feed claude-shaped
+        # JSONL so the generator's stream_ai_agent_events accumulator
+        # produces a sensible response.
+        scripted = b'{"type":"result","result":"ok"}\n'
+        proc = _FakeProc(scripted, b"")
+        with patch(
+            "keboola_agent_cli.server.agent_runner.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ):
+            events = []
+            async for evt in stream_ai_agent_events(registry, {"cli": "claude", "prompt": "ok"}):
+                events.append(evt)
+
+        done = events[-1]["data"]
+        assert done["status"] == "ok"
+        # Success path leaves the error field absent — UI checks for status
+        # before reading error, but absence keeps the wire shape clean.
+        assert "error" not in done


### PR DESCRIPTION
## Summary

- Local AI dashboard chat with the **codex** CLI failed immediately with a generic `AI chat failed` placeholder; claude and gemini worked fine.
- Two independent bugs combined to produce that symptom. This PR fixes both and adds regression tests for each.

## Root cause

### 1. codex 0.131+ requires `--skip-git-repo-check` for headless use

`codex exec` refuses to run in any directory the user has not interactively "trusted" via the first-run dialog. A headless subprocess never sees that dialog, so it exits 1 with `Not inside a trusted directory and --skip-git-repo-check was not specified` before reading the prompt. Reproduced locally:

```
$ codex exec "co umis?" < /dev/null; echo "EXIT=$?"
Reading additional input from stdin...
Not inside a trusted directory and --skip-git-repo-check was not specified.
EXIT=1
```

Both `_AI_CLI_RECIPES["codex"]` (cron-driven one-shot) and `_AI_CLI_STREAM_RECIPES["codex"]` (Local AI streaming) now pass the flag.

### 2. `stream_ai_agent_events` masked non-timeout failures

The done payload only populated the `error` field when the failure was a timeout. Non-zero exit codes (codex above, but also any future claude/gemini auth or network failure) left `error` absent, so the React side (`LocalAi.tsx:202`) fell back to a generic placeholder string and the real diagnostic was lost.

`done.error` is now always set on `status="error"`. For non-timeout failures it carries the exit code and the last 8 non-empty stderr lines, capped at 800 chars so a chatty CLI cannot blow up the SSE frame:

```
AI CLI 'codex' exited with code 1.
stderr (tail):
Reading additional input from stdin...
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

## Tests

5 new regression tests in `tests/test_agent_runner.py`:

- `TestCodexHeadlessRecipe::test_one_shot_recipe_includes_skip_git_repo_check`
- `TestCodexHeadlessRecipe::test_stream_recipe_includes_skip_git_repo_check`
- `TestCodexHeadlessRecipe::test_codex_extra_args_land_before_prompt` -- pins the positional invariant so user-supplied `extra_args` cannot displace the prompt from its terminal position
- `TestStreamErrorSurfacing::test_non_timeout_failure_populates_error_with_stderr_tail` -- pins that the new `error` field is set on non-zero exit and contains the stderr tail
- `TestStreamErrorSurfacing::test_successful_run_does_not_set_error_field` -- the wire shape stays clean on success

Full sweep: `tests/test_agent_runner.py` 24/24 pass, `tests/test_local_ai_chat.py + test_agent_prompt_helper.py + test_workspace_sql_helper.py + test_run_broadcaster.py` 68/68 pass. Ruff check + format clean.

## Test plan

- [ ] `make check`
- [ ] Restart `kbagent serve --ui`, open Local AI, send a message with `codex` selected from any CWD (including non-git-repo dirs); the response should render the same way claude/gemini already do.
- [ ] Inject an artificial failure (e.g. invalidate the codex auth file) and confirm the UI shows the actual stderr tail in the error box instead of `AI chat failed`.