### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -69,17 +69,21 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
+          # v6 can auto-enable package-manager caching when a package.json
+          # declares `packageManager`; the SPA is built from web/frontend/, so
+          # keep the v4 behaviour (no implicit cache) explicit and predictable.
+          package-manager-cache: false
 
       # Bug 1: with npm present, the hook must resolve `npm.cmd` via
       # shutil.which and run it (shell=False) instead of crashing with


### PR DESCRIPTION
## Summary

GitHub deprecated the **Node.js 20 action runtime** (actions are force-migrated to Node 24 by June 2 2026). Every CI run on `main` was emitting a deprecation annotation naming `actions/setup-python@v5`, `astral-sh/setup-uv@v6`, and `actions/setup-node@v4`.

This bumps those actions to majors whose `action.yml` declares `runs.using: node24` — verified directly against each action's `action.yml` at the pinned tag:

| Action | Before | After | `runs.using` after |
|---|---|---|---|
| `astral-sh/setup-uv` | `v6` | `v7` | `node24` |
| `actions/setup-python` | `v5` | `v6` | `node24` |
| `actions/setup-node` | `v4` | `v6` | `node24` |
| `actions/checkout` | `v5` | `v5` (unchanged) | `node24` (already) |

`actions/checkout@v5` already targets Node 24, which is why it was never in the deprecation list — left as-is.

## Note on `setup-node@v6`

v6 can auto-enable package-manager caching when a `package.json` declares a `packageManager` field. The SPA is built from `web/frontend/` (not the repo root), so `package-manager-cache: false` is set explicitly to preserve the exact v4 behaviour (no implicit caching) and avoid surprises.

## Risk / verification

No functional change to either job — the action inputs are otherwise unchanged, and the build Node version stays at `20`. The `setup-uv` major was pinned to `v7` (the first node24 release) rather than the latest `v8` because v8 introduced immutable-tag semantics that add complexity without any additional node24 benefit.

**CI is the verification:** both jobs (the ubuntu `check` suite and the `windows-latest` wheel build) run on the bumped actions in this PR. If they pass, nothing broke.
