### PR TITLE
chore: move hatch_build.py to scripts/ + complete README command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ kbagent workspace query --project prod --workspace-id WS_ID \
 | **Data apps** | First-class lifecycle for Streamlit / Flask / Node deployments (`keboola.data-apps`). `create / deploy / start / stop / password / delete` (since 0.27.0); `secrets-set / -list / -get / -remove` for `#`-prefixed runtime secrets with per-project KMS encryption (since 0.29.0); `validate-repo` pre-flight Golden Rule check that catches misconfigured git repos before a deploy (since 0.29.0); `logs` tails the container log buffer for triaging stuck deploys / runtime crashes (since 0.43.8). Hides the redeploy contract and per-project KMS encryption of git PATs. |
 | **Project members & invitations** | `project invite` (single or `--from-csv` bulk with parallel workers), `project member-list / member-remove / member-set-role`, `project invitation-list / invitation-cancel`. Role whitelist enforced at the CLI layer; Manage API "already invited" treated as `noop` not error (since 0.29.0). |
 | **Lineage** | Column-level dependency analysis across projects. SQL/Python parsing, AI-enhanced detection, interactive web browser, Mermaid/HTML/ER export. |
+| **Semantic layer** | Define and manage a metastore semantic model per project — datasets, metrics, relationships, constraints, glossary. Validate (incl. `--deep`), export, diff two models/files, import/promote across projects, AI-assisted `build` from tables. `kbagent semantic-layer ...` (alias `sl`). |
 | **Kai (AI Assistant)** | Ask Keboola's built-in AI questions about your project. One-shot or chat sessions with full MCP context. |
 | **Encryption** | Encrypt secrets (`#password`, `#api_token`) via Keboola Encryption API. Works with sync push and MCP. |
 | **Permissions** | Firewall for AI agents: read-only, deny-writes, deny-destructive (session-only flags or persisted policy). Project pin + `KBAGENT_PROJECT` env override. Code-level enforcement, stable `ErrorCode` enum, not prompt tricks. |
@@ -199,14 +200,21 @@ kbagent data-app    list | detail | create | deploy | start | stop | delete | pa
                     secrets-set | secrets-list | secrets-get | secrets-remove
                     validate-repo
 kbagent lineage     build | show | info | server
+kbagent semantic-layer  model | show | validate | export | diff | import | promote | build | token
+                    add | edit | remove   (metric/dataset/relationship/constraint/glossary; alias: sl)
 kbagent branch      list | create | use | reset | delete | merge
                     metadata-list | metadata-get | metadata-set | metadata-delete
 kbagent workspace   create | list | detail | delete | password | load | query | from-transformation | gc
 kbagent tool        list | call
 kbagent sync        init | pull | status | diff | push | branch-link | branch-unlink | branch-status
+kbagent schedule    list | detail | find
 kbagent kai         ping | ask | chat | history
 kbagent encrypt     values
 kbagent permissions list | show | set | reset | check
+kbagent agent       list | show | create | update | delete | run | runs | run-detail | run-events
+                    test | cron-preview | prompt-improve
+kbagent serve       [--host HOST] [--port PORT] [--ui]   # HTTP API + Web UI server
+kbagent http        get | post | patch | delete          # calls a running `kbagent serve`
 kbagent             init | context | doctor | version | update | changelog
 
 # Global flags: --json, --verbose, --no-color, --config-dir, --hint client|service (deprecated since 0.45.0; use `kbagent serve` REST API)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ packages = ["src/keboola_agent_cli"]
 "src/keboola_agent_cli/_ui_dist" = "keboola_agent_cli/_ui_dist"
 
 [tool.hatch.build.targets.wheel.hooks.custom]
-path = "hatch_build.py"
+path = "scripts/hatch_build.py"
 
 [tool.hatch.build.targets.sdist]
 # Include the React source tree in sdist so `pip install` from sdist can
@@ -69,7 +69,7 @@ include = [
     "README.md",
     "CONTRIBUTING.md",
     "CLAUDE.md",
-    "hatch_build.py",
+    "scripts/hatch_build.py",
     "pyproject.toml",
 ]
 exclude = [

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -43,7 +43,9 @@ handled here:
 Set ``KBAGENT_SKIP_UI_BUILD=1`` to skip the on-the-fly npm build and ship a
 CLI-only wheel deliberately (fast builds; CI exercising the no-UI path).
 
-Wired in via ``[tool.hatch.build.hooks.custom]`` in pyproject.toml.
+Wired in via ``[tool.hatch.build.targets.wheel.hooks.custom]`` in pyproject.toml
+(``path = "scripts/hatch_build.py"``). hatchling resolves the hook by that
+explicit path, so this file does not need to sit at the repo root.
 """
 
 from __future__ import annotations

--- a/tests/test_build_hook.py
+++ b/tests/test_build_hook.py
@@ -28,12 +28,12 @@ from unittest import mock
 
 import pytest
 
-# ``hatch_build.py`` lives at the repo root (not under ``src/``), so it is not
-# importable as a normal package. Load it by file path and register it in
-# ``sys.modules`` so ``mock.patch("hatch_build.<attr>")`` resolves to *this*
-# instance. The hatchling import inside is guarded, so this works in a plain
-# dev venv that has no hatchling installed.
-_HOOK_PATH = Path(__file__).resolve().parents[1] / "hatch_build.py"
+# ``scripts/hatch_build.py`` is not under ``src/``, so it is not importable as a
+# normal package. Load it by file path and register it in ``sys.modules`` so
+# ``mock.patch("hatch_build.<attr>")`` resolves to *this* instance. The hatchling
+# import inside is guarded, so this works in a plain dev venv that has no
+# hatchling installed.
+_HOOK_PATH = Path(__file__).resolve().parents[1] / "scripts" / "hatch_build.py"
 _spec = importlib.util.spec_from_file_location("hatch_build", _HOOK_PATH)
 assert _spec is not None and _spec.loader is not None
 hatch_build = importlib.util.module_from_spec(_spec)


### PR DESCRIPTION
Two small housekeeping changes (no runtime code change).

## 1. Move `hatch_build.py` out of the repo root → `scripts/`
The hatchling custom build hook doesn't need to sit at the root — its location is set explicitly via `path` in pyproject.toml. Moved it next to the other build/release helpers (`check_wheel_ui.py`, `sync_version.py`).
- `git mv hatch_build.py scripts/hatch_build.py`
- pyproject: wheel-hook `path` + sdist `include` now point at `scripts/hatch_build.py`
- `test_build_hook.py` loads the hook from the new path
- **Verified**: `uv build --wheel` resolves the hook (logs `[hatch:build-ui]`); `test_build_hook.py` (20 tests) passes.

## 2. Complete the README command reference
The README "All commands" block and "What it does" table had drifted — they omitted groups that shipped since. Added:
- **All commands**: `semantic-layer` (alias `sl`), `schedule`, `agent`, `serve`, `http`
- **What it does**: a `Semantic layer` row

## Testing
`make check` green: **3569 passed**, ty clean, lint/format/skill/version/changelog/error-codes all pass.