### PR TITLE
ci: pin uv to exact version to avoid flaky version-manifest fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,11 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          # Pin an exact version so setup-uv downloads the release asset
+          # directly instead of fetching the `uv.ndjson` version manifest from
+          # raw.githubusercontent.com on every run -- that fetch is rate-limited
+          # and flaky on shared CI egress IPs (it killed the Windows job once).
+          version: "0.11.16"
 
       - uses: actions/setup-python@v6
         with:
@@ -71,7 +75,11 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          # Pin an exact version so setup-uv downloads the release asset
+          # directly instead of fetching the `uv.ndjson` version manifest from
+          # raw.githubusercontent.com on every run -- that fetch is rate-limited
+          # and flaky on shared CI egress IPs (it killed the Windows job once).
+          version: "0.11.16"
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Why

The Windows wheel build job [failed](https://github.com/padak/keboola_agent_cli/actions/runs/26371845723) at the `astral-sh/setup-uv@v7` step after only 12s, with no error output. The last log line was:

```
Fetching version data from https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson ...
```

With `version: "latest"`, setup-uv must fetch the `uv.ndjson` version manifest from `raw.githubusercontent.com` on every run to resolve the newest uv. That endpoint is rate-limited and flaky on shared CI egress IPs (Windows runners hit it more often than Linux), so this is a transient network failure unrelated to the repo code.

## What

Pin an **exact** uv version (`0.11.16`) on both `setup-uv` usages in `ci.yml`. An exact pin makes setup-uv download the release asset directly and skip the manifest fetch entirely. A version *range* would still need the manifest, so exact is required to remove the flaky network hop.

## Maintenance note

Bumping uv now means editing this pin. That's an intentional tradeoff: deterministic CI over auto-latest.