### PR TITLE
test(e2e): make E2E suite robust to non-US / keypair / branched-storage projects

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,7 +28,13 @@ def metastore_scope_available(url: str, token: str) -> bool:
             mc.list_items(SEMANTIC_TYPES[0])  # ty: ignore[invalid-argument-type]  # probe; str vs SemanticType Literal
         return True
     except KeboolaApiError as exc:
-        if exc.status_code == 502 or "scope" in (exc.message or "").lower():
+        # Skip cleanly when the scope is genuinely unavailable (502 / "scope")
+        # OR the metastore host is simply unreachable (network / DNS -- e.g. a
+        # malformed or accidentally doubled stack URL). Both mean "no usable
+        # metastore here"; raising would turn one preflight failure into a wall
+        # of errors across every dependent test.
+        msg = (exc.message or "").lower()
+        if exc.status_code == 502 or "scope" in msg or "cannot connect" in msg:
             return False
         raise
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1895,8 +1895,14 @@ class TestFullE2E:
         assert detail["workspace_id"] == workspace_id
 
     def _test_workspace_password(self, workspace_id: int) -> None:
-        """Reset workspace password and verify a new password is returned."""
-        data = self._run_ok(
+        """Reset workspace password and verify a new password is returned.
+
+        Keypair-auth workspaces (Snowflake ``person-keypair`` login) have no
+        password, so the API rejects the reset with HTTP 400 "Reset password is
+        not supported for login type ...". That is an environment property of
+        the project, not a failure -- skip cleanly when it happens.
+        """
+        result = self._run(
             "workspace",
             "password",
             "--project",
@@ -1904,6 +1910,10 @@ class TestFullE2E:
             "--workspace-id",
             str(workspace_id),
         )
+        if result.exit_code != 0 and "not supported for login type" in result.output:
+            print(f"  {_DIM}skip: keypair-auth workspace has no password to reset{_RESET}")
+            return
+        data = _json_ok(result)
         assert data["data"]["password"]  # non-empty password
 
     def _test_workspace_load(self, workspace_id: int, table_id: str) -> None:
@@ -7393,7 +7403,9 @@ class TestE2EStorageSwapTables:
         assert result.exit_code == 5, result.output
         payload = json.loads(result.output)
         assert payload["status"] == "error"
-        assert "dev branch" in payload["error"]["message"]
+        # Wording corrected in #373 (swap works on any branch, incl. production);
+        # match the stable part of the message, not the old "dev branch" phrasing.
+        assert "requires a branch" in payload["error"]["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -11307,7 +11319,7 @@ class TestE2EConfigSecretEncryption:
             "--no-validate",
             "--configuration",
             '{"parameters":{"#password":"e2e-canary-create"}}',
-        )
+        )["data"]
         config_id = str(created["id"])
         self._created.append((self.COMPONENT, config_id))
 
@@ -11353,7 +11365,7 @@ class TestE2EConfigSecretEncryption:
             "--no-validate",
             "--configuration",
             '{"parameters":{"user":"probe"}}',
-        )
+        )["data"]
         config_id = str(created["id"])
         self._created.append((self.COMPONENT, config_id))
 
@@ -11370,6 +11382,6 @@ class TestE2EConfigSecretEncryption:
             "--configuration",
             '{"parameters":{"#password":"e2e-canary-dryrun"}}',
             "--dry-run",
-        )
+        )["data"]
         new_pw = data["new_configuration"]["parameters"]["#password"]
         assert new_pw == "e2e-canary-dryrun", f"dry-run encrypted the diff: {new_pw!r}"


### PR DESCRIPTION
## Why

The nightly `e2e.yml` from #385 ran the E2E suite against a **GCP / Snowflake-keypair** project for the first time — a different environment than the US / password stack the suite was originally written against. After fixing a doubled `E2E_URL` secret (operator config, which had caused an unrelated metastore-URL cascade), 6 real failures remained. **All are test / environment robustness, not product bugs — no product code is touched here.**

This PR fixes the 4 test-side ones. The other 2 (`NativeTypes/BranchMaterialize`, `CloneTable`) were purely environmental (branched storage was disabled on the project) and pass once it is enabled.

## What (tests only)

- **`ConfigSecretEncryption` ×2** — read `created["data"]["id"]`, not `created["id"]`. `config new --push` returns the standard `{status, data}` envelope; the test forgot to unwrap `["data"]` (the sibling `_test_config_new_push` already does it). Manifested as `KeyError: 'id'`.
- **`swap-tables` rejection test** — assert `"requires a branch"` instead of the old `"dev branch"` wording. The message was corrected in #373 (swap works on any branch, incl. production); the CLI test was updated there but this E2E assertion was missed.
- **`FullE2E` workspace password** — keypair-auth workspaces (Snowflake `person-keypair` login) have no password, so the API returns HTTP 400 "not supported for login type …". Skip that one step cleanly instead of failing the whole run.
- **`metastore_scope_available` preflight** — also treat an unreachable metastore host (connection error) as "scope unavailable" and skip, so a misconfigured stack URL yields one clean skip instead of a wall of errors across every dependent test.

## Verification
- `ruff` + `ty` clean; full suite collects (3976 tests).
- E2E runs nightly / on-demand via `e2e.yml` (#385); this PR is what makes that run green on non-US / keypair / branched-storage projects.

## Out of scope
- No product code changed (tests + one E2E preflight helper only).
- `NativeTypes` / `CloneTable` were branched-storage-off (environment), not code.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->