### PR TITLE
chore(release): 0.56.0 — maintenance re-release (redo after #389 merge collision)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.55.0"
+version = "0.56.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -8,6 +8,20 @@ from __future__ import annotations
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.56.0": [
+        "Maintenance re-release -- no code changes since 0.55.0. The `0.55.0` version number lived in "
+        "`main` across three successive builds (#383 sync-secret audit, then #379 `semantic-layer "
+        "reference-data`, then #388 its changelog backfill) before the `v0.55.0` tag was cut, so anyone "
+        "who installed an interim 0.55.0 build did not receive the `reference-data` commands via "
+        "`kbagent update`: the auto-update check compares version numbers only (`_is_up_to_date` -> "
+        "`Version(local) >= Version(latest)`), so `0.55.0 >= 0.55.0` reads as already-up-to-date and "
+        "skips the reinstall even though the `v0.55.0` tag points at a newer commit. Bumping to 0.56.0 "
+        "gives auto-update a strictly-greater `/releases/latest` target, so the `reference-data` "
+        "sub-app (#379) and the rest of the 0.55.0 changes reach every user on the next `kbagent "
+        "update`. No behaviour change beyond the version string; the reference-data feature entry stays "
+        "recorded under 0.55.0 (the release it first shipped in) and its `since v0.55.0` doc tags "
+        "remain correct.",
+    ],
     "0.55.0": [
         "New: `kbagent semantic-layer reference-data` (alias `kbagent sl reference-data`) -- a CRUD "
         "surface for the metastore `semantic-reference-data` type, a per-dimension member store that "

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.55.0"
+version = "0.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Re-do of #389

#389 was marked MERGED but its content never landed on `main` — it collided with #391 (test e2e) merging at the same time, and #391's content won the merge commit. `origin/main` is still **0.55.0** with no 0.56.0 changelog entry. This re-applies the lost `fc2efe6` (cherry-picked clean onto current main).

## Why 0.56.0 (unchanged from #389)

0.55.0 lived in `main` across three builds under one version number, so users on an interim 0.55.0 build never get the `reference-data` commands via `kbagent update` (auto-update is version-only: `0.55.0 >= 0.55.0` → skips reinstall). Bump to 0.56.0 gives a strictly-greater `/releases/latest` target.

## Scope

- **No code changes** — version + changelog only (`make version-sync` propagated plugin.json/marketplace.json/uv.lock).
- reference-data stays under 0.55.0; `since v0.55.0` tags correct.
- `make check` green (3843 passed).

⚠️ **Please merge this one solo** (no other PR merging simultaneously) to avoid repeating the squash collision.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->