### PR TITLE
chore(review): flag new tuple[...] returns in kbagent-pr-reviewer

### DIFF
--- a/plugins/kbagent/agents/kbagent-pr-reviewer.md
+++ b/plugins/kbagent/agents/kbagent-pr-reviewer.md
@@ -215,7 +215,30 @@ grep -E '^\+\s*print\(' /tmp/kbagent-pr-<pr_number>.diff | grep -E 'src/keboola_
 
 # Token in any new logged output (should use mask_token)
 grep -E '^\+' /tmp/kbagent-pr-<pr_number>.diff | grep -E '(token|TOKEN|api_key|password)' | grep -vE 'mask_token|test_token|TEST_TOKEN|#\s|"""|"[a-z]+_token"|\.token\b'
+
+# NEW tuple[...] return annotations (CONTRIBUTING.md: semantically-distinct
+# multi-value returns must use a @dataclass, never a bare tuple). The final
+# `-v` drops variadic `tuple[X, ...]` (homogeneous collections, not a finding).
+grep -E '^\+' /tmp/kbagent-pr-<pr_number>.diff | grep -E '-> ?tuple\[' | grep -vE 'tuple\[[^],]+, ?\.\.\.\]'
 ```
+
+**Judging tuple returns** (the grep finds candidates; you apply the semantics).
+Only `-> tuple[...]` annotations **added in this diff** matter -- the ~63
+pre-existing ones are explicitly grandfathered by CONTRIBUTING.md and must NOT
+be flagged. Of the newly-added ones:
+
+- Variadic `tuple[X, ...]` and parallel-worker callbacks
+  (`def worker(...) -> tuple[Any, ...]`) -- OK, skip.
+- The `BaseService` parallel-result shape
+  `tuple[str, list[...], bool] | tuple[str, dict[str, str]]` -- OK, established
+  convention for per-project fan-out (don't flag a new service that follows it).
+- A heterogeneous 2+ element tuple of semantically-distinct values
+  (e.g. `tuple[dict | None, str | None]` = a schema **plus** a failure reason)
+  -- **NON-BLOCKING**: recommend a small frozen `@dataclass`. Name the function
+  and the two values it conflates so the author can see the field names it
+  would gain. This is the exact class of finding CI does not catch (the
+  `error_code` check is deterministic; "semantically distinct" is not), so it
+  is squarely the reviewer's job.
 
 ### Step 3.9 — Security & token discipline
 


### PR DESCRIPTION
## What

Teaches the `kbagent-pr-reviewer` subagent to surface **newly-added `tuple[...]` return annotations** during review (Step 3.8 — Convention compliance).

## Why

`CONTRIBUTING.md` requires semantically-distinct multi-value returns to use a `@dataclass`, never a bare tuple. Unlike the `error_code` enum rule, *"semantically distinct"* is **subjective**, so it can't be a deterministic CI gate the way `scripts/check_error_codes.py` is. It therefore slipped past CI to an LLM/human review on #387 — the `_fetch_flow_schema` / `fetch_flow_schema` `tuple[dict | None, str | None]` that became the `FlowSchemaFetch` dataclass.

This closes the loop: the reviewer now has a concrete, reproducible step instead of relying on remembering the rule.

## How

In Step 3.8, adds a grep over the PR diff that finds added `-> tuple[...]` annotations (skipping variadic `tuple[X, ...]`), plus a judging rubric so the reviewer:

- ignores the ~63 grandfathered returns (only diff-added ones count);
- skips the `BaseService` parallel-result shape and worker callbacks;
- flags a newly-added heterogeneous tuple of semantically-distinct values as **NON-BLOCKING** with a `@dataclass` recommendation.

## Scope / notes

- Touches only `plugins/kbagent/agents/kbagent-pr-reviewer.md` — internal review tooling, **not** in the Plugin synchronization map, no CLI surface, no version bump, no changelog entry needed.
- `kbagent-pr-reviewer.md` is 23 KB, well under the agent-prompt budget (and it has no byte-budget test — only `keboola-expert.md` does). `make check` is unaffected (no `.py` change).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->