### PR TITLE
fix(serve): route-aware --ui auth (no /doctor /version /changelog bypass) (GHSA-ffpq, 0.60.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.60.3",
+      "version": "0.60.4",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-agent-cli"
-version = "0.60.3"
+version = "0.60.4"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,18 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.60.4": [
+        "Security: `kbagent serve --ui` no longer lets `GET /doctor`, `/version`, and `/changelog` "
+        "(and any other registered endpoint) bypass bearer auth. In single-process UI mode the auth "
+        "middleware consulted a hand-maintained prefix allow-list to decide which GETs were public "
+        "SPA paths; that list had gone stale and omitted those health-router routes, so they "
+        "executed unauthenticated -- `/doctor` in particular exposes project aliases, ids, stack "
+        "URLs, and the config path. The predicate is now route-aware: it derives the protected set "
+        "from the app's actually-registered routes, so every current and future endpoint requires "
+        "auth while genuine client-side SPA paths still fall through to the public index.html shell. "
+        "Only affects `--ui` mode; API-only `serve` was never exposed. Private advisory "
+        "GHSA-ffpq-prmh-3gx2.",
+    ],
     "0.60.3": [
         "Security: `kbagent sync pull` now sanitizes the API-supplied bucket id and table name "
         "before using them as filesystem paths when writing storage metadata + samples, and asserts "

--- a/src/keboola_agent_cli/server/app.py
+++ b/src/keboola_agent_cli/server/app.py
@@ -718,62 +718,43 @@ def _install_ui(app: FastAPI, *, ui_dist: str, token: str) -> None:
 def _allow_static_through_auth(app: FastAPI) -> None:
     """Mark the SPA's GET-only static surface as auth-public.
 
-    The auth middleware already exempts ``PUBLIC_PATHS`` (docs, openapi,
-    health). For the UI mode we also need to let through the SPA shell:
-    ``GET /``, ``GET /index.html``, ``GET /assets/*``, favicons, and the
-    SPA's client-side routes (which all resolve to index.html via the
-    StaticFiles ``html=True`` fallback).
+    The auth middleware exempts ``PUBLIC_PATHS`` (docs, openapi, health). In UI
+    mode the SPA also needs ``GET /``, ``GET /index.html``, ``GET /assets/*``,
+    favicons, and the SPA's client-side routes (which resolve to index.html via
+    the StaticFiles ``html=True`` fallback) to load without a token.
+
+    Route-aware (GHSA-ffpq-prmh-3gx2): instead of a hand-maintained prefix
+    deny-list -- which silently went stale and let ``GET /doctor`` / ``/stream``
+    / ``/version`` / ``/changelog`` bypass auth in ``--ui`` mode -- we derive the
+    protected set from the app's *actually-registered* routes. All routers are
+    included before this runs (and before the StaticFiles mount is appended), so
+    any GET that resolves to a real endpoint must authenticate, and only genuine
+    client-side SPA routes fall through to the public index.html shell. New API
+    routes are protected automatically, with no list to keep in sync.
 
     Implemented by stashing a predicate on ``app.state`` that the auth
-    middleware consults; we don't import-cycle by editing the auth module
-    here.
+    middleware consults; we don't import-cycle by editing the auth module here.
     """
+    from starlette.routing import Route
+
+    # Snapshot the real endpoints once. The StaticFiles mount (added by the
+    # caller AFTER this function) is a ``Mount``, not a ``Route``, so it is
+    # correctly excluded -- otherwise it would match every path and break the
+    # SPA fallback.
+    api_route_patterns = [r.path_regex for r in app.routes if isinstance(r, Route)]
+    static_paths = frozenset({"/", "/index.html", "/favicon.svg", "/favicon.ico", "/manifest.json"})
 
     def _is_ui_public(method: str, path: str) -> bool:
         if method != "GET":
             return False
-        if path == "/" or path == "/index.html":
+        # SPA shell + built assets are always public (they carry no secrets) so
+        # the browser can bootstrap and pick up the session cookie.
+        if path in static_paths or path.startswith("/assets/"):
             return True
-        if path.startswith("/assets/"):
-            return True
-        if path in {"/favicon.svg", "/favicon.ico", "/manifest.json"}:
-            return True
-        # Any non-API GET that doesn't look like an API endpoint we own:
-        # treat as a SPA route and let StaticFiles serve index.html.
-        # API routes always start with a known prefix; everything else
-        # falls to the SPA. Use a tight allow-list to avoid leaking auth
-        # bypass to API routes that might be added in future.
-        api_prefixes = (
-            "/projects",
-            "/configs",
-            "/components",
-            "/storage",
-            "/jobs",
-            "/branches",
-            "/workspaces",
-            "/flows",
-            "/schedules",
-            "/lineage",
-            "/sharing",
-            "/data-apps",
-            "/dev-portal",
-            "/mcp",
-            "/kai",
-            "/ai",
-            "/encrypt",
-            "/search",
-            "/semantic-layer",
-            "/org",
-            "/feature",
-            "/agents",
-            "/members",
-            "/health",
-            "/docs",
-            "/redoc",
-            "/openapi.json",
-            "/api/",
-        )
-        return not any(path == p or path.startswith(p + "/") for p in api_prefixes)
+        # A path that resolves to a registered route is a real endpoint and
+        # MUST go through auth. Anything else is a client-side SPA route served
+        # by the public StaticFiles shell, so skipping auth there leaks nothing.
+        return not any(pattern.match(path) for pattern in api_route_patterns)
 
     app.state.is_ui_public = _is_ui_public
 

--- a/tests/test_serve_ui.py
+++ b/tests/test_serve_ui.py
@@ -125,6 +125,37 @@ class TestApiAlias:
         assert resp.status_code in {404, 401}
 
 
+class TestUiAuthRouteAwareBypass:
+    """GHSA-ffpq-prmh-3gx2: in --ui mode, real API routes must require auth even
+    when they were absent from the old hand-maintained prefix allow-list. The
+    predicate is now route-aware, so /doctor, /version, /changelog (health
+    router, all previously missing from the list and thus served unauthenticated)
+    are protected, while genuine client-side SPA routes still fall through to the
+    public index.html shell."""
+
+    @pytest.mark.parametrize("path", ["/doctor", "/version", "/changelog"])
+    def test_health_router_extras_require_auth_in_ui_mode(
+        self, tmp_path: Path, ui_dist: Path, path: str
+    ) -> None:
+        client = _make_client(tmp_path, ui_dist=ui_dist, token="t")
+        resp = client.get(path)
+        assert resp.status_code == 401, (
+            f"GET {path} must require auth in --ui mode, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_non_api_path_stays_public_not_auth_walled(self, tmp_path: Path, ui_dist: Path) -> None:
+        # A path that is NOT a registered API route must remain PUBLIC (auth
+        # skipped) so the SPA surface is reachable -- it must not be mistaken
+        # for a protected endpoint and 401'd. (StaticFiles 404s an unknown path;
+        # the security-relevant property is that it is NOT a 401, i.e. the
+        # route-aware predicate did not over-protect a non-endpoint path.)
+        client = _make_client(tmp_path, ui_dist=ui_dist, token="t")
+        resp = client.get("/some-client-side-view")
+        assert resp.status_code != 401, (
+            f"non-API path must stay public (not auth-walled), got {resp.status_code}"
+        )
+
+
 class TestCookieAuth:
     """Cookie path: ``GET /`` sets the cookie, subsequent requests use it.
 

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "keboola-agent-cli"
-version = "0.60.3"
+version = "0.60.4"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Fixes **M4** from the 2026-06-12 security audit (private advisory **GHSA-ffpq-prmh-3gx2**) — an auth bypass in `kbagent serve --ui` mode.

In single-process UI mode the bearer-auth middleware consults `app.state.is_ui_public` to decide which GETs are public SPA surface. That predicate was a **hand-maintained prefix deny-list** (`_allow_static_through_auth` in `server/app.py`) whose comment literally said "tight allow-list to avoid leaking auth bypass to API routes added in future" — but the implementation was a deny-list, and it had gone stale: it omitted the health-router routes `/version`, `/changelog`, and `/doctor`. So in `--ui` mode those executed **unauthenticated**. `GET /doctor` runs `registry.doctor.run_checks()` → exposes project aliases, ids, stack URLs, and the config-file path; reachable from the LAN under `--host 0.0.0.0 --ui`.

## Fix

Replace the prefix list with a **route-aware** predicate. All routers are included before the UI is installed and before the StaticFiles mount is appended, so `_allow_static_through_auth` snapshots the app's actually-registered route patterns (`isinstance(r, Route)` — the `Mount` is correctly excluded). A GET is public only if it's the static shell (`/`, `/index.html`, `/assets/*`, favicons) **or** matches no registered route (a genuine client-side SPA path → public index.html shell). Any path that resolves to a real endpoint requires auth.

This is **drift-proof**: every current and future endpoint is protected automatically, with no list to keep in sync — directly removing the failure mode that produced the bug. Only `--ui` mode is affected; API-only `serve` never exposed these (it has no `is_ui_public` predicate).

## Tests

New `TestUiAuthRouteAwareBypass` in `test_serve_ui.py`: parametrized over `/doctor` `/version` `/changelog` asserting each is `401` without auth in `--ui` mode (the exact bypass), plus a test that a non-API path stays public (not auth-walled). The pre-existing `test_dev_portal_read_requires_auth_in_ui_mode` continues to pass. Full suite green: **3978 passed, 132 skipped**; lint/format/`ty`/changelog clean.

(While writing the test I noticed the `html=True` "SPA fallback for client-side routes" claim in the `_install_ui` comment is inaccurate — `StaticFiles` 404s unknown paths rather than serving index.html — but that's pre-existing and out of scope for this auth fix; flagging for a possible follow-up.)

## Audit progress

Open advisories after this: M5 (serve-token blast radius), M6 (CORS), M7 (plaintext-on-encrypt warning), M8 (SSRF), M10 (version regex), plus the M1 residual.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->