### PR TITLE
fix(test): add missing --json to full_cli_e2e project add (#407)

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -692,6 +692,7 @@ class TestFullE2E:
             _invoke(
                 init_config_dir,
                 [
+                    "--json",
                     "project",
                     "add",
                     "--project",


### PR DESCRIPTION
## Why

`test_full_cli_e2e` fails on `project add` with "Output is not valid JSON". Root cause: the `init --from-global` setup block calls `_invoke(init_config_dir, ["project", "add", ...])` **without `--json`** but wraps it in `_json_ok` (which parses output as JSON). `project add` correctly returns its human-readable "Success: Project ... added" Rich text, so the JSON parse fails.

It is the only `project add` in the E2E suite invoked via `_invoke` directly; every other goes through `_run_ok`, which prepends `--json` automatically — so the omission went unnoticed.

**Not a production bug:** `project add --json` works (unit test `test_project_add_success_json` passes; the real CLI returns valid JSON). Introduced in 0.59.0 (#407, the `init --project` filter setup), unrelated to the 0.61.x library facade work.

## What

Add the missing `--json` to that one `_invoke` call.

## Tests

`ruff` + pre-commit clean. Verified by re-running `test_full_cli_e2e` against the live e2e-snowflake project.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->