### PR TITLE
fix(serve): reject unsafe CORS origins (wildcard + credentials) (GHSA-5mh2, code-only)

### DIFF
--- a/src/keboola_agent_cli/commands/serve.py
+++ b/src/keboola_agent_cli/commands/serve.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import typer
 
 from ..constants import ENV_CONVERSATION_ID
+from ..errors import ConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +153,7 @@ def serve_command(
         import uvicorn
 
         from ..server import create_app
+        from ..server.app import _resolve_cors_origins
     except ModuleNotFoundError as exc:  # pragma: no cover
         missing = exc.name or "server extras"
         typer.echo(
@@ -179,6 +181,13 @@ def serve_command(
     os.environ[ENV_CONVERSATION_ID] = conversation_id
 
     cors = list(cors_origin) if cors_origin else None
+    # Validate --cors-origin up front so an unsafe value (wildcard with
+    # credentials, GHSA-5mh2) is a clean usage error -- and so we do NOT
+    # mis-attribute an unrelated create_app ConfigError to --cors-origin.
+    try:
+        _resolve_cors_origins(cors)
+    except ConfigError as exc:
+        raise typer.BadParameter(str(exc), param_hint="--cors-origin") from None
 
     serve_url = f"http://{host}:{port}"
 

--- a/src/keboola_agent_cli/server/app.py
+++ b/src/keboola_agent_cli/server/app.py
@@ -438,6 +438,52 @@ def _format_error(
     )
 
 
+_DEFAULT_CORS_ORIGINS = (
+    "http://localhost:5173",  # Vite dev default
+    "http://localhost:8000",  # Node BFF
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:8000",
+)
+
+
+def _is_valid_cors_origin(origin: object) -> bool:
+    """True if ``origin`` is a concrete ``scheme://host[:port]`` CORS origin.
+
+    Rejects ``"*"`` and any value carrying a path / query / fragment / userinfo
+    -- per the CORS spec an Origin is scheme + host + optional port and nothing
+    else (no ``user:pass@`` credentials, no path).
+    """
+    if not isinstance(origin, str) or origin == "*":
+        return False
+    for scheme in ("http://", "https://"):
+        if origin.startswith(scheme):
+            rest = origin[len(scheme) :]
+            return bool(rest) and not any(c in rest for c in "/?#@")
+    return False
+
+
+def _resolve_cors_origins(cors_origins: list[str] | None) -> list[str]:
+    """Resolve CORS origins for the credentialed app, rejecting unsafe values.
+
+    The app sets ``allow_credentials=True``. Combined with a wildcard (or
+    otherwise malformed) origin, Starlette reflects the request ``Origin`` and
+    returns ``Access-Control-Allow-Credentials: true`` -- letting any website
+    read authenticated cross-origin responses (GHSA-5mh2-6xgr-rf89). Fail fast
+    rather than ship that: reject ``"*"`` and any non ``scheme://host[:port]``
+    origin. Default (no ``--cors-origin``) is the localhost dev set.
+    """
+    origins = cors_origins or list(_DEFAULT_CORS_ORIGINS)
+    invalid = [o for o in origins if not _is_valid_cors_origin(o)]
+    if invalid:
+        raise ConfigError(
+            f"Refusing to start: CORS origin(s) {invalid} are unsafe with "
+            f"credentialed requests. Use explicit 'scheme://host[:port]' origins "
+            f"(e.g. http://localhost:5173); '*' is rejected because it would "
+            f"expose authenticated responses to any website."
+        )
+    return origins
+
+
 def create_app(
     *,
     config_dir: str | None = None,
@@ -524,13 +570,7 @@ def create_app(
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=cors_origins
-        or [
-            "http://localhost:5173",  # Vite dev default
-            "http://localhost:8000",  # Node BFF
-            "http://127.0.0.1:5173",
-            "http://127.0.0.1:8000",
-        ],
+        allow_origins=_resolve_cors_origins(cors_origins),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/tests/test_serve_ui.py
+++ b/tests/test_serve_ui.py
@@ -156,6 +156,66 @@ class TestUiAuthRouteAwareBypass:
         )
 
 
+class TestCorsCredentialsGuard:
+    """GHSA-5mh2-6xgr-rf89: allow_credentials=True must never pair with a
+    wildcard or malformed CORS origin (Starlette would reflect any Origin and
+    return Access-Control-Allow-Credentials: true). create_app rejects such a
+    config at startup so the unsafe combination can never ship."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            ["*"],
+            ["http://localhost:5173", "*"],
+            ["evil.com"],
+            ["http://evil.com/path"],
+            ["ws://x"],
+        ],
+    )
+    def test_unsafe_cors_origins_rejected(self, tmp_path: Path, bad: list[str]) -> None:
+        from keboola_agent_cli.errors import ConfigError
+
+        with pytest.raises(ConfigError):
+            create_app(config_dir=str(tmp_path / "cfg"), auth_token="t", cors_origins=bad)
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            None,
+            ["http://localhost:5173"],
+            ["https://app.example.com", "http://127.0.0.1:8000"],
+        ],
+    )
+    def test_safe_cors_origins_accepted(self, tmp_path: Path, good: list[str] | None) -> None:
+        app = create_app(config_dir=str(tmp_path / "cfg"), auth_token="t", cors_origins=good)
+        assert app is not None
+
+    def test_is_valid_cors_origin_predicate(self) -> None:
+        from keboola_agent_cli.server.app import _is_valid_cors_origin
+
+        assert _is_valid_cors_origin("http://localhost:5173")
+        assert _is_valid_cors_origin("https://app.example.com")
+        assert _is_valid_cors_origin("http://127.0.0.1:8000")
+        assert not _is_valid_cors_origin("*")
+        assert not _is_valid_cors_origin("example.com")  # no scheme
+        assert not _is_valid_cors_origin("http://x/path")  # carries a path
+        assert not _is_valid_cors_origin("ws://x")  # wrong scheme
+        assert not _is_valid_cors_origin("http://user:pass@evil.com")  # userinfo
+
+    def test_serve_cli_rejects_wildcard_cors_origin(self, monkeypatch) -> None:
+        # NB: the CLI layer must surface an unsafe --cors-origin as a clean
+        # usage error (exit 2 from typer.BadParameter), not a traceback, and
+        # must not start the server -- validation runs before create_app /
+        # uvicorn.run, so the wildcard case fails fast without binding a port.
+        monkeypatch.setenv("KBAGENT_AUTO_UPDATE", "false")
+        from typer.testing import CliRunner
+
+        from keboola_agent_cli.cli import app as cli_app
+
+        result = CliRunner().invoke(cli_app, ["serve", "--cors-origin", "*"])
+        assert result.exit_code == 2, result.output
+
+
 class TestCookieAuth:
     """Cookie path: ``GET /`` sets the cookie, subsequent requests use it.
 


### PR DESCRIPTION
## Summary

Fixes **M6** from the 2026-06-12 security audit (private advisory **GHSA-5mh2-6xgr-rf89**) — a permissive-CORS misconfiguration in `kbagent serve`.

`create_app` registers `CORSMiddleware` with `allow_credentials=True`. Combined with a wildcard `--cors-origin '*'` (or a malformed origin), Starlette reflects the request `Origin` and returns `Access-Control-Allow-Credentials: true` — letting any website read authenticated cross-origin responses from a victim's running `serve`.

## Fix

`create_app` validates origins via `_resolve_cors_origins`: rejects `*` and any value that isn't a concrete `scheme://host[:port]` (raising `ConfigError`); `kbagent serve` surfaces it as a clean `typer.BadParameter` on `--cors-origin` (exit 2). The default localhost dev set is unchanged — only the actively-dangerous wildcard/malformed config is refused.

## ⚠️ Code-only PR (no version bump / changelog entry)

This PR deliberately touches **only the 3 code files** (`server/app.py`, `commands/serve.py`, `tests/test_serve_ui.py`) and does **not** bump the version or add a changelog entry. Rationale: `main` releases ~daily, and a security PR carrying a version bump + changelog entry conflicts on `pyproject.toml`/`changelog.py` against every release — this PR was rebased 4× over 2 days chasing the moving version. Dropping the release-bookkeeping makes it **conflict-immune** so it can be merged on the owner's schedule.

**At merge/next release, add:** a version bump and a `changelog.py` entry for the CORS guard (text available in the advisory / prior PR revisions).

## Tests

`TestCorsCredentialsGuard` in `test_serve_ui.py` (9 tests): parametrized rejection of `*`, mixed-with-`*`, scheme-less, path-carrying, and `ws://` origins; acceptance of defaults + explicit `http(s)://host[:port]`; unit test of the `_is_valid_cors_origin` predicate. Full suite green: **4146 passed, 133 skipped**; lint/format/`ty`/version-check clean.