### PR TITLE
chore(release): rename PyPI distribution to keboola-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Verify the wheel version matches the tag
         # The asset URL that build_kbagent_upgrade_command / install.sh construct
-        # is `keboola_agent_cli-<version>-py3-none-any.whl` under the `v<version>`
+        # is `keboola_cli-<version>-py3-none-any.whl` under the `v<version>`
         # tag. A mismatch here means clients would build a 404 URL, so fail loud.
         run: |
           tag="$TAG"
           version="${tag#v}"
-          expected="dist/keboola_agent_cli-${version}-py3-none-any.whl"
+          expected="dist/keboola_cli-${version}-py3-none-any.whl"
           if [ ! -f "$expected" ]; then
             echo "::error::Expected $expected but built: $(ls dist/)"
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Seven clients, all inheriting `BaseHttpClient` (`http_base.py`) which provides s
 
 **Single source of truth: `pyproject.toml`** (`version = "X.Y.Z"`).
 
-- `src/keboola_agent_cli/__init__.py` reads the version at runtime via `importlib.metadata.version("keboola-agent-cli")`. **Never hardcode a version string in `__init__.py`.**
+- `src/keboola_agent_cli/__init__.py` reads the version at runtime via `importlib.metadata.version(APP_NAME)` (where `APP_NAME = "keboola-cli"`). **Never hardcode a version string in `__init__.py`.**
 - `plugins/kbagent/.claude-plugin/plugin.json` must match. Run `make version-sync` (or `python scripts/sync_version.py`) to update it.
 - The pre-commit hook and CI automatically check version consistency.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -559,7 +559,7 @@ PEP 440 syntax in `pyproject.toml`'s `version` field). Two gates keep stable
 users safe from accidentally landing on a beta:
 
 1. **Version string itself.** PEP 440 marks any pre-release suffix as such;
-   `pip install keboola-agent-cli` and `uv tool install ...` default to
+   `pip install keboola-cli` and `uv tool install ...` default to
    **skipping** pre-releases unless the resolver is told otherwise (`--pre`
    for pip, `--prerelease=allow` for uv).
 2. **GitHub Release `prerelease: true` flag.** The auto-update startup

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Auto-updates kbagent **and** its `keboola-mcp-server` dependency on every launch
 Want a browser dashboard? One command:
 
 ```bash
-uv tool install --with 'keboola-agent-cli[server]' 'git+https://github.com/keboola/cli'
+uv tool install --with 'keboola-cli[server]' 'git+https://github.com/keboola/cli'
 kbagent serve --ui
 # Open the URL printed at startup -- the browser is auto-authenticated.
 ```
@@ -51,7 +51,7 @@ Build the agent once, schedule it, walk away — the platform handles auth, sche
 The scheduler runs **inside `kbagent serve`** -- the same single Python process that hosts the Web UI. If you already installed kbagent with the `[server]` extras (see [Web UI](#web-ui-optional) above), you're set; otherwise:
 
 ```bash
-uv tool install --with 'keboola-agent-cli[server]' 'git+https://github.com/keboola/cli'
+uv tool install --with 'keboola-cli[server]' 'git+https://github.com/keboola/cli'
 kbagent serve --ui
 # Open the URL printed at startup -> sidebar "Agent Tasks" -> "+ New task".
 ```

--- a/docs/superpowers/plans/2026-06-04-conditional-flow-support.md
+++ b/docs/superpowers/plans/2026-06-04-conditional-flow-support.md
@@ -203,7 +203,7 @@ Run:
 uv build --wheel 2>&1 | tail -5
 ```
 
-Expected: a `dist/keboola_agent_cli-0.55.0-*.whl` (version bumps later).
+Expected: a `dist/keboola_cli-0.55.0-*.whl` (version bumps later).
 
 - [ ] **Step 2: Assert the schema is inside the wheel**
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -345,7 +345,7 @@ Expired tokens clean themselves up. No manual rotation needed.
 
 ```bash
 # Install
-uv pip install keboola-agent-cli
+uv pip install keboola-cli
 
 # Add your first project
 kbagent project add --project analytics \

--- a/install.sh
+++ b/install.sh
@@ -22,8 +22,8 @@
 set -eu
 
 REPO="keboola/cli"
-PKG="keboola-agent-cli"
-DIST="keboola_agent_cli" # normalized distribution name used in the wheel filename
+PKG="keboola-cli"
+DIST="keboola_cli" # normalized distribution name used in the wheel filename
 
 info() { printf '%s\n' "$*" >&2; }
 

--- a/plugins/kbagent/skills/kbagent/references/agent-tasks-rest-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/agent-tasks-rest-workflow.md
@@ -13,7 +13,7 @@ use it from scripts, other AI agents, or `kbagent http` subprocesses.
 
 ```bash
 # One-time install with server extras
-uv tool install --with 'keboola-agent-cli[server]' \
+uv tool install --with 'keboola-cli[server]' \
   'git+https://github.com/keboola/cli'
 
 # Run (keep this terminal open; scheduler dies when the server stops)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "keboola-agent-cli"
+name = "keboola-cli"
 version = "0.62.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -5,7 +5,7 @@ End-users install this package via:
 - ``uv tool install git+https://github.com/keboola/cli`` --
   uv clones the repo, runs ``hatchling`` to produce a wheel, installs it,
   then deletes the clone. The user does NOT have a checkout on disk.
-- ``pip install keboola-agent-cli`` (PyPI) -- prebuilt wheel.
+- ``pip install keboola-cli`` (PyPI) -- prebuilt wheel.
 
 For ``kbagent serve --ui`` to work after either install path, the wheel
 must already carry the SPA. This hook arranges that by:

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -11,7 +11,7 @@ Files kept in sync:
 - ``plugins/kbagent/.claude-plugin/plugin.json``            (plugin manifest)
 - ``.claude-plugin/marketplace.json`` -> ``plugins[*].version``
   (per-plugin entry the marketplace descriptor exposes to Claude Code)
-- ``uv.lock`` -> the ``keboola-agent-cli`` package's own ``version`` pin
+- ``uv.lock`` -> the ``keboola-cli`` package's own ``version`` pin
   (uv records the workspace package version; a pyproject bump leaves it
   stale until ``uv lock`` reruns, which ``version-check`` then flags)
 
@@ -43,7 +43,7 @@ UV_LOCK = REPO_ROOT / "uv.lock"
 KBAGENT_PLUGIN_NAME = "kbagent"
 
 # Distribution name of this project as it appears in uv.lock's [[package]] table.
-KBAGENT_DIST_NAME = "keboola-agent-cli"
+KBAGENT_DIST_NAME = "keboola-cli"
 
 
 def get_pyproject_version() -> str:

--- a/src/keboola_agent_cli/auto_update.py
+++ b/src/keboola_agent_cli/auto_update.py
@@ -171,7 +171,7 @@ def _is_dev_install() -> bool:
         return True
 
     try:
-        dist = distribution("keboola-agent-cli")
+        dist = distribution("keboola-cli")
         direct_url = dist.read_text("direct_url.json")
         if direct_url:
             data = json.loads(direct_url)

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -40,6 +40,13 @@ CHANGELOG: dict[str, list[str]] = {
         "could drop a column (`delete-column`) but not add one. The Storage add-column "
         "endpoint is synchronous (no job to wait on); the operation is classified `write` "
         "in the permission registry.",
+        "Change (#424): the PyPI distribution is renamed from `keboola-agent-cli` to "
+        "`keboola-cli`; the prebuilt-wheel asset is now `keboola_cli-<version>-py3-none-any.whl`. "
+        "The import package (`keboola_agent_cli`), the `kbagent` binary, and the config dir "
+        "(`~/.config/keboola-agent-cli/`) are unchanged, so existing installs keep working. "
+        "Only a literal `pip install keboola-agent-cli` from PyPI stops resolving -- use "
+        "`keboola-cli`. The release CI, `install.sh`, and the self-update resolver all build "
+        "the new wheel name end-to-end.",
     ],
     "0.61.1": [
         "Note (#416 follow-up): clarified the value-typing contract of the importable "

--- a/src/keboola_agent_cli/commands/serve.py
+++ b/src/keboola_agent_cli/commands/serve.py
@@ -159,7 +159,7 @@ def serve_command(
             f"(missing: {missing}).\n\n"
             "Reinstall with the [server] extras:\n\n"
             "  # If you installed via uv tool install (recommended for end users):\n"
-            "  uv tool install --force --with 'keboola-agent-cli[server]' \\\n"
+            "  uv tool install --force --with 'keboola-cli[server]' \\\n"
             "    git+https://github.com/keboola/cli\n\n"
             "  # If you have a local checkout (development):\n"
             "  uv pip install -e '.[server]'\n",

--- a/src/keboola_agent_cli/config_store.py
+++ b/src/keboola_agent_cli/config_store.py
@@ -180,7 +180,7 @@ class ConfigStore:
         if version > CURRENT_CONFIG_VERSION:
             raise ConfigError(
                 f"Config file version {version} is newer than supported version "
-                f"{CURRENT_CONFIG_VERSION}. Please upgrade keboola-agent-cli."
+                f"{CURRENT_CONFIG_VERSION}. Please upgrade keboola-cli."
             )
 
         try:

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -10,7 +10,7 @@ import httpx
 # --- Application identity ---
 # Distribution/package name; single source for importlib.metadata lookup and
 # the User-Agent product token that signs every Keboola API call.
-APP_NAME: str = "keboola-agent-cli"
+APP_NAME: str = "keboola-cli"
 
 # --- Sentinel for missing metadata keys ---
 # Distinguishes "key absent" from "value is None/null" in branch metadata lookups.

--- a/src/keboola_agent_cli/http_base.py
+++ b/src/keboola_agent_cli/http_base.py
@@ -34,8 +34,8 @@ def build_user_agent() -> str:
 
     Format (RFC 7231 product + comment):
 
-        keboola-agent-cli/<version> (<os> <release>; <arch>; <impl> <pyver>)
-        e.g. keboola-agent-cli/0.45.0 (Darwin 25.3.0; arm64; CPython 3.12.7)
+        keboola-cli/<version> (<os> <release>; <arch>; <impl> <pyver>)
+        e.g. keboola-cli/0.45.0 (Darwin 25.3.0; arm64; CPython 3.12.7)
 
     Keboola's edge logs this verbatim (DataDog access logs), so the fleet can
     be segmented by version and OS/arch. Only neutral host metadata is sent --

--- a/src/keboola_agent_cli/services/version_service.py
+++ b/src/keboola_agent_cli/services/version_service.py
@@ -55,11 +55,11 @@ def has_server_extras() -> bool:
     is pulled in *only* by the optional ``[server]`` extra (declared in
     ``pyproject.toml``'s ``[project.optional-dependencies]`` table), so its
     presence is a reliable proxy for "user originally installed with
-    ``--with 'keboola-agent-cli[server]'``".
+    ``--with 'keboola-cli[server]'``".
 
     Used by every kbagent self-upgrade path (``kbagent update`` and the
     startup auto-update hook) to decide whether to pair ``uv tool install``
-    with ``--with 'keboola-agent-cli[server]'`` -- without that flag, the
+    with ``--with 'keboola-cli[server]'`` -- without that flag, the
     fresh re-resolution silently drops the FastAPI + uvicorn extras and
     breaks ``kbagent serve --ui`` for users who originally installed with
     ``[server]``. (Bug fixed in v0.40.2 for the explicit ``kbagent update``
@@ -170,9 +170,9 @@ def build_kbagent_upgrade_command(
     # (git-source knobs) do not apply here.
     if wheel_url is not None:
         spec = (
-            f"keboola-agent-cli[server] @ {wheel_url}"
+            f"keboola-cli[server] @ {wheel_url}"
             if has_server_extras()
-            else f"keboola-agent-cli @ {wheel_url}"
+            else f"keboola-cli @ {wheel_url}"
         )
         uv_path = shutil.which("uv")
         if uv_path:
@@ -205,7 +205,7 @@ def build_kbagent_upgrade_command(
                 "install",
                 "--force",
                 "--with",
-                "keboola-agent-cli[server]",
+                "keboola-cli[server]",
                 install_source,
             ]
         else:
@@ -221,7 +221,7 @@ def build_kbagent_upgrade_command(
     # pip extras syntax: the [server] suffix attaches to the project
     # name in the PEP 508 spec; for git+ URLs we wrap with the project
     # name on the left of the URL.
-    install_spec = f"keboola-agent-cli[server] @ {install_source}" if has_server else install_source
+    install_spec = f"keboola-cli[server] @ {install_source}" if has_server else install_source
     cmd = [pip_path, "install", "--upgrade", install_spec]
     if prerelease:
         cmd.insert(2, "--pre")
@@ -882,7 +882,7 @@ class VersionService:
             prerelease=include_prerelease, target_version=target_version, wheel_url=wheel_url
         )
         if cmd is None:
-            with_flag = "--with 'keboola-agent-cli[server]' " if has_server_extras() else ""
+            with_flag = "--with 'keboola-cli[server]' " if has_server_extras() else ""
             pre_flag = "--prerelease=allow " if include_prerelease else ""
             tag_suffix = f"@v{target_version}" if target_version else ""
             return {

--- a/src/keboola_agent_cli/services/version_service.py
+++ b/src/keboola_agent_cli/services/version_service.py
@@ -74,7 +74,7 @@ def resolve_kbagent_wheel_url(
     """Return the prebuilt-wheel Release asset URL for ``version`` if present.
 
     The ``release.yml`` workflow (issue #353) attaches a universal
-    ``keboola_agent_cli-<version>-py3-none-any.whl`` to every GitHub release.
+    ``keboola_cli-<version>-py3-none-any.whl`` to every GitHub release.
     Installing that prebuilt wheel skips the on-machine npm/React SPA build that
     makes ``git+`` installs take minutes on WSL.
 
@@ -95,7 +95,7 @@ def resolve_kbagent_wheel_url(
         return None
     url = (
         f"https://github.com/{KBAGENT_GITHUB_REPO}/releases/download/"
-        f"v{version}/keboola_agent_cli-{version}-py3-none-any.whl"
+        f"v{version}/keboola_cli-{version}-py3-none-any.whl"
     )
     try:
         resp = httpx.head(url, follow_redirects=True, timeout=timeout)

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -348,7 +348,7 @@ class TestPerformUpdateWheel:
         argv = mock_run.call_args[0][0]
         # PEP 508 direct ref to the versioned wheel, --force, and no git+ source.
         assert "--force" in argv
-        assert any(part.endswith("keboola_agent_cli-2.0.0-py3-none-any.whl") for part in argv)
+        assert any(part.endswith("keboola_cli-2.0.0-py3-none-any.whl") for part in argv)
         assert all("git+" not in part for part in argv)
 
     @patch("keboola_agent_cli.services.version_service.httpx.head")

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -294,7 +294,7 @@ class TestPerformUpdate:
         Before v0.41.1, ``_perform_update`` ran a bare
         ``uv tool install --upgrade git+...`` which silently dropped the
         FastAPI + uvicorn extras a user originally installed with
-        ``--with 'keboola-agent-cli[server]'`` -- so a user who had
+        ``--with 'keboola-cli[server]'`` -- so a user who had
         ``kbagent serve --ui`` working would lose it on the next startup
         auto-update. Now ``_perform_update`` delegates to
         :func:`build_kbagent_upgrade_command`, which pairs ``--with`` and
@@ -303,10 +303,10 @@ class TestPerformUpdate:
         mock_run.return_value = MagicMock(returncode=0)
         assert _perform_update("2.0.0") is UpdateOutcome.SUCCESS
         argv = mock_run.call_args[0][0]
-        # uv tool install --force --with 'keboola-agent-cli[server]' git+...
+        # uv tool install --force --with 'keboola-cli[server]' git+...
         assert "--force" in argv
         assert "--with" in argv
-        assert "keboola-agent-cli[server]" in argv
+        assert "keboola-cli[server]" in argv
         # Must NOT pass --upgrade in this branch (uv rejects --upgrade + --with).
         assert "--upgrade" not in argv
 
@@ -323,7 +323,7 @@ class TestPerformUpdate:
         argv = mock_run.call_args[0][0]
         assert "--upgrade" in argv
         assert "--with" not in argv
-        assert "keboola-agent-cli[server]" not in argv
+        assert "keboola-cli[server]" not in argv
 
 
 class TestPerformUpdateWheel:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -486,7 +486,7 @@ class TestClientHeaders:
         client.verify_token()
 
         request = httpx_mock.get_request()
-        assert "keboola-agent-cli/" in request.headers["user-agent"]
+        assert "keboola-cli/" in request.headers["user-agent"]
         client.close()
 
     def test_storage_api_token_header(self, httpx_mock) -> None:

--- a/tests/test_manage_client.py
+++ b/tests/test_manage_client.py
@@ -37,7 +37,7 @@ class TestManageClientHeaders:
 
         request = httpx_mock.get_request()
         assert request.headers["X-KBC-ManageApiToken"] == MANAGE_TOKEN
-        assert "keboola-agent-cli" in request.headers["User-Agent"]
+        assert "keboola-cli" in request.headers["User-Agent"]
         client.close()
 
     def test_does_not_send_storage_token_header(self, httpx_mock) -> None:

--- a/tests/test_metastore_client.py
+++ b/tests/test_metastore_client.py
@@ -73,7 +73,7 @@ class TestAuthHeader:
             client.close()
         request = httpx_mock.get_requests()[0]
         assert request.headers["X-StorageApi-Token"] == TOKEN
-        assert "keboola-agent-cli/" in request.headers["User-Agent"]
+        assert "keboola-cli/" in request.headers["User-Agent"]
 
 
 class TestListItems:

--- a/tests/test_sync_version_script.py
+++ b/tests/test_sync_version_script.py
@@ -34,7 +34,7 @@ def isolated_repo(tmp_path: Path, monkeypatch):
     """Lay out a miniature repo tree the sync script can operate on."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        '[project]\nname = "keboola-agent-cli"\nversion = "9.9.9"\n',
+        '[project]\nname = "keboola-cli"\nversion = "9.9.9"\n',
         encoding="utf-8",
     )
 
@@ -50,7 +50,7 @@ def isolated_repo(tmp_path: Path, monkeypatch):
     marketplace_json.write_text(
         json.dumps(
             {
-                "name": "keboola-agent-cli",
+                "name": "keboola-cli",
                 "version": "1.0.0",
                 "plugins": [
                     {
@@ -67,10 +67,10 @@ def isolated_repo(tmp_path: Path, monkeypatch):
     )
 
     # Minimal uv.lock with our package entry plus an unrelated one, so we can
-    # assert the version patch is scoped to keboola-agent-cli only.
+    # assert the version patch is scoped to keboola-cli only.
     uv_lock = tmp_path / "uv.lock"
     uv_lock.write_text(
-        '[[package]]\nname = "keboola-agent-cli"\nversion = "0.0.0"\n'
+        '[[package]]\nname = "keboola-cli"\nversion = "0.0.0"\n'
         'source = { editable = "." }\n\n'
         '[[package]]\nname = "croniter"\nversion = "1.2.3"\n'
         'source = { registry = "https://pypi.org/simple" }\n',
@@ -194,21 +194,21 @@ def test_main_runs_end_to_end(isolated_repo: dict, capsys) -> None:
     out = capsys.readouterr().out
     assert "Updated plugin.json to 9.9.9" in out
     assert "Updated marketplace.json" in out
-    assert "Updated uv.lock keboola-agent-cli version to 9.9.9" in out
+    assert "Updated uv.lock keboola-cli version to 9.9.9" in out
 
     # Second run prints the idempotent message on all targets.
     _sync.main()
     out = capsys.readouterr().out
     assert "plugin.json already at 9.9.9" in out
     assert "marketplace.json" in out and "already at 9.9.9" in out
-    assert "uv.lock keboola-agent-cli version already at 9.9.9" in out
+    assert "uv.lock keboola-cli version already at 9.9.9" in out
 
 
 def test_sync_uv_lock_updates_self_version(isolated_repo: dict) -> None:
     changed = _sync.sync_uv_lock("9.9.9")
     assert changed is True
     text = isolated_repo["uv_lock"].read_text(encoding="utf-8")
-    assert 'name = "keboola-agent-cli"\nversion = "9.9.9"' in text
+    assert 'name = "keboola-cli"\nversion = "9.9.9"' in text
 
 
 def test_sync_uv_lock_does_not_touch_other_packages(isolated_repo: dict) -> None:
@@ -241,4 +241,4 @@ def test_sync_uv_lock_missing_package_entry_warns(isolated_repo: dict, capsys) -
     )
     changed = _sync.sync_uv_lock("9.9.9")
     assert changed is False
-    assert "keboola-agent-cli" in capsys.readouterr().err.lower()
+    assert "keboola-cli" in capsys.readouterr().err.lower()

--- a/tests/test_version_service.py
+++ b/tests/test_version_service.py
@@ -293,10 +293,7 @@ class TestGetLocalMcpVersion:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=(
-                "keboola-agent-cli v0.30.1\n"
-                "- kbagent\n"
-                f"{MCP_PACKAGE_NAME} v1.59.1\n"
-                f"- {MCP_BINARY_NAME}\n"
+                f"keboola-cli v0.30.1\n- kbagent\n{MCP_PACKAGE_NAME} v1.59.1\n- {MCP_BINARY_NAME}\n"
             ),
             stderr="",
         )
@@ -409,7 +406,7 @@ class TestUvToolListGetMcpVersion:
             "- da\n"
             "juncture v0.41.3\n"
             "- juncture\n"
-            "keboola-agent-cli v0.30.1\n"
+            "keboola-cli v0.30.1\n"
             "- kbagent\n"
             f"{MCP_PACKAGE_NAME} v1.59.1\n"
             f"- {MCP_BINARY_NAME}\n"
@@ -417,7 +414,7 @@ class TestUvToolListGetMcpVersion:
         assert _uv_tool_list_get_mcp_version(stdout) == "1.59.1"
 
     def test_not_listed_returns_none(self) -> None:
-        stdout = "keboola-agent-cli v0.30.1\n- kbagent\n"
+        stdout = "keboola-cli v0.30.1\n- kbagent\n"
         assert _uv_tool_list_get_mcp_version(stdout) is None
 
     def test_similar_named_package_rejected(self) -> None:
@@ -485,7 +482,7 @@ class TestUvToolListHasMcp:
     def test_match_with_other_tools_listed(self) -> None:
         """The package is found alongside other unrelated tools."""
         stdout = (
-            "keboola-agent-cli v0.30.0\n"
+            "keboola-cli v0.30.0\n"
             "- kbagent\n"
             f"{MCP_PACKAGE_NAME} v1.59.1\n"
             f"- {MCP_BINARY_NAME}\n"
@@ -988,7 +985,7 @@ class TestBuildKbagentWheelInstall:
             "tool",
             "install",
             "--force",
-            f"keboola-agent-cli[server] @ {self.WHEEL}",
+            f"keboola-cli[server] @ {self.WHEEL}",
         ]
         # The wheel path uses a PEP 508 direct ref -- no git+ source, no --with.
         assert all("git+" not in part for part in cmd)
@@ -1006,7 +1003,7 @@ class TestBuildKbagentWheelInstall:
             "tool",
             "install",
             "--force",
-            f"keboola-agent-cli @ {self.WHEEL}",
+            f"keboola-cli @ {self.WHEEL}",
         ]
 
     @patch("keboola_agent_cli.services.version_service.has_server_extras", return_value=False)
@@ -1018,7 +1015,7 @@ class TestBuildKbagentWheelInstall:
             "/usr/bin/pip",
             "install",
             "--upgrade",
-            f"keboola-agent-cli @ {self.WHEEL}",
+            f"keboola-cli @ {self.WHEEL}",
         ]
 
     @patch("keboola_agent_cli.services.version_service.has_server_extras", return_value=False)
@@ -1041,7 +1038,7 @@ class TestBuildKbagentWheelInstall:
         assert cmd is not None
         assert "--prerelease=allow" not in cmd
         assert all("git+" not in part for part in cmd)
-        assert cmd[-1] == f"keboola-agent-cli[server] @ {self.WHEEL}"
+        assert cmd[-1] == f"keboola-cli[server] @ {self.WHEEL}"
 
 
 class TestBuildKbagentUpgradeCommand:
@@ -1090,7 +1087,7 @@ class TestBuildKbagentUpgradeCommand:
         assert "--prerelease=allow" in cmd
         # Extras flag preserved
         assert "--with" in cmd
-        assert "keboola-agent-cli[server]" in cmd
+        assert "keboola-cli[server]" in cmd
 
     @patch("keboola_agent_cli.services.version_service.has_server_extras")
     @patch("keboola_agent_cli.services.version_service.shutil.which")

--- a/tests/test_version_service.py
+++ b/tests/test_version_service.py
@@ -920,7 +920,7 @@ class TestResolveKbagentWheelUrl:
         url = resolve_kbagent_wheel_url("0.60.0")
         assert url == (
             "https://github.com/keboola/cli/releases/download/"
-            "v0.60.0/keboola_agent_cli-0.60.0-py3-none-any.whl"
+            "v0.60.0/keboola_cli-0.60.0-py3-none-any.whl"
         )
         # follow_redirects is required to traverse GitHub's asset CDN redirect.
         assert mock_head.call_args.kwargs.get("follow_redirects") is True
@@ -968,8 +968,7 @@ class TestBuildKbagentWheelInstall:
     """build_kbagent_upgrade_command wheel_url fast path (issue #353)."""
 
     WHEEL = (
-        "https://github.com/keboola/cli/releases/download/"
-        "v1.2.3/keboola_agent_cli-1.2.3-py3-none-any.whl"
+        "https://github.com/keboola/cli/releases/download/v1.2.3/keboola_cli-1.2.3-py3-none-any.whl"
     )
 
     @patch("keboola_agent_cli.services.version_service.has_server_extras", return_value=True)

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 ]
 
 [[package]]
-name = "keboola-agent-cli"
+name = "keboola-cli"
 version = "0.62.0"
 source = { editable = "." }
 dependencies = [

--- a/web/README.md
+++ b/web/README.md
@@ -16,7 +16,7 @@ Two ways to run the UI:
 
 ```bash
 # Node 20+ on PATH so the build hook can compile the SPA into the wheel:
-uv tool install --with 'keboola-agent-cli[server]' 'git+https://github.com/keboola/cli'
+uv tool install --with 'keboola-cli[server]' 'git+https://github.com/keboola/cli'
 
 # Run:
 kbagent serve --ui


### PR DESCRIPTION
## Summary
Renames the **PyPI distribution name** from `keboola-agent-cli` to **`keboola-cli`**, to match the PyPI **Trusted Publisher** registered for this repo. Scope is deliberately limited to the distribution name; the import package (`keboola_agent_cli`) and the binary (`kbagent`) are unchanged.

## What changed (distribution name only)
- `pyproject.toml` `[project].name` → `keboola-cli`
- `constants.APP_NAME` (drives `importlib.metadata` version lookup **and** the User-Agent token)
- `auto_update.distribution(...)`, and the `[server]` self-update specs in `version_service.py` / `commands/serve.py`
- `scripts/sync_version.py` `KBAGENT_DIST_NAME`, `uv.lock` (project package now `keboola-cli`)
- `README.md` `[server]` install spec, `http_base` User-Agent docstring
- Tests updated for the new UA token + install specs (`test_client`, `test_metastore_client`, `test_manage_client`, `test_auto_update`, `test_version_service`, `test_sync_version_script`)

## Deliberately NOT changed
- **Config dir** `~/.config/keboola-agent-cli/` (`platformdirs.user_config_dir(...)`) — renaming it would **orphan every existing user's stored tokens**; that's a separate migration, out of scope.
- **Claude Code plugin/marketplace logical name** `kbagent@keboola-agent-cli` and the plugin cache path — intentionally logical names (per changelog), not the dist/repo name.
- `changelog.py` historical entries (accurate history).

## Why
`uv tool install keboola-cli` / `pip install keboola-cli` is the intended install name, and it must equal the PyPI project the Trusted Publisher is bound to. `keboola-cli` is confirmed **available** on PyPI.

## Change type
Chore (release/packaging). No behavior change; binary and import package unchanged.

## Test plan
- 371 affected tests pass (`test_client`, `test_metastore_client`, `test_manage_client`, `test_auto_update`, `test_version_service`, `test_sync_version_script`).
- Gates pass locally: ruff lint + format, `ty` (no new diagnostics), `command-sync-check`, `skill-check` (SKILL.md unchanged), `version-check` (uv.lock/plugin.json/marketplace.json in sync).

## Deployment / Rollback
Merge & automatic. Rollback = revert of this PR.