### PR TITLE
chore(release): 0.63.0 -- typed SDK contracts, idempotent run_job, sync clone

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.62.0"
+version = "0.63.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,37 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.63.0": [
+        "New (#428): the importable SDK is now statically typed -- a PEP 561 `py.typed` "
+        "marker ships in the wheel and the high-traffic facade operations return typed "
+        "pydantic models (`JobResult`, `QueryResult`, `UploadTableResult`, `SyncPushResult`, "
+        "`ConfigDetailResult`, `CloneResult`) exported from the package root. Downstream "
+        "`mypy`/`ty`/IDEs now treat `keboola_agent_cli` as typed, so an SDK contract change "
+        'surfaces at type-check time instead of at runtime. Every model is `extra="allow"` '
+        "(backend field drift never raises) and accepts the raw API key or the snake_case "
+        "field name, so `Model.model_validate(service_dict)` works directly. Typed at the "
+        "facade only: the dict-returning service layer and `--json` CLI output are unchanged. "
+        "New typed wrappers: `Client.run_job` / `query_result` / `config_detail` / `upload_table`.",
+        "New (#427): `kbagent job run --idempotency-key KEY [--force-rerun]` (and "
+        "`Client.run_job(idempotency_key=..., idempotency_store=...)`) makes a replayed, "
+        "interrupted build step safe -- a prior still-running or non-failed job is returned "
+        "instead of creating a duplicate side effect; a prior failed run is re-run. The Queue "
+        "API `POST /jobs` has no server-side idempotency token (verified against the live spec "
+        "v1.3.8 and the job-queue server source -- the internal `deduplicationId` is "
+        "daemon-only), so dedup is client-side: a `JobIdempotencyStore` (atomic, fcntl-locked, "
+        "0600) at `<config-dir>/job_idempotency.json`. Reusing a key for a different "
+        "component/config raises; dedup is scoped to one machine.",
+        "New (#426): `kbagent sync clone --source DIR --target ALIAS --target-dir DIR` (and "
+        "`SyncService.clone_project` -> `CloneResult`) builds a new project by cloning a "
+        "reference synced tree and parameterizing it via declarative override files -- "
+        "`--bucket-map` (rewrite storage input/output bucket prefixes), `--variable-values` "
+        "(override keboola.variables rows), `--instance-rename` (rename config-path prefixes) "
+        "-- then pushes so every config CREATEs fresh. A new push Phase D remaps `keboola.flow` "
+        "task `configId`s reference->ULID via `created_id_map` (generic; benefits any "
+        "fresh-create push), alongside the Phase-C variable-link remap. Cloning into a fresh "
+        "target needs no id surgery; a fresh-target guard refuses a non-empty target and a "
+        "re-run with an existing target-dir is idempotent (`no_changes`).",
+    ],
     "0.62.0": [
         "New (#417): `storage download-table` gains server-side row filtering -- "
         "`--where-column` + `--where-value` (repeatable, OR within the set) + "

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.62.0"
+version = "0.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Version bump **0.62.0 -> 0.63.0** + changelog for everything merged since the 0.62.0 release.

## Shipped in 0.63.0 (`#432`)
- **#428** -- typed SDK return models (`JobResult`/`QueryResult`/`UploadTableResult`/`SyncPushResult`/`ConfigDetailResult`/`CloneResult`) + PEP 561 `py.typed`.
- **#427** -- `job run --idempotency-key` + `Client.run_job(idempotency_key=...)` (client-side dedup; Queue API has no server token).
- **#426** -- `sync clone` composite + new push Phase D (`keboola.flow` task configId remap).

(The internal `sync_service.py` split (#437) and the PyPI rename to `keboola-cli` (#424, already noted under 0.62.0) are not re-listed here.)

## Changes
- `pyproject.toml` `version = "0.63.0"`
- `src/keboola_agent_cli/changelog.py` -- new `0.63.0` entry (3 bullets)
- `make version-sync` -> `plugin.json`, `marketplace.json`, `uv.lock`

## After merge
Tag `v0.63.0` on the merge commit + `gh release create v0.63.0` (stable, non-prerelease) -- the auto-update startup hook then picks it up via `/releases/latest`.

`make check` green (4092 passed).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->