### PR TITLE
docs(sdk): document the in-process Python SDK + add a runnable demo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,21 @@ uv run pytest tests/test_cli.py::TestProjectAdd::test_project_add_success_json -
 
 ```
 src/keboola_agent_cli/
-  __init__.py           # exposes __version__ (read at runtime via importlib.metadata; never hardcoded)
+  __init__.py           # PUBLIC SDK ENTRYPOINT + __version__. Re-exports the importable
+                        #   facade (Client, Files, FileEntry) and the typed result models
+                        #   (JobResult, QueryResult, UploadTableResult, SyncPushResult,
+                        #   ConfigDetailResult, CloneResult, JobIdempotencyStore). Everything
+                        #   in __all__ is committed public API (semver). __version__ is read
+                        #   at runtime via importlib.metadata; never hardcoded. See docs/sdk.md.
+  lib.py                # In-process SDK facade: Client (query/run_job/config_detail/
+                        #   upload_table + .files + .raw) over KeboolaClient. Stateless,
+                        #   config-dir-free, token passed at construction (issue #415). See docs/sdk.md.
+  result_models.py      # Typed pydantic return contracts for the SDK facade (extra="allow",
+                        #   populate_by_name); the semver-stable shapes consumers type against (issue #428).
+  py.typed              # PEP 561 marker -- ships in the wheel so downstream mypy/ty treat the SDK as typed.
   __main__.py           # python -m support
   cli.py                # Typer root app, global options, subcommand wiring
-  constants.py          # Shared constants (retry params, timeouts, exit codes, defaults)
+  constants.py          # Shared constants + dynamic APP_NAME resolution (retry params, timeouts, defaults)
   json_utils.py         # Deep-merge, set_nested_value, compute_diff utilities
   models.py             # Pydantic models shared across layers
   output.py             # OutputFormatter: JSON vs Rich dual-mode output
@@ -135,7 +146,7 @@ Seven clients, all inheriting `BaseHttpClient` (`http_base.py`) which provides s
 
 **Single source of truth: `pyproject.toml`** (`version = "X.Y.Z"`).
 
-- `src/keboola_agent_cli/__init__.py` reads the version at runtime via `importlib.metadata.version(APP_NAME)` (where `APP_NAME = "keboola-cli"`). **Never hardcode a version string in `__init__.py`.**
+- `src/keboola_agent_cli/__init__.py` reads the version at runtime via `importlib.metadata.version(APP_NAME)`. `APP_NAME` is resolved **dynamically** in `constants.py` (`_resolve_app_name()`: prefers the current distribution `keboola-cli`, falls back to the legacy `keboola-agent-cli` so the #424 migration-bridge wheel keeps working) -- it is **not** a fixed literal. **Never hardcode a version string in `__init__.py`.**
 - `plugins/kbagent/.claude-plugin/plugin.json` must match. Run `make version-sync` (or `python scripts/sync_version.py`) to update it.
 - The pre-commit hook and CI automatically check version consistency.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Read this **before** writing code. It will save review rounds.
 
 ### Python conventions
 
-- **Python 3.11+** -- use modern syntax (`str | None`, not `Optional[str]`)
+- **Python 3.12+** (`pyproject.toml` pins `requires-python = ">=3.12"`) -- use modern syntax (`str | None`, not `Optional[str]`)
 - **Type hints** on all function signatures
 - **f-strings** for string formatting (no `.format()` or `%`)
 - **`pathlib.Path`** over `os.path` -- consistently used throughout the project
@@ -391,6 +391,42 @@ before the PR is mergeable.
 - [ ] Error messages are actionable ("Bucket not found" not just "404")
 - [ ] Destructive operations have `--dry-run` and `--yes` flags
 - [ ] Write operations log what they did (created X, uploaded Y rows)
+
+## Extending the importable SDK
+
+Besides the CLI, kbagent ships an **in-process Python SDK** -- the importable
+`Client` facade (`lib.py`) and its typed result models (`result_models.py`),
+re-exported from the package root. A Keboola Data App, a transformation, or any
+Python service can `from keboola_agent_cli import Client` and use Query Service
+SQL, Storage Files, run-job, and config detail **without** a CLI subprocess or a
+`kbagent serve` daemon.
+
+**Everything exported from `keboola_agent_cli.__all__` is committed public API
+under semver.** Changing it is a deliberate act, not a side effect of touching a
+service. The full architecture, method reference, and the step-by-step checklist
+for adding a facade method or a result model live in **[docs/sdk.md](docs/sdk.md)**
+(see "Extending the SDK"). The short version:
+
+- [ ] **Facade methods go in `lib.py`** and call `KeboolaClient` directly --
+  never import the service layer (it carries config-dir / orchestration
+  assumptions the stateless facade must not inherit). Re-assemble the
+  high-level shape yourself, and **state in the docstring** which service
+  conveniences you intentionally omit (auto-create, alias/variable resolution).
+- [ ] **Return a typed model** (`result_models.py`), not a bare dict, for any
+  non-trivial shape. Subclass `_ApiResultModel` (`extra="allow"` +
+  `populate_by_name`); type **only** the stable subset, alias raw API keys via
+  `AliasChoices`, and never `extra="forbid"` (the API grows fields and the
+  contract must not raise).
+- [ ] **Export it** from `__init__.py` + `__all__` -- that list *is* the public
+  surface. Treat a field rename or a type tightening as a **breaking change**;
+  prefer adding over mutating.
+- [ ] **`make typecheck` stays clean** (types are a user-facing promise here),
+  add facade/model tests in `tests/`, and **document the addition in
+  [docs/sdk.md](docs/sdk.md)** (and the README "Use as a library" one-liner if
+  it's a headline capability).
+
+A runnable teaching example -- a curses Storage browser built entirely on the
+SDK -- lives in [`examples/storage_tui/`](examples/storage_tui/).
 
 ## Plugin synchronization map
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ with Client(url=os.environ["KBC_URL"], token=os.environ["KBC_TOKEN"]) as kbc:
     files = kbc.files.list(tags=["demo"])                             # list[FileEntry]
 ```
 
-`query()` reads results inline (fast, native JSON types) and returns rows keyed by column name; `files` returns a uniform `FileEntry` shape and reads bytes straight into memory. Everything exported from `keboola_agent_cli` is committed public API (semver). For lower-level endpoints, reach for `Client.raw` (the underlying `KeboolaClient`).
+`query()` reads results inline and returns rows keyed by column name; `files` returns a uniform `FileEntry` shape and reads bytes straight into memory; `run_job()` / `config_detail()` / `upload_table()` return typed pydantic models. Everything exported from `keboola_agent_cli` is committed public API (semver). For lower-level endpoints, reach for `Client.raw` (the underlying `KeboolaClient`).
+
+**Full SDK reference:** [docs/sdk.md](docs/sdk.md) -- the deep guide (every method, the typed result-model contract, `py.typed`, idempotent `run_job`, gotchas, and how to extend the SDK). **Runnable demo:** [`examples/storage_tui/`](examples/storage_tui/) -- a terminal Storage browser built entirely on this `Client`.
 
 ## 30-second demo
 
@@ -259,6 +261,8 @@ kbagent             init | context | doctor | version | update | changelog
 |-------|---------------|
 | [Tutorial](docs/TUTORIAL.md) | End-to-end walkthrough: register projects (1, N, whole org), global vs local config, plugin install, using the specialist subagent and `/keboola` slash command. |
 | [User Guide](docs/guide.md) | Configuration, permissions, per-directory isolation, workflows |
+| [Python SDK](docs/sdk.md) | The in-process importable `Client`: method reference, typed result models, `py.typed`, idempotent jobs, gotchas, and how to extend the SDK. Demo: [`examples/storage_tui/`](examples/storage_tui/). |
+| [Build a REST client](docs/build-your-own-client.md) | The `kbagent serve` HTTP API spec for non-Python callers (JS, Go, Slack bots, Web UIs). |
 | [Contributing](CONTRIBUTING.md) | Architecture, coding style, adding commands, testing checklist |
 
 ## Development

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,316 @@
+# Programming against kbagent: the in-process Python SDK
+
+`kbagent` is three things at once, and you can program against any of them:
+
+| Surface | Import / entrypoint | Use it when | Reference |
+|---|---|---|---|
+| **CLI** | `kbagent ...` (subprocess) | shell scripts, AI agents, CI steps, anything that shells out | [README](../README.md), `kbagent --help` |
+| **In-process SDK** | `from keboola_agent_cli import Client` | a Python process that already has the token and wants Keboola data **without** spawning a subprocess or a daemon | **this document** |
+| **HTTP REST** | `kbagent serve` + any HTTP client | a separate process / language (JS, Go), a Web UI, a Slack bot | [build-your-own-client.md](build-your-own-client.md) |
+
+This guide is the deep reference for the **middle row**: the importable, stateless `Client` facade introduced in [issue #415](https://github.com/keboola/cli/issues/415) and given typed return contracts in [#428](https://github.com/keboola/cli/issues/428).
+
+> **Working demo:** [`examples/storage_tui/`](../examples/storage_tui/) is a runnable terminal app (curses) that browses a real project's Storage entirely through this SDK. Read it alongside this doc.
+
+---
+
+## 1. What the SDK is (and is not)
+
+```python
+import os
+from keboola_agent_cli import Client
+
+with Client(url=os.environ["KBC_URL"], token=os.environ["KBC_TOKEN"]) as kbc:
+    rows = kbc.query(workspace_id, "SELECT id, name FROM customers")   # list[dict]
+    meta = kbc.files.upload(b"hello", name="greeting.txt", tags=["demo"])
+    data = kbc.files.read_bytes(meta.id)                                # bytes
+    job  = kbc.run_job("keboola.ex-db-snowflake", "12345", wait=True)   # JobResult
+```
+
+**It is:**
+
+- **Stateless.** A `Client` holds the stack URL, the token, one pooled HTTP client (with the shared retry/backoff), and an optional idempotency store. Nothing else.
+- **Config-dir-free.** No `~/.config/keboola-agent-cli/`, no `kbagent project add`, no `config.json`. Auth is the token you pass in (12-factor: you read `KBC_TOKEN` yourself).
+- **In-process.** No CLI subprocess, no `kbagent serve` daemon. Just function calls.
+- **Typed.** `py.typed` ships in the wheel; the high-traffic operations return pydantic models (`JobResult`, `QueryResult`, ...). Your `mypy`/`ty`/IDE sees the shapes.
+
+**It is not:**
+
+- **Not the whole CLI.** The facade exposes the high-value operations (Query Service, Storage Files, run-job, config detail, table upload). For everything else there is [`Client.raw`](#7-clientraw-the-escape-hatch).
+- **Not config-aware.** It does not resolve project aliases, default branches from a config file, or linked variable values. You pass IDs explicitly.
+- **Not auto-creating.** `upload_table` requires the table to already exist (the CLI's auto-create-bucket-and-table path lives in the service layer, which the facade deliberately does not carry).
+
+---
+
+## 2. Where the SDK sits in the architecture
+
+kbagent is a strict 3-layer codebase (see [CONTRIBUTING.md](../CONTRIBUTING.md#3-layer-architecture--respect-the-boundaries)):
+
+```
+ CLI command  ─┐
+ REST route   ─┼─►  Service (services/*.py)  ─►  KeboolaClient (client.py)  ─►  HTTP
+ SDK facade   ─┘         business logic              endpoints, retry
+   (lib.py)
+```
+
+The SDK **facade** (`lib.py`) is a *fourth caller* that sits beside the CLI and REST layers, but it **skips the service layer** and talks to `KeboolaClient` directly, re-assembling the high-level shapes (`list[dict]` rows, `bytes`, `FileEntry`, the typed models) that the service layer would otherwise build for the CLI.
+
+**Consequence for contributors:** a facade method is intentionally *thinner* than the matching service method. `Client.run_job` does not auto-resolve linked variable values the way `JobService.run_job` does; `Client.upload_table` does not auto-create the bucket/table the way `StorageService.upload_table` does. When you add or change a facade method, decide consciously which service conveniences to replicate and which to omit — and document the omission in the docstring (the existing methods do this).
+
+---
+
+## 3. Quick start
+
+```python
+import os
+from keboola_agent_cli import Client
+
+# 12-factor: the token is your responsibility to source. Never hardcode it.
+kbc = Client(url=os.environ["KBC_URL"], token=os.environ["KBC_TOKEN"])
+try:
+    for bucket in kbc.raw.list_buckets():
+        print(bucket["id"], bucket.get("description", ""))
+finally:
+    kbc.close()
+
+# ...or as a context manager (preferred — closes the HTTP client for you):
+with Client(url=os.environ["KBC_URL"], token=os.environ["KBC_TOKEN"]) as kbc:
+    ...
+```
+
+`Client(...)` raises `ValueError` immediately if `url` or `token` is empty — fail-fast, no silent default.
+
+To scope every call to a dev branch, pass `branch_id`:
+
+```python
+with Client(url=URL, token=TOKEN, branch_id=1234) as kbc:
+    rows = kbc.query(ws_id, "SELECT 1")   # runs on branch 1234
+```
+
+`branch_id=None` (the default) targets **production**: Storage Files use the production scope and `query()` resolves the project's *default* branch on first use.
+
+---
+
+## 4. `Client` method reference
+
+Every method below is committed public API; signatures change only under semver.
+
+### `query(workspace_id, sql, *, transactional=False, limit=500) -> list[dict]`
+
+Runs SQL in a workspace via the Query Service inline-results fast path (no CSV materialization) and returns rows as dicts keyed by column name.
+
+```python
+rows = kbc.query(workspace_id, "SELECT id, name FROM customers LIMIT 10")
+# [{"ID": "1", "NAME": "Acme"}, ...]
+```
+
+Three gotchas baked into the contract:
+
+- **Snowflake string-typing.** Values are returned exactly as the Query Service serializes them and are **not** coerced by the facade. For Snowflake every scalar comes back as a JSON string (`1` → `"1"`, `1.5` → `"1.5"`, `true` → `"true"`), with SQL `NULL` as `None`. Cast on your side.
+- **Column-name case.** Snowflake folds unquoted aliases to UPPERCASE — `SELECT id AS foo` keys the dict as `"FOO"`. Quote the alias (`AS "foo"`) for lowercase.
+- **Multi-statement.** With several statements, the rows of the **last** statement that produced a result set win (`USE ...; SELECT ...` yields the SELECT). Statements without a result set yield `[]`.
+
+Over-`limit` results are capped and a warning is logged — raise `limit` to fetch more.
+
+### `query_result(workspace_id, sql, *, transactional=False, limit=500) -> QueryResult`
+
+Same execution as `query`, but returns the full typed [`QueryResult`](#5-typed-result-models) — `columns` (in warehouse order), `rows`, `truncated`, `total_rows`, and a `.row_count` property. Use it when you need column ordering or want to detect a `limit` cap:
+
+```python
+res = kbc.query_result(ws_id, "SELECT * FROM big_table", limit=500)
+if res.truncated:
+    print(f"showing {res.row_count} of {res.total_rows} rows")
+print(res.columns)   # ["ID", "NAME", "CREATED_AT"]
+```
+
+### `run_job(component_id, config_id, *, wait=False, timeout=300.0, ...) -> JobResult`
+
+Creates a Queue API job and — with `wait=True` — polls until terminal (or `timeout`). Returns a typed [`JobResult`](#5-typed-result-models) with `.succeeded` / `.failed` convenience properties.
+
+```python
+job = kbc.run_job("keboola.ex-db-snowflake", "12345", wait=True, timeout=600)
+if job.failed:
+    raise RuntimeError(f"job {job.id} ended {job.status}")
+```
+
+Full signature knobs: `config_row_ids`, `variable_values_id` (the facade does **not** auto-resolve linked variable values — pass it explicitly if the config needs one), `branch_id`, `mode` (`run`/`debug`/`forceRun`), `poll_strategy`, and the idempotency pair below.
+
+**Idempotency** ([#427](https://github.com/keboola/cli/issues/427)). The Queue API has no server-side idempotency, so the facade does it client-side against a store *you* supply (it has no config-dir to default to):
+
+```python
+from keboola_agent_cli import JobIdempotencyStore
+
+store = JobIdempotencyStore(path="/my/app/checkpoints/jobs.json")
+with Client(url=URL, token=TOKEN, idempotency_store=store) as kbc:
+    job = kbc.run_job("keboola.ex-db-snowflake", "12345",
+                      wait=True, idempotency_key="nightly-2026-06-17")
+    if job.idempotent_replay:
+        print("a prior run for this key was returned — no new side effect")
+```
+
+A prior still-running or non-failed job is returned (with `idempotent_replay=True`) instead of firing a duplicate; a prior *failed* run is re-run; `force_rerun=True` always creates fresh. Passing `idempotency_key` without a store raises `ValueError`.
+
+### `config_detail(component_id, config_id, *, branch_id=None) -> ConfigDetailResult`
+
+Fetches one configuration's detail as a typed [`ConfigDetailResult`](#5-typed-result-models) (`id`, `name`, `description`, `version`, `configuration`, `rows`, ...).
+
+```python
+cfg = kbc.config_detail("keboola.ex-db-snowflake", "12345")
+print(cfg.name, cfg.version)
+host = cfg.configuration["parameters"]["db"]["host"]
+```
+
+### `upload_table(table_id, file_path, *, incremental=False, ...) -> UploadTableResult`
+
+Imports a CSV into an **existing** Storage table. Unlike the CLI, it does **not** auto-create a missing bucket/table — use `kbagent storage upload-table` for that.
+
+```python
+res = kbc.upload_table("in.c-crm.customers", "customers.csv", incremental=True)
+print(res.imported_rows, res.warnings)
+```
+
+### `files` — Storage Files (`Client.files`)
+
+A `Files` helper bound to the client's project/branch. See [§6](#6-files-storage-files).
+
+### `raw` — the underlying `KeboolaClient`
+
+Escape hatch for endpoints the facade omits. See [§7](#7-clientraw-the-escape-hatch).
+
+### `close()` / context manager
+
+`close()` closes the pooled HTTP client. Prefer `with Client(...) as kbc:` so it always runs.
+
+---
+
+## 5. Typed result models
+
+`result_models.py` defines the **stable return shapes** (`JobResult`, `QueryResult`, `UploadTableResult`, `ConfigDetailResult`, `SyncPushResult`, `CloneResult`), all re-exported from the package root. They exist so a downstream consumer types against a **semver-versioned contract** instead of an undocumented `dict[str, Any]` — a contract change then surfaces at *type-check* time, not at runtime against a customer build.
+
+Two design rules every model follows (`_ApiResultModel` base):
+
+- **`extra="allow"` — forward-compatible.** The backing Keboola APIs grow fields across stack versions. An SDK contract must never *raise* because the server returned more than the documented subset. Only the **named** fields are the committed surface; everything else is preserved as model extras (reachable via attribute access and `model_dump()`), so nothing is lost.
+
+  ```python
+  job = kbc.run_job("keboola.ex-db-snowflake", "12345", wait=True)
+  job.status          # named field — committed contract
+  job.model_extra     # {"branchId": ..., "durationSeconds": ..., "runId": ...} — preserved, not typed
+  ```
+
+- **`populate_by_name=True` — alias-tolerant.** Each model accepts both the snake_case field name and the raw API key (declared via `AliasChoices`), so `Model.model_validate(service_dict)` works directly on a service-layer dict without renaming. `JobResult` reads `isFinished`/`is_finished`, `componentId`/`component`/`component_id`, etc.
+
+Convenience properties carry semantic meaning so callers don't re-derive it: `JobResult.succeeded` / `.failed`, `QueryResult.row_count`, `SyncPushResult.ok`, `CloneResult.ok`.
+
+> **The committed surface is `__all__`.** Anything exported from `keboola_agent_cli` (`Client`, `Files`, `FileEntry`, the six result models, `JobIdempotencyStore`, `__version__`) is public API under semver. Renaming or removing a named field, or tightening a type, is a breaking change.
+
+---
+
+## 6. `files` — Storage Files
+
+`Client.files` is a `Files` instance bound to the project (and branch). It returns a uniform `FileEntry` regardless of whether the API response happened to include a signed URL.
+
+```python
+# upload bytes (name required) or a path (name derived from basename)
+meta = kbc.files.upload(b"col1,col2\n1,2\n", name="data.csv", tags=["nightly"])
+meta = kbc.files.upload("report.pdf", tags=["report"], permanent=True)
+
+# list as FileEntry records (tags AND-filter, name full-text query, pagination)
+entries = kbc.files.list(tags=["nightly"], limit=50)
+for e in entries:
+    print(e.id, e.name, e.size_bytes, e.is_permanent)
+
+# read the whole file into memory (handles sliced + gzip transparently)
+raw_bytes = kbc.files.read_bytes(meta.id)
+
+kbc.files.delete(meta.id)
+```
+
+`FileEntry` fields: `id`, `name`, `tags`, `created`, `size_bytes`, `is_permanent`, and `raw` (the untouched API dict for anything the facade doesn't surface).
+
+**Memory note:** `read_bytes` holds the whole payload in RAM — fine for results, manifests, and small exports. For multi-GB tables, stream to disk via `Client.raw` instead.
+
+---
+
+## 7. `Client.raw` — the escape hatch
+
+The facade is intentionally small. For any endpoint it omits — listing buckets/tables, table previews, workspaces, sharing, dev branches — reach the underlying `KeboolaClient`:
+
+```python
+with Client(url=URL, token=TOKEN) as kbc:
+    buckets = kbc.raw.list_buckets()                                  # list[dict]
+    tables  = kbc.raw.list_tables(bucket_id="in.c-crm")               # list[dict]
+    detail  = kbc.raw.get_table_detail("in.c-crm.customers")          # dict
+    csv     = kbc.raw.get_table_data_preview("in.c-crm.customers", limit=20)  # CSV str
+```
+
+`raw` returns `dict`/`list[dict]`/`str` straight from the API — **not** the typed models. It is the lower-level, less-stable surface: useful, but you own the parsing. The [storage TUI demo](../examples/storage_tui/) is built almost entirely on these four `raw` methods.
+
+---
+
+## 8. The three integration modes — choosing one
+
+```
+                      already in a Python      separate process /     a shell / an
+                      process with the token?   language?              AI agent?
+  ───────────────────────────────────────────────────────────────────────────────
+  in-process SDK            ✅ best
+  kbagent serve (REST)                          ✅ best
+  kbagent CLI                                                          ✅ best
+```
+
+- **SDK** when you are *already* a Python process holding the token — a Keboola **Data App**, a transformation, a hosted FastAPI service, a one-off automation script. Lowest latency (no subprocess, no daemon), typed, 12-factor auth.
+- **REST (`kbagent serve`)** when the caller is a *different* process or language — a React/Next.js UI, a Go service, a Slack bot. One server, many clients, auth via a bearer token. Spec: [build-your-own-client.md](build-your-own-client.md).
+- **CLI** when you are in a shell or an AI agent that shells out — scripted glue, CI steps, `claude`/`codex`/`gemini` tasks. Structured `--json` on every command.
+
+They share the same `KeboolaClient` underneath, so behavior (retry, error shapes) is identical across all three.
+
+---
+
+## 9. Extending the SDK (for contributors)
+
+The importable surface is a **committed contract**, so changing it is a deliberate act with its own checklist — parallel to ["Adding a New CLI Command"](../CONTRIBUTING.md#checklist-adding-a-new-cli-command) but smaller. Add a facade method (or a result model) when an in-process consumer would otherwise have to drop to `Client.raw` and hand-assemble a high-value shape.
+
+**Adding a `Client` method:**
+
+1. **Write it in `lib.py`**, calling `self._client` (the `KeboolaClient`) directly — do **not** import the service layer (that would drag config-dir/orchestration assumptions into a stateless facade). Re-assemble the high-level shape yourself, the way the existing methods do.
+2. **Decide which service conveniences to omit** (auto-create, alias resolution, linked-variable resolution) and **state the omission in the docstring** — the existing methods set this precedent (`run_job`, `upload_table`).
+3. **Return a typed model**, not a bare dict, for anything non-trivial (see below).
+4. **Keyword-only for everything past the required positionals** (`*,`), matching the existing signatures — it keeps call sites readable and lets you add knobs without breaking positional callers.
+
+**Adding a result model (`result_models.py`):**
+
+1. Subclass `_ApiResultModel` (gives you `extra="allow"` + `populate_by_name`). **Never** set `extra="forbid"` — the API grows fields and the contract must not raise.
+2. Type **only the stable subset** you are willing to commit to under semver. Everything else stays a model extra.
+3. Use `Field(validation_alias=AliasChoices("rawApiKey", "snake_case_name"))` so `Model.model_validate(api_or_service_dict)` works without renaming.
+4. Add semantic `@property` helpers (`.succeeded`, `.ok`) rather than making callers re-derive state.
+
+**Then, the contract chores:**
+
+5. **Export it** from `__init__.py` and add it to `__all__` — that list *is* the public API.
+6. **`make typecheck` must stay clean** — the SDK is the one place where types are a user-facing promise, not just an internal aid.
+7. **Test it** in `tests/` (facade tests mock `KeboolaClient`; model tests assert alias-acceptance and `extra` preservation).
+8. **Document it here** in §4 / §5, and update the one-liner in the [README "Use as a library"](../README.md#use-as-a-library) section if it's a headline capability.
+9. **Treat removals/renames as breaking** — a field rename or a type tightening is a semver-major-worthy change; prefer adding over mutating.
+
+---
+
+## 10. Gotchas cheat-sheet
+
+| Gotcha | Why | What to do |
+|---|---|---|
+| Snowflake values are **strings** | Query Service serializes scalars as JSON strings; the facade does not coerce | cast on your side (`int(row["N"])`) |
+| Column keys are **UPPERCASE** | Snowflake folds unquoted aliases | quote the alias for lowercase |
+| `query` returns only the **last** result set | multi-statement SQL | split, or put the SELECT last |
+| `run_job` ignores **linked variable values** | the facade is not config-aware | pass `variable_values_id` explicitly |
+| `upload_table` **won't create** the table | no service/config context | create it first, or use the CLI |
+| `idempotency_key` raises without a store | stateless facade has no config-dir | pass `idempotency_store=` |
+| `read_bytes` loads the **whole file** into RAM | convenience over streaming | stream via `Client.raw` for huge tables |
+| `branch_id=None` means **production** | default scope | pass a `branch_id` to target a dev branch |
+
+---
+
+## See also
+
+- [`examples/storage_tui/`](../examples/storage_tui/) — runnable curses demo built on this SDK.
+- [build-your-own-client.md](build-your-own-client.md) — the REST surface (`kbagent serve`) for non-Python callers.
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — full 3-layer architecture and coding conventions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# Examples
+
+Runnable, self-contained programs that show how to build **on top of** kbagent.
+
+| Example | Surface it demonstrates | What it does |
+|---|---|---|
+| [`storage_tui/`](storage_tui/) | **In-process Python SDK** (`from keboola_agent_cli import Client`) | A curses terminal app that browses a real project's Storage (buckets → tables → preview), driven entirely through the importable `Client` and `Client.raw`. |
+
+Each example is independent and not part of the installed wheel — clone the repo
+to run them.
+
+## Which integration surface should I build on?
+
+kbagent exposes three programmable surfaces; the examples here target the first.
+See the comparison and decision guide in **[docs/sdk.md](../docs/sdk.md)**:
+
+- **In-process Python SDK** — you're already a Python process with the token
+  (a Keboola Data App, a transformation, a hosted service). Lowest latency,
+  typed. → [docs/sdk.md](../docs/sdk.md), demoed by `storage_tui/`.
+- **REST API (`kbagent serve`)** — a different process or language (JS, Go, a
+  Web UI, a Slack bot). → [docs/build-your-own-client.md](../docs/build-your-own-client.md).
+- **CLI (`kbagent ...`)** — a shell or an AI agent that shells out. →
+  [README](../README.md), `kbagent --help`.
+
+## Running an example
+
+Every example reads its Keboola credentials from the environment (12-factor) and
+never writes a token anywhere:
+
+```bash
+export KBC_URL=https://connection.keboola.com
+export KBC_TOKEN=your-storage-api-token        # read access is enough for storage_tui
+python examples/storage_tui/app.py
+```
+
+You need kbagent importable in the environment — `uv pip install -e .` from the
+repo root, or `pip install keboola-cli`.

--- a/examples/storage_tui/README.md
+++ b/examples/storage_tui/README.md
@@ -1,0 +1,118 @@
+# Keboola Storage Browser (curses TUI demo)
+
+A self-contained terminal app that showcases the **in-process kbagent Python
+SDK** (`from keboola_agent_cli import Client`). It is a drill-down browser over a
+*real* Keboola project, built with nothing but Python's stdlib `curses` — no extra
+dependencies. Every panel is populated by a live Storage API call routed through
+the SDK; there is no mock data anywhere. Point it at a project, arrow through your
+**buckets**, drill into a bucket's **tables**, and open a table to see its
+columns, row count, and a 20-row **data preview**.
+
+## What it looks like
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Keboola Storage Browser  │  https://connection.keboola.com  │ Buckets / in.c-… │   ← header (host only, never the token)
+│                                                                                │
+│  Tables in in.c-sales (3)                                                      │   ← pane title
+│  ▶ orders        ·  12,840 rows                                                 │   ← selected row (highlighted)
+│    customers     ·  3,201 rows                                                  │
+│    order_items   ·  48,910 rows                                                 │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│ ↑/↓ or j/k move │ →/Enter open │ ←/Esc/⌫ back │ r refresh │ q quit            │   ← footer (key hints)
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Drilling one level deeper (Enter on a table) swaps the body for a detail view:
+table ID, row count, column list, and a small CSV-derived preview grid. A
+centered `Loading…` message is shown while each API call is in flight, and any
+API failure is rendered on a status line above the footer instead of crashing the
+terminal.
+
+## Requirements
+
+- Python **3.12+**.
+- The `keboola-cli` package importable in your environment. From a checkout of
+  this repo: `uv pip install -e ".[dev]"` (or `uv sync`).
+- A **real Storage API token with read access** to the project you want to
+  browse. The token is read from the environment and is **never written, logged,
+  or printed** — only the URL *host* is ever shown on screen.
+
+## Run it
+
+```bash
+export KBC_URL=https://connection.keboola.com
+export KBC_TOKEN=your-storage-api-token
+python examples/storage_tui/app.py
+```
+
+`KBC_URL` and `KBC_TOKEN` are **required**. If either is missing or empty the app
+prints a one-line explanation to stderr and exits with status `1` *before* curses
+starts — there is no invented default for the URL, and never a default token.
+
+## Keyboard shortcuts
+
+| Key(s)                 | Action                                              |
+| ---------------------- | --------------------------------------------------- |
+| `↑` / `↓` or `k` / `j` | Move the selection up / down in a list              |
+| `→` or `Enter`         | Drill in (bucket → its tables, table → its detail)  |
+| `←` / `Esc` / `⌫`      | Go back one level (no-op at the buckets list)       |
+| `r`                    | Refresh the data backing the current view           |
+| `q`                    | Quit (curses restores the terminal on the way out)  |
+
+## How it uses the SDK (a teaching example)
+
+The whole point of this demo is to show the **importable, in-process SDK** in a
+realistic app. The relevant lines live in `app.py`:
+
+1. **Import the public entry point** — the same line any downstream consumer uses
+   (`app.py`, near the top):
+
+   ```python
+   from keboola_agent_cli import Client
+   from keboola_agent_cli.errors import KeboolaApiError
+   ```
+
+2. **Open the client as a context manager** (`main()`), so the underlying HTTP
+   client is closed on exit even if curses raises. The token is passed straight in
+   and never stored:
+
+   ```python
+   with Client(url=url, token=token) as kbc:
+       browser = StorageBrowser(kbc, host)
+       curses.wrapper(browser.run)
+   ```
+
+3. **Use `client.raw` for the Storage listing endpoints.** The typed `Client`
+   facade intentionally exposes only high-level shapes (queries, files, jobs,
+   config detail) — bucket/table *listing* is deliberately not on it, and the
+   facade's own docstring points you to the underlying `KeboolaClient` via
+   `Client.raw` for those raw endpoints. The three fetch methods in
+   `StorageBrowser` are the entire data layer:
+
+   | Screen          | SDK call                                                    |
+   | --------------- | ----------------------------------------------------------- |
+   | Buckets list    | `client.raw.list_buckets()`                                 |
+   | Tables list     | `client.raw.list_tables(bucket_id=...)`                     |
+   | Table detail    | `client.raw.get_table_detail(table_id)`                     |
+   | Data preview    | `client.raw.get_table_data_preview(table_id, limit=20)`     |
+
+   `get_table_data_preview` returns a **CSV string**, which the demo parses with
+   the stdlib `csv` module (`parse_preview_csv`).
+
+4. **Handle API errors specifically.** Every fetch is wrapped so a
+   `KeboolaApiError` is caught and its `.message` shown on the status line — the
+   curses UI keeps running and the terminal is always restored (via
+   `curses.wrapper`).
+
+### File layout
+
+| File         | Responsibility                                                        |
+| ------------ | --------------------------------------------------------------------- |
+| `app.py`     | SDK data layer, curses navigation/state controller, and `main()`.     |
+| `_render.py` | Pure curses drawing helpers (no API calls, no token, no app state).   |
+
+Both modules are fully type-hinted, use `pathlib`-free stdlib only, and are
+ruff-clean at the repo's 100-column line length.

--- a/examples/storage_tui/_render.py
+++ b/examples/storage_tui/_render.py
@@ -1,0 +1,216 @@
+"""Curses rendering helpers for the Keboola Storage Browser demo.
+
+Pure presentation: every function here takes a curses window plus already-fetched
+data and draws it. No API calls, no application state, no token handling happen in
+this module -- that all lives in ``app.py``. Splitting the drawing out keeps
+``app.py`` focused on navigation and SDK wiring while staying well under the
+file-size budget the repo's style guide asks for.
+
+All drawing is defensive about the terminal size: every write is clipped to the
+window bounds so a small window never raises ``curses.error``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import curses
+from collections.abc import Sequence
+
+# Color-pair handles, initialised once by :func:`init_colors`. Kept as a small
+# module-level registry (not magic numbers scattered through the draw calls).
+PAIR_HEADER = 1
+PAIR_FOOTER = 2
+PAIR_SELECTED = 3
+PAIR_DIM = 4
+PAIR_TITLE = 5
+PAIR_ERROR = 6
+
+
+def init_colors() -> None:
+    """Initialise the color pairs the renderer uses (no-op without color)."""
+    if not curses.has_colors():
+        return
+    curses.start_color()
+    curses.use_default_colors()
+    curses.init_pair(PAIR_HEADER, curses.COLOR_BLACK, curses.COLOR_CYAN)
+    curses.init_pair(PAIR_FOOTER, curses.COLOR_BLACK, curses.COLOR_WHITE)
+    curses.init_pair(PAIR_SELECTED, curses.COLOR_BLACK, curses.COLOR_GREEN)
+    curses.init_pair(PAIR_DIM, curses.COLOR_CYAN, -1)
+    curses.init_pair(PAIR_TITLE, curses.COLOR_YELLOW, -1)
+    curses.init_pair(PAIR_ERROR, curses.COLOR_WHITE, curses.COLOR_RED)
+
+
+def _pair(pair_id: int) -> int:
+    """Return the attribute for a color pair, or 0 when color is unavailable."""
+    if not curses.has_colors():
+        return 0
+    return curses.color_pair(pair_id)
+
+
+def _fit(text: str, width: int) -> str:
+    """Truncate ``text`` to ``width`` columns, adding an ellipsis when cut."""
+    if width <= 0:
+        return ""
+    if len(text) <= width:
+        return text
+    if width == 1:
+        return text[:1]
+    return text[: width - 1] + "…"
+
+
+def _addstr(win: curses.window, row: int, col: int, text: str, attr: int = 0) -> None:
+    """Write ``text`` at (row, col), clipped to the window, swallowing overflow.
+
+    curses raises if you write the bottom-right cell or past the edge; for a
+    read-only browser we would rather clip silently than crash the UI.
+    """
+    height, width = win.getmaxyx()
+    if row < 0 or row >= height or col >= width:
+        return
+    visible = _fit(text, width - col)
+    if not visible:
+        return
+    # Writing the bottom-right cell or past the edge raises curses.error; for a
+    # read-only browser we would rather clip silently than crash the UI.
+    with contextlib.suppress(curses.error):
+        win.addstr(row, col, visible, attr)
+
+
+def _draw_bar(win: curses.window, row: int, text: str, pair_id: int) -> None:
+    """Draw a full-width colored bar (header/footer) on ``row``."""
+    height, width = win.getmaxyx()
+    if row < 0 or row >= height:
+        return
+    attr = _pair(pair_id)
+    padded = text.ljust(width)[: max(width - 1, 0)]
+    _addstr(win, row, 0, padded, attr)
+
+
+def draw_header(win: curses.window, host: str, breadcrumb: str) -> None:
+    """Draw the top bar: the project host (never the token) and breadcrumb."""
+    left = f" Keboola Storage Browser  │  {host}"
+    bar = left if not breadcrumb else f"{left}  │  {breadcrumb}"
+    _draw_bar(win, 0, bar, PAIR_HEADER)
+
+
+def draw_footer(win: curses.window, hints: str, status: str) -> None:
+    """Draw the bottom two lines: an optional status line then the key hints."""
+    height, _ = win.getmaxyx()
+    if height < 2:
+        return
+    if status:
+        _addstr(win, height - 2, 0, _fit(status, win.getmaxyx()[1] - 1), _pair(PAIR_ERROR))
+    _draw_bar(win, height - 1, f" {hints}", PAIR_FOOTER)
+
+
+def draw_loading(win: curses.window, message: str) -> None:
+    """Centre a transient 'Loading...' style message in the body area."""
+    height, width = win.getmaxyx()
+    row = height // 2
+    col = max((width - len(message)) // 2, 0)
+    _addstr(win, row, col, message, _pair(PAIR_TITLE) | curses.A_BOLD)
+
+
+def draw_list_pane(
+    win: curses.window,
+    *,
+    title: str,
+    rows: Sequence[str],
+    selected: int,
+    top: int,
+    empty_message: str,
+) -> None:
+    """Draw a scrollable, single-select list filling the body area.
+
+    Args:
+        win: Target window (already cleared by the caller).
+        title: Pane title drawn on the first body row.
+        rows: Pre-formatted display strings, one per item.
+        selected: Index of the highlighted row within ``rows``.
+        top: Index of the first visible row (scroll offset).
+        empty_message: Shown instead of rows when ``rows`` is empty.
+    """
+    height, width = win.getmaxyx()
+    body_top = 1
+    body_bottom = height - 2  # leave header (0) and footer (height-1, height-2)
+    _addstr(win, body_top, 1, _fit(title, width - 2), _pair(PAIR_TITLE) | curses.A_BOLD)
+
+    list_top = body_top + 1
+    visible_rows = max(body_bottom - list_top, 0)
+    if not rows:
+        _addstr(win, list_top + 1, 2, empty_message, _pair(PAIR_DIM))
+        return
+
+    for offset in range(visible_rows):
+        index = top + offset
+        if index >= len(rows):
+            break
+        is_selected = index == selected
+        marker = "▶ " if is_selected else "  "
+        line = f"{marker}{rows[index]}"
+        attr = _pair(PAIR_SELECTED) | curses.A_BOLD if is_selected else 0
+        if is_selected:
+            line = line.ljust(width - 2)
+        _addstr(win, list_top + offset, 1, _fit(line, width - 2), attr)
+
+
+def draw_table_detail(
+    win: curses.window,
+    *,
+    title: str,
+    info_lines: Sequence[str],
+    columns: Sequence[str],
+    preview_header: Sequence[str],
+    preview_rows: Sequence[Sequence[str]],
+) -> None:
+    """Draw the table-detail view: metadata, column list, and a data preview grid.
+
+    The preview grid is laid out with fixed-width columns sized to the header so
+    it reads like a tiny spreadsheet; long values are individually truncated.
+    """
+    height, width = win.getmaxyx()
+    row = 1
+    _addstr(win, row, 1, _fit(title, width - 2), _pair(PAIR_TITLE) | curses.A_BOLD)
+    row += 1
+
+    for line in info_lines:
+        if row >= height - 2:
+            return
+        _addstr(win, row, 2, _fit(line, width - 3), _pair(PAIR_DIM))
+        row += 1
+
+    if columns:
+        if row >= height - 2:
+            return
+        _addstr(win, row, 2, _fit("Columns: " + ", ".join(columns), width - 3))
+        row += 1
+
+    row += 1  # spacer before the preview grid
+    if not preview_header:
+        if row < height - 2:
+            _addstr(win, row, 2, "(no data preview available)", _pair(PAIR_DIM))
+        return
+
+    col_width = _preview_column_width(preview_header, width)
+    _addstr(
+        win, row, 2, _format_grid_row(preview_header, col_width), curses.A_BOLD | _pair(PAIR_TITLE)
+    )
+    row += 1
+    for data_row in preview_rows:
+        if row >= height - 2:
+            break
+        _addstr(win, row, 2, _format_grid_row(data_row, col_width))
+        row += 1
+
+
+def _preview_column_width(header: Sequence[str], term_width: int) -> int:
+    """Pick a per-column width so the preview grid fits the terminal."""
+    column_count = max(len(header), 1)
+    usable = max(term_width - 4, column_count)
+    return max(min(usable // column_count, 24), 6)
+
+
+def _format_grid_row(values: Sequence[str], col_width: int) -> str:
+    """Render one preview row as space-separated fixed-width cells."""
+    cells = [_fit(str(value), col_width).ljust(col_width) for value in values]
+    return " ".join(cells)

--- a/examples/storage_tui/app.py
+++ b/examples/storage_tui/app.py
@@ -76,6 +76,18 @@ class View(Enum):
     TABLE_DETAIL = auto()
 
 
+@dataclass(frozen=True)
+class PreviewData:
+    """Parsed CSV data preview: the header row and the data rows, named.
+
+    A dataclass (not a bare tuple) because the two lists are semantically
+    distinct -- see CONTRIBUTING.md "Code Quality Patterns".
+    """
+
+    header: list[str]
+    rows: list[list[str]]
+
+
 @dataclass
 class TableDetail:
     """Parsed, render-ready table detail for the deepest view."""
@@ -164,22 +176,22 @@ def _column_names(detail: dict[str, Any]) -> list[str]:
     return [str(item) for item in columns] if isinstance(columns, list) else []
 
 
-def parse_preview_csv(csv_text: str, max_columns: int) -> tuple[list[str], list[list[str]]]:
+def parse_preview_csv(csv_text: str, max_columns: int) -> PreviewData:
     """Parse a Storage data-preview CSV string into a header row and data rows.
 
     Uses the stdlib ``csv`` module (the preview comes back as a CSV string).
     Columns are capped to ``max_columns`` so a wide table still fits the grid.
-    Returns ``([], [])`` for empty input.
+    Returns an empty :class:`PreviewData` for empty input.
     """
     if not csv_text.strip():
-        return [], []
+        return PreviewData(header=[], rows=[])
     reader = csv.reader(io.StringIO(csv_text))
     rows = list(reader)
     if not rows:
-        return [], []
+        return PreviewData(header=[], rows=[])
     header = rows[0][:max_columns]
     data_rows = [row[:max_columns] for row in rows[1:]]
-    return header, data_rows
+    return PreviewData(header=header, rows=data_rows)
 
 
 def build_table_detail(
@@ -200,13 +212,13 @@ def build_table_detail(
     created = detail.get("created")
     if created:
         info_lines.append(f"Created  : {created}")
-    header, preview_rows = parse_preview_csv(preview_csv, max_columns)
+    preview = parse_preview_csv(preview_csv, max_columns)
     return TableDetail(
         title=f"Table: {name}",
         info_lines=info_lines,
         columns=columns,
-        preview_header=header,
-        preview_rows=preview_rows,
+        preview_header=preview.header,
+        preview_rows=preview.rows,
     )
 
 

--- a/examples/storage_tui/app.py
+++ b/examples/storage_tui/app.py
@@ -1,0 +1,515 @@
+"""Keboola Storage Browser -- a curses TUI demo for the in-process kbagent SDK.
+
+A small, dependency-free terminal app that drills down through a *real* Keboola
+project: buckets -> tables -> table detail + data preview. Every screen is backed
+by a live Storage API call made through the importable SDK:
+
+    from keboola_agent_cli import Client
+
+    with Client(url=KBC_URL, token=KBC_TOKEN) as kbc:
+        buckets = kbc.raw.list_buckets()
+
+This file is the whole application: a thin data layer over the SDK, a curses
+controller that owns navigation/state, and a ``main()`` that reads config and
+hands control to :func:`curses.wrapper`. Pure drawing lives in ``_render.py``.
+
+Why ``client.raw`` and not the typed facade? The :class:`Client` facade
+intentionally exposes only high-level shapes (queries, files, jobs, config
+detail) -- bucket/table *listing* is deliberately not on it. The facade documents
+that you reach for the underlying :class:`KeboolaClient` via :attr:`Client.raw`
+for those raw Storage endpoints, which is exactly what a storage browser needs.
+
+Run it::
+
+    export KBC_URL=https://connection.keboola.com
+    export KBC_TOKEN=your-storage-api-token
+    python examples/storage_tui/app.py
+
+The token is read from the environment and is never printed, logged, or written
+anywhere; only the URL host is ever shown on screen.
+"""
+
+from __future__ import annotations
+
+import csv
+import curses
+import io
+import os
+import sys
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+from urllib.parse import urlparse
+
+import _render  # local sibling module (pure curses drawing helpers)
+
+# Importing from the package root mirrors how a real downstream consumer would
+# use the SDK: ``from keboola_agent_cli import Client``. When this file is run as
+# a loose script (``python examples/storage_tui/app.py``) the package is on the
+# path because it is installed in the dev environment (``uv pip install -e .``).
+from keboola_agent_cli import Client
+from keboola_agent_cli.errors import KeboolaApiError
+
+# --- Config keys (read from the environment; never hardcode a token/URL). -----
+ENV_URL = "KBC_URL"
+ENV_TOKEN = "KBC_TOKEN"
+
+# --- UI tunables. Kept here as named constants rather than magic numbers. -----
+PREVIEW_ROW_LIMIT = 20  # rows pulled for the table data preview
+PREVIEW_MAX_COLUMNS = 8  # columns shown in the preview grid (terminal width)
+KEY_HINTS = "↑/↓ or j/k move │ →/Enter open │ ←/Esc/⌫ back │ r refresh │ q quit"
+ESC_KEY = 27
+ENTER_KEYS = (curses.KEY_ENTER, ord("\n"), ord("\r"))
+BACK_KEYS = (curses.KEY_LEFT, ESC_KEY, curses.KEY_BACKSPACE, ord("\b"), 127)
+UP_KEYS = (curses.KEY_UP, ord("k"))
+DOWN_KEYS = (curses.KEY_DOWN, ord("j"))
+FORWARD_KEYS = (curses.KEY_RIGHT, *ENTER_KEYS)
+QUIT_KEYS = (ord("q"), ord("Q"))
+REFRESH_KEYS = (ord("r"), ord("R"))
+
+
+class View(Enum):
+    """Which drill-down level is currently on screen."""
+
+    BUCKETS = auto()
+    TABLES = auto()
+    TABLE_DETAIL = auto()
+
+
+@dataclass
+class TableDetail:
+    """Parsed, render-ready table detail for the deepest view."""
+
+    title: str
+    info_lines: list[str]
+    columns: list[str]
+    preview_header: list[str]
+    preview_rows: list[list[str]]
+
+
+@dataclass
+class BrowserState:
+    """All mutable UI state for the browser, kept in one place.
+
+    The two list views (buckets, tables) each track their own selection and
+    scroll offset so going back restores where you were.
+    """
+
+    view: View = View.BUCKETS
+    buckets: list[dict[str, Any]] = field(default_factory=list)
+    tables: list[dict[str, Any]] = field(default_factory=list)
+    detail: TableDetail | None = None
+    bucket_sel: int = 0
+    bucket_top: int = 0
+    table_sel: int = 0
+    table_top: int = 0
+    status: str = ""  # transient message (errors), shown above the footer
+
+
+def host_only(url: str) -> str:
+    """Return just the scheme+host of a stack URL (never any credentials)."""
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return url
+
+
+def bucket_label(bucket: dict[str, Any]) -> str:
+    """Format a single bucket as a list row, defensively reading optional keys."""
+    bucket_id = str(bucket.get("id", "?"))
+    stage = str(bucket.get("stage", "")).upper()
+    name = str(bucket.get("name", ""))
+    description = str(bucket.get("description") or "").strip()
+    label = f"[{stage}] {bucket_id}" if stage else bucket_id
+    if name and name != bucket_id:
+        label = f"{label}  ({name})"
+    if description:
+        label = f"{label} — {description}"
+    return label
+
+
+def _row_count_text(table: dict[str, Any]) -> str:
+    """Human row-count for a table dict, tolerating a missing/None count."""
+    count = table.get("rowsCount")
+    if count is None:
+        return "? rows"
+    try:
+        return f"{int(count):,} rows"
+    except (TypeError, ValueError):
+        return f"{count} rows"
+
+
+def table_label(table: dict[str, Any]) -> str:
+    """Format a single table as a list row."""
+    table_id = str(table.get("id", "?"))
+    name = str(table.get("name", "")) or table_id
+    return f"{name}  ·  {_row_count_text(table)}"
+
+
+def _column_names(detail: dict[str, Any]) -> list[str]:
+    """Extract column names from a table-detail dict (names or definition objects).
+
+    The Storage API returns ``columns`` as a list of names, but with newer typed
+    tables a richer ``definition.columns`` (objects with a ``name``) may be
+    present. Prefer the plain list and fall back gracefully.
+    """
+    columns = detail.get("columns")
+    if isinstance(columns, list) and all(isinstance(item, str) for item in columns):
+        return [str(item) for item in columns]
+    definition = detail.get("definition")
+    if isinstance(definition, dict):
+        def_columns = definition.get("columns")
+        if isinstance(def_columns, list):
+            return [str(col.get("name", "")) for col in def_columns if isinstance(col, dict)]
+    return [str(item) for item in columns] if isinstance(columns, list) else []
+
+
+def parse_preview_csv(csv_text: str, max_columns: int) -> tuple[list[str], list[list[str]]]:
+    """Parse a Storage data-preview CSV string into a header row and data rows.
+
+    Uses the stdlib ``csv`` module (the preview comes back as a CSV string).
+    Columns are capped to ``max_columns`` so a wide table still fits the grid.
+    Returns ``([], [])`` for empty input.
+    """
+    if not csv_text.strip():
+        return [], []
+    reader = csv.reader(io.StringIO(csv_text))
+    rows = list(reader)
+    if not rows:
+        return [], []
+    header = rows[0][:max_columns]
+    data_rows = [row[:max_columns] for row in rows[1:]]
+    return header, data_rows
+
+
+def build_table_detail(
+    detail: dict[str, Any], preview_csv: str, *, max_columns: int
+) -> TableDetail:
+    """Combine a table-detail dict and a preview CSV into render-ready state."""
+    table_id = str(detail.get("id", "?"))
+    name = str(detail.get("name", "")) or table_id
+    columns = _column_names(detail)
+    info_lines = [
+        f"Table ID : {table_id}",
+        f"Rows     : {_row_count_text(detail)}",
+        f"Columns  : {len(columns)}",
+    ]
+    bucket = detail.get("bucket")
+    if isinstance(bucket, dict) and bucket.get("id"):
+        info_lines.append(f"Bucket   : {bucket['id']}")
+    created = detail.get("created")
+    if created:
+        info_lines.append(f"Created  : {created}")
+    header, preview_rows = parse_preview_csv(preview_csv, max_columns)
+    return TableDetail(
+        title=f"Table: {name}",
+        info_lines=info_lines,
+        columns=columns,
+        preview_header=header,
+        preview_rows=preview_rows,
+    )
+
+
+def clamp_scroll(selected: int, top: int, visible_rows: int) -> int:
+    """Return a new scroll offset so ``selected`` stays within the visible window."""
+    if visible_rows <= 0:
+        return top
+    if selected < top:
+        return selected
+    if selected >= top + visible_rows:
+        return selected - visible_rows + 1
+    return top
+
+
+def _visible_rows(stdscr: curses.window) -> int:
+    """Number of list rows that fit between the title and the footer."""
+    height, _ = stdscr.getmaxyx()
+    # body starts at row 2 (after header row 0 + title row 1); footer takes 2 rows
+    return max(height - 4, 0)
+
+
+class StorageBrowser:
+    """Owns the curses loop, navigation, and the SDK-backed data fetches.
+
+    The :class:`Client` is injected so the loop never constructs it (and never
+    touches the token): ``main`` builds the client inside a ``with`` block and
+    hands it in.
+    """
+
+    def __init__(self, client: Client, host: str) -> None:
+        self._client = client
+        self._host = host
+        self._state = BrowserState()
+
+    # --- SDK-backed data fetches. ---------------------------------------------
+    # All three use ``self._client.raw`` -- the underlying KeboolaClient -- because
+    # the typed Client facade deliberately omits bucket/table listing.
+
+    def _fetch_buckets(self) -> None:
+        """Load buckets via ``client.raw.list_buckets()``."""
+        self._state.buckets = self._client.raw.list_buckets()
+        self._state.bucket_sel = 0
+        self._state.bucket_top = 0
+
+    def _fetch_tables(self, bucket_id: str) -> None:
+        """Load tables for one bucket via ``client.raw.list_tables(bucket_id)``."""
+        self._state.tables = self._client.raw.list_tables(bucket_id=bucket_id)
+        self._state.table_sel = 0
+        self._state.table_top = 0
+
+    def _fetch_table_detail(self, table_id: str) -> None:
+        """Load detail + a small data preview for one table via the raw client.
+
+        ``get_table_detail`` yields columns/row-count; ``get_table_data_preview``
+        returns a CSV string we parse with the stdlib ``csv`` module.
+        """
+        detail = self._client.raw.get_table_detail(table_id)
+        preview_csv = self._client.raw.get_table_data_preview(table_id, limit=PREVIEW_ROW_LIMIT)
+        self._state.detail = build_table_detail(
+            detail, preview_csv, max_columns=PREVIEW_MAX_COLUMNS
+        )
+
+    def _run_with_loading(self, stdscr: curses.window, message: str, action: Any) -> bool:
+        """Show a loading frame, run a fetch ``action``, surface API errors.
+
+        Returns True on success, False if a :class:`KeboolaApiError` was caught
+        (the message is stored in the status line instead of crashing curses).
+        """
+        self._state.status = ""
+        self._draw_loading(stdscr, message)
+        try:
+            action()
+        except KeboolaApiError as exc:
+            self._state.status = f"API error: {exc.message}"
+            return False
+        return True
+
+    # --- Drawing dispatch. ----------------------------------------------------
+
+    def _breadcrumb(self) -> str:
+        """Breadcrumb string for the header, reflecting the current drill path."""
+        state = self._state
+        if state.view is View.BUCKETS:
+            return "Buckets"
+        bucket_id = self._selected_bucket_id() or "?"
+        if state.view is View.TABLES:
+            return f"Buckets / {bucket_id}"
+        table_id = self._selected_table_id() or "?"
+        return f"Buckets / {bucket_id} / {table_id}"
+
+    def _draw_loading(self, stdscr: curses.window, message: str) -> None:
+        """Render a full frame whose body is just a centered loading message."""
+        stdscr.erase()
+        _render.draw_header(stdscr, self._host, self._breadcrumb())
+        _render.draw_loading(stdscr, message)
+        _render.draw_footer(stdscr, KEY_HINTS, self._state.status)
+        stdscr.refresh()
+
+    def _draw(self, stdscr: curses.window) -> None:
+        """Render the current view in full."""
+        stdscr.erase()
+        _render.draw_header(stdscr, self._host, self._breadcrumb())
+        state = self._state
+        if state.view is View.BUCKETS:
+            self._draw_buckets(stdscr)
+        elif state.view is View.TABLES:
+            self._draw_tables(stdscr)
+        else:
+            self._draw_detail(stdscr)
+        _render.draw_footer(stdscr, KEY_HINTS, state.status)
+        stdscr.refresh()
+
+    def _draw_buckets(self, stdscr: curses.window) -> None:
+        """Draw the buckets list pane."""
+        state = self._state
+        rows = [bucket_label(bucket) for bucket in state.buckets]
+        _render.draw_list_pane(
+            stdscr,
+            title=f"Buckets ({len(rows)})",
+            rows=rows,
+            selected=state.bucket_sel,
+            top=state.bucket_top,
+            empty_message="No buckets in this project.",
+        )
+
+    def _draw_tables(self, stdscr: curses.window) -> None:
+        """Draw the tables list pane for the selected bucket."""
+        state = self._state
+        rows = [table_label(table) for table in state.tables]
+        bucket_id = self._selected_bucket_id() or ""
+        _render.draw_list_pane(
+            stdscr,
+            title=f"Tables in {bucket_id} ({len(rows)})",
+            rows=rows,
+            selected=state.table_sel,
+            top=state.table_top,
+            empty_message="This bucket has no tables.",
+        )
+
+    def _draw_detail(self, stdscr: curses.window) -> None:
+        """Draw the table-detail + preview pane."""
+        detail = self._state.detail
+        if detail is None:
+            _render.draw_loading(stdscr, "No table selected.")
+            return
+        _render.draw_table_detail(
+            stdscr,
+            title=detail.title,
+            info_lines=detail.info_lines,
+            columns=detail.columns,
+            preview_header=detail.preview_header,
+            preview_rows=detail.preview_rows,
+        )
+
+    # --- Selection helpers. ---------------------------------------------------
+
+    def _selected_bucket_id(self) -> str | None:
+        """ID of the highlighted bucket, or None when the list is empty."""
+        state = self._state
+        if not state.buckets:
+            return None
+        bucket = state.buckets[state.bucket_sel]
+        return str(bucket.get("id")) if bucket.get("id") is not None else None
+
+    def _selected_table_id(self) -> str | None:
+        """ID of the highlighted table, or None when the list is empty."""
+        state = self._state
+        if not state.tables:
+            return None
+        table = state.tables[state.table_sel]
+        return str(table.get("id")) if table.get("id") is not None else None
+
+    # --- Input handling. ------------------------------------------------------
+
+    def _move_selection(self, stdscr: curses.window, delta: int) -> None:
+        """Move the selection in the active list view by ``delta`` and re-scroll."""
+        state = self._state
+        visible = _visible_rows(stdscr)
+        if state.view is View.BUCKETS and state.buckets:
+            state.bucket_sel = max(0, min(state.bucket_sel + delta, len(state.buckets) - 1))
+            state.bucket_top = clamp_scroll(state.bucket_sel, state.bucket_top, visible)
+        elif state.view is View.TABLES and state.tables:
+            state.table_sel = max(0, min(state.table_sel + delta, len(state.tables) - 1))
+            state.table_top = clamp_scroll(state.table_sel, state.table_top, visible)
+
+    def _drill_in(self, stdscr: curses.window) -> None:
+        """Enter the next level down from the current view."""
+        state = self._state
+        if state.view is View.BUCKETS:
+            bucket_id = self._selected_bucket_id()
+            if bucket_id is None:
+                return
+            if self._run_with_loading(
+                stdscr, "Loading tables…", lambda: self._fetch_tables(bucket_id)
+            ):
+                state.view = View.TABLES
+        elif state.view is View.TABLES:
+            table_id = self._selected_table_id()
+            if table_id is None:
+                return
+            if self._run_with_loading(
+                stdscr, "Loading table detail…", lambda: self._fetch_table_detail(table_id)
+            ):
+                state.view = View.TABLE_DETAIL
+
+    def _go_back(self) -> None:
+        """Pop one level up; from buckets, back is a no-op."""
+        state = self._state
+        if state.view is View.TABLE_DETAIL:
+            state.view = View.TABLES
+            state.detail = None
+        elif state.view is View.TABLES:
+            state.view = View.BUCKETS
+            state.tables = []
+
+    def _refresh(self, stdscr: curses.window) -> None:
+        """Re-fetch the data backing the current view."""
+        state = self._state
+        if state.view is View.BUCKETS:
+            self._run_with_loading(stdscr, "Refreshing buckets…", self._fetch_buckets)
+        elif state.view is View.TABLES:
+            bucket_id = self._selected_bucket_id()
+            if bucket_id is not None:
+                self._run_with_loading(
+                    stdscr, "Refreshing tables…", lambda: self._fetch_tables(bucket_id)
+                )
+        else:
+            table_id = self._selected_table_id()
+            if table_id is not None:
+                self._run_with_loading(
+                    stdscr,
+                    "Refreshing detail…",
+                    lambda: self._fetch_table_detail(table_id),
+                )
+
+    def _handle_key(self, stdscr: curses.window, key: int) -> bool:
+        """Process one keypress. Returns False when the user asked to quit."""
+        if key in QUIT_KEYS:
+            return False
+        if key in UP_KEYS:
+            self._move_selection(stdscr, -1)
+        elif key in DOWN_KEYS:
+            self._move_selection(stdscr, 1)
+        elif key in FORWARD_KEYS:
+            self._drill_in(stdscr)
+        elif key in BACK_KEYS:
+            self._go_back()
+        elif key in REFRESH_KEYS:
+            self._refresh(stdscr)
+        return True
+
+    def run(self, stdscr: curses.window) -> None:
+        """Curses entry point: initial load, then the event loop."""
+        curses.curs_set(0)
+        stdscr.keypad(True)
+        _render.init_colors()
+        self._run_with_loading(stdscr, "Loading buckets…", self._fetch_buckets)
+        running = True
+        while running:
+            self._draw(stdscr)
+            key = stdscr.getch()
+            running = self._handle_key(stdscr, key)
+
+
+def _require_env(name: str) -> str:
+    """Read a required env var, failing fast with a clear stderr message.
+
+    We deliberately do NOT invent a default (especially not for the token): a
+    missing value is a hard, explained exit *before* curses starts so the error
+    is visible on a normal terminal.
+    """
+    try:
+        value = os.environ[name]
+    except KeyError:
+        print(
+            f"error: required environment variable {name} is not set.\n"
+            f"  export {ENV_URL}=https://connection.keboola.com\n"
+            f"  export {ENV_TOKEN}=your-storage-api-token",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from None
+    if not value.strip():
+        print(f"error: environment variable {name} is empty.", file=sys.stderr)
+        raise SystemExit(1)
+    return value
+
+
+def main() -> None:
+    """Read config from the environment and launch the curses browser.
+
+    The token is read here and passed straight into the SDK context manager; it
+    is never printed, logged, or stored. Only the URL host reaches the screen.
+    """
+    url = _require_env(ENV_URL)
+    token = _require_env(ENV_TOKEN)
+    host = host_only(url)
+
+    # The SDK as a context manager: the underlying HTTP client is closed on exit
+    # even if curses raises. curses.wrapper guarantees the terminal is restored.
+    with Client(url=url, token=token) as kbc:
+        browser = StorageBrowser(kbc, host)
+        curses.wrapper(browser.run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The importable `Client` facade (`lib.py`) and its typed result models (`result_models.py`, #428) are **committed public API**, but had **no developer-facing documentation** — and a few doc surfaces had drifted (some by the recent #424 rename). This PR documents how to *program against* kbagent's Python SDK, ships a runnable teaching demo, and fixes the drift. **No code changes.**

## What

### New — SDK documentation
- **`docs/sdk.md`** — the deep reference:
  - the three programmable surfaces (CLI / in-process SDK / `serve` REST) and when to pick each;
  - where the facade sits in the 3-layer architecture (it's a 4th caller that skips the service layer);
  - full method reference — `query` / `query_result` / `run_job` / `config_detail` / `upload_table` / `files` / `raw`;
  - the typed result-model contract (`extra="allow"` forward-compat, `populate_by_name` aliasing, semver via `__all__`), `py.typed`;
  - idempotent `run_job` (#427), a gotchas cheat-sheet (Snowflake string-typing, UPPERCASE columns, no auto-create, ...);
  - a **contributor section** on extending the SDK.
- **`CONTRIBUTING.md` → "Extending the importable SDK"** — a checklist parallel to "Adding a New CLI Command", linking `docs/sdk.md`.

### New — runnable demo
- **`examples/storage_tui/`** — a dependency-free **curses Storage browser** (buckets → tables → detail + data preview) driven entirely through `from keboola_agent_cli import Client` and `client.raw`. No mocks (live data, empty-states rendered honestly); fail-fast on missing `KBC_URL`/`KBC_TOKEN`; token never printed/logged/written. `app.py` + `_render.py` (pure drawing) + `README.md`.
- **`examples/README.md`** — index + "which surface should I build on?" guide.

### Drift fixes
| File | Was | Now |
|---|---|---|
| `CLAUDE.md` (Versioning) | "`APP_NAME = "keboola-cli"`" (fixed literal) | `APP_NAME` resolved dynamically (`_resolve_app_name`, shipped 0.63.1) |
| `CONTRIBUTING.md` | "Python 3.11+" | "Python 3.12+" (matches `pyproject` `requires-python`) |
| `CLAUDE.md` (Project Structure) | `__init__.py # exposes __version__` | documents the public SDK entrypoint; adds `lib.py` / `result_models.py` / `py.typed` |
| `README.md` | — | "Use as a library" + Documentation table now link `docs/sdk.md` and the demo |

## Verification

- Every documented method/signature was checked against the actual source (`lib.py`, `result_models.py`, `client.py`) — no invented API.
- Demo: `ruff check` + `ruff format --check` clean; parses; imports with `KBC_URL`/`KBC_TOKEN` **unset** without any network (all config/API work is inside `main()`).
- All relative doc links resolve to real files.
- `make check` green — **4099 passed** (no code touched in `src/`/`tests/`).

## Note

No version bump / changelog entry — this is docs + examples only, not a release. `examples/` is outside the wheel (`[tool.hatch.build.targets.wheel] packages = ["src/keboola_agent_cli"]`) and outside the CI lint scope (`src/ tests/`), but was kept ruff-clean anyway.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->