### PR TITLE
chore(release): 0.63.2 — document the in-process Python SDK

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.63.1",
+      "version": "0.63.2",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.63.1",
+  "version": "0.63.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.63.1"
+version = "0.63.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,20 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.63.2": [
+        "Docs: the in-process Python SDK is now documented. New `docs/sdk.md` is the deep "
+        "guide -- the importable `Client` facade vs the CLI vs the `serve` REST API, where the "
+        "facade sits in the 3-layer architecture, a full method reference "
+        "(query / query_result / run_job / config_detail / upload_table / files / raw), the "
+        'typed result-model contract (`extra="allow"`, `populate_by_name`, semver via '
+        "`__all__`), `py.typed`, idempotent `run_job`, a gotchas cheat-sheet, and a contributor "
+        "section on extending the SDK. A runnable curses Storage-browser demo "
+        "(`examples/storage_tui/`) drives a real project entirely through the SDK, and "
+        "`CONTRIBUTING.md` gains an 'Extending the importable SDK' section. Also fixes doc "
+        "drift (dynamic `APP_NAME`, Python 3.12+, `__init__` documented as the public SDK "
+        "entrypoint). No runtime code change -- the installed package is functionally identical "
+        "to 0.63.1; docs and examples ship in the repo, not the wheel.",
+    ],
     "0.63.1": [
         "Fix (#424): self-update is repaired for users still on <=0.62.0. The PyPI rename "
         "`keboola-agent-cli` -> `keboola-cli` broke `kbagent update` for every already-installed "

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.63.1"
+version = "0.63.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## What

Release bump **0.63.1 → 0.63.2** for the SDK documentation that landed in [#440](https://github.com/keboola/cli/pull/440).

- `pyproject.toml` version bump + `make version-sync` (plugin.json / marketplace.json / uv.lock).
- Changelog entry for 0.63.2 (the `docs/sdk.md` guide, the `examples/storage_tui` demo, the CONTRIBUTING "Extending the importable SDK" section, and the doc-drift fixes).

## No runtime code change

Docs and examples ship in the **repo, not the wheel** (`[tool.hatch.build.targets.wheel] packages = ["src/keboola_agent_cli"]`), so the installed 0.63.2 package is **functionally identical to 0.63.1**. The bump exists so:

1. `kbagent changelog` surfaces the new SDK guide, and
2. the 0.63.2 GitHub release carries the migration-bridge compat wheel (`keboola_agent_cli-0.63.2-*.whl`) for any `<=0.62` client that auto-updates to latest.

## Verification

- `make check` green — **4099 passed**, version consistency / changelog completeness OK.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->