### PR TITLE
ci(release): give changelog-check step a GH token

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -110,6 +110,8 @@ jobs:
           git diff --exit-code plugins/kbagent/skills/kbagent/SKILL.md plugins/kbagent/.claude-plugin/plugin.json .claude-plugin/marketplace.json uv.lock
       - name: changelog-check (skipped on pre-releases)
         if: needs.version.outputs.IS_PRERELEASE == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}  # gh release list needs auth; contents:read is enough scope
         run: uv run python scripts/generate_changelog.py --check
 
   # ── Build the prebuilt wheel and publish to PyPI (for the `uv`/`pipx` audience).


### PR DESCRIPTION
## Summary
The release pipeline's `gate` job failed with:

```
subprocess.CalledProcessError: Command '['gh', 'release', 'list', ...]' returned non-zero exit status 4.
```

Exit code **4 from `gh` means "not authenticated."** The `changelog-check` step runs `scripts/generate_changelog.py --check`, which shells out to `gh release list`. `gh` only authenticates when a token is in its environment (`GH_TOKEN`/`GITHUB_TOKEN`), and this step never set one — so `subprocess.run(..., check=True)` re-raised the auth failure.

The per-job permission scoping in `16765c5` is what exposed this: the step depends on `gh` but was left without a token.

## Fix
- Add `GH_TOKEN: ${{ github.token }}` to the `changelog-check` step.
- The workflow-default `contents: read` scope already covers listing releases, so no permission change is needed.

## Test Plan
- `gh` returns exit 4 specifically on missing auth; supplying `github.token` (a trusted built-in) resolves it.
- Verified by inspection: `contents: read` is sufficient scope for `gh release list`.
- The next tagged release / `workflow_dispatch` exercises the `gate` job end-to-end.

## Impact analysis
- `.github/workflows/release-kbagent.yml` only — single step gains an `env` block.
- No code, dependency, or runtime behavior change. Release-CI only.
- Fully backwards-compatible.

## Related
- Regression introduced by `16765c5 ci(release): scope GITHUB_TOKEN permissions per job`.