### PR TITLE
chore(release): 0.64.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.63.4",
+      "version": "0.64.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.63.4",
+  "version": "0.64.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.63.4"
+version = "0.64.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,35 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.64.0": [
+        "New: data-app git-repo introspection + managed-repo credentials -- five `data-app "
+        "git-*` commands over the sandboxes-service `/apps/{id}/git-repo/*` endpoints. "
+        "`git-repo` shows the clone URLs + a managed flag, `git-branches` lists remote branches "
+        "with commit metadata, `git-entrypoints` lists root-level `.py` files, `git-credentials` "
+        "lists managed-repo credentials, and `git-credentials-create` mints an SSH key or HTTP "
+        "token (a one-time secret for `http_token`). Mirrored 1:1 on the `kbagent serve` REST "
+        "API. The read trio needs only the project storage token; the credential pair is "
+        "managed-repo only (admin token). Gotcha: the introspection endpoints return 409 until "
+        "the app has been deployed at least once -- the git block syncs from the Storage config "
+        "into the Data Science app record at deploy time (first tagged 0.63.3, #414).",
+        "Security: `kbagent serve --ui` now decides which paths require auth via the router "
+        "match protocol and fails closed, fixing a fastapi-0.137 nested-router bypass that "
+        "served `/doctor`, `/version`, `/changelog`, and `/agents` unauthenticated "
+        "(GHSA-ffpq-prmh-3gx2); the temporary `fastapi<0.137` cap is lifted (0.63.4).",
+        "Fix: invalid `--mode` / `--poll-strategy` (`job run`), `--role` / `--default-role` "
+        "(`project invite`, `member-set-role`) and `--role-hint` (`dev-portal identity`) values "
+        "fail with a clean exit-2 usage error again instead of an uncaught traceback -- they "
+        "regressed under Typer >=0.25's vendored Click, so the choice options now use `StrEnum`. "
+        "The interactive REPL `help` and tab-completion again list every command (0.63.4).",
+        "Change: kbagent now ships as a self-contained native binary via Homebrew / apt / dnf / "
+        "apk / Chocolatey / WinGet (PyInstaller + nfpm release pipeline), alongside the existing "
+        "pip / uv install (#405).",
+        "Internal: the data-app command and service layers were split into sibling modules "
+        "(`commands/_data_app_git.py`, `commands/_data_app_runtime.py`, "
+        "`services/data_app_git_service.py`) to keep `data_app.py` under the file-size budget -- "
+        "no behavior change (#423). Dependency bumps: cryptography 48, starlette 1.3, "
+        "python-multipart 0.0.31, pyjwt 2.13.",
+    ],
     "0.63.4": [
         "Fix: the interactive REPL `help` command and tab-completion again list every "
         "command instead of only `help`/`exit`. `_build_command_tree` guarded its walk "

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.63.4"
+version = "0.64.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Cuts **0.64.0**, consolidating everything merged since the last *published* GitHub Release (**v0.63.2**). Tags `v0.63.3` and `v0.63.4` exist but were never published as releases (the native-distribution pipeline was being built/fixed in that window — #405, #439, #444, #445); 0.64.0 is the first clean release on the finished pipeline.

## Version bump (all surfaces)
`pyproject.toml` · `plugin.json` · `marketplace.json` · `uv.lock` → `0.64.0` (via `make version-sync`), plus a `0.64.0` entry in `changelog.py`. No code change vs current `main` HEAD — pure release commit.

## What's in 0.64.0 (since v0.63.2)
- **New — data-app git-repo** (#414, was tagged 0.63.3): `data-app git-repo` / `git-branches` / `git-entrypoints` / `git-credentials` / `git-credentials-create`, mirrored 1:1 on `kbagent serve`. Read trio = project token; credentials = managed-repo + admin token. 409-until-deployed gotcha documented.
- **Security** (0.63.4): `serve --ui` auth resolves via the router match protocol and fails closed — fixes the fastapi-0.137 nested-router bypass (GHSA-ffpq-prmh-3gx2); `fastapi<0.137` cap lifted.
- **Fix** (0.63.4): invalid `--mode`/`--poll-strategy`/`--role`/`--role-hint` again exit 2 (StrEnum under Typer ≥0.25's vendored Click); REPL `help` + completion list all commands again.
- **Change** (#405): native binary distribution (brew / apt / dnf / apk / chocolatey / winget).
- **Internal** (#423): data-app command/service split into sibling modules (`_data_app_git.py`, `_data_app_runtime.py`, `data_app_git_service.py`); dep bumps (cryptography 48, starlette 1.3, python-multipart 0.0.31, pyjwt 2.13).

## Release mechanics (after merge)
`make check` green (4137 passed); changelog-check + command-sync + version consistency pass. **Pushing the `v0.64.0` tag triggers `release-kbagent.yml`** → PyInstaller freeze + nfpm + Homebrew/Chocolatey/WinGet + PyPI + S3 + the GitHub Release. That tag push is the deliberate, outward-facing publish step — to be done after this merges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->