### PR TITLE
fix(release): unblock native-binary pipeline (macOS staple, Windows TSA, PyPI idempotency)

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -130,6 +130,10 @@ jobs:
       - run: uv build
       - run: uv run python scripts/check_wheel_ui.py --expect-ui
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Idempotent: a re-tag / re-run after a downstream (signing) failure
+          # must not fail just because this version is already on PyPI.
+          skip-existing: true
 
   # ── Freeze a self-contained native binary per OS/arch (PyInstaller).
   freeze:

--- a/build/package/macos/sign_notarize.sh
+++ b/build/package/macos/sign_notarize.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Code-sign + notarize + staple a macOS binary. Required Apple secrets:
+# Code-sign + notarize a macOS binary (no staple -- see the note by the staple
+# step: a bare CLI binary cannot be stapled and does not need to be). Required Apple secrets:
 #   APPLE_DEVELOPER_CERTIFICATE_P12_BASE64  (Developer ID Application cert, base64 .p12)
 #   APPLE_DEVELOPER_CERTIFICATE_PASSWORD    (.p12 password)
 #   APPLE_ACCOUNT_USERNAME                  (Apple ID email, e.g. apple@keboola.com)
@@ -35,8 +36,14 @@ xcrun notarytool submit "$ZIP" \
   --password "$APPLE_ACCOUNT_PASSWORD" \
   --team-id "$APPLE_TEAM_ID" \
   --wait
-# Staple must succeed on a real release (an unstapled binary needs online
-# notarization checks → worse offline install UX). Pre-release tags mark the
-# whole signing step continue-on-error, so a hard failure here is safe there.
-xcrun stapler staple "$BIN"
+# Do NOT staple: `xcrun stapler staple` only supports bundles (.app / .dmg /
+# .pkg) -- a bare Mach-O CLI binary cannot be stapled and returns "Error 73"
+# (per the stapler(1) man page: "works only with UDIF disk images, signed
+# 'flat' installer packages, and certain code-signed executable bundles").
+# The binary IS Developer-ID-signed (hardened runtime) and notarized
+# (notarytool returned Accepted above), so Gatekeeper validates it ONLINE via
+# Apple's notarization catalog keyed by the code-directory hash. Stapling only
+# matters for OFFLINE first-run of a *bundle*, which this is not -- so a signed
+# + notarized standalone CLI binary is safe to ship unstapled.
+echo "Skipping stapler: a bare CLI binary is notarized; Gatekeeper checks it online."
 codesign --verify --verbose "$BIN"

--- a/build/package/windows/sign.sh
+++ b/build/package/windows/sign.sh
@@ -26,11 +26,17 @@ TOKEN=$(curl -sf -X POST "https://login.microsoftonline.com/${WINDOWS_SIGNING_TE
 
 curl -fsSL -o /tmp/jsign.jar https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar
 echo "05ca18d4ab7b8c2183289b5378d32860f0ea0f3bdab1f1b8cae5894fb225fa8a  /tmp/jsign.jar" | sha256sum -c -
+# Timestamping hits a public RFC3161/Authenticode TSA, which occasionally times
+# out (seen as `SocketTimeoutException: Connect timed out`). jsign accepts a
+# comma-separated --tsaurl list it falls back across, plus per-URL retries, so a
+# single flaky TSA no longer fails the whole signed release.
 java -jar /tmp/jsign.jar \
   --storetype AZUREKEYVAULT \
   --keystore "$KEYVAULT" \
   --alias "$ALIAS" \
   --storepass "$TOKEN" \
-  --tsaurl https://timestamp.digicert.com \
+  --tsaurl "https://timestamp.digicert.com,http://timestamp.sectigo.com,http://ts.ssl.com" \
+  --tsretries 5 \
+  --tsretrywait 15 \
   --replace \
   "$EXE"


### PR DESCRIPTION
## Problem
The `release-kbagent.yml` **freeze** job has failed at the code-signing steps on **every recent stable tag** — v0.63.3, v0.63.4, and v0.64.0 — so `github-release`, `publish-s3`, `homebrew`, `winget`, `chocolatey`, and `package-linux` were all **skipped**. Result: no GitHub Release and no native packages were ever published; only the PyPI wheel shipped.

## Root causes (diagnosed from the v0.64.0 run logs)
1. **macOS — `stapler` Error 73.** `build/package/macos/sign_notarize.sh` runs `xcrun stapler staple` on the bare PyInstaller Mach-O binary. `stapler` only supports bundles (`.app`/`.dmg`/`.pkg`) — a standalone executable cannot be stapled (`stapler.1`: *"works only with UDIF disk images, signed 'flat' installer packages, and certain code-signed executable bundles"*). Notarization itself **succeeded** (`notarytool` → Accepted).
2. **Windows — TSA timeout.** `build/package/windows/sign.sh` timestamps against a single TSA (`timestamp.digicert.com`) with no retry/fallback → `java.net.SocketTimeoutException: Connect timed out`.
3. **PyPI — not idempotent.** `pypa/gh-action-pypi-publish` had no `skip-existing`, so any re-tag/re-run after a downstream signing failure fails on the already-published version.

## Fixes
1. **macOS:** drop the staple step. A Developer-ID-signed + notarized standalone CLI binary is valid to ship unstapled — Gatekeeper validates it **online** by code-directory hash; stapling only helps offline first-run of a *bundle*. (Confirmed against the `stapler` man page + Apple notarization docs.)
2. **Windows:** jsign comma-separated `--tsaurl` failover (`digicert,sectigo,ssl.com`) + `--tsretries 5 --tsretrywait 15`.
3. **PyPI:** `skip-existing: true`.

## Validation
`bash -n` on both scripts; workflow YAML parses. No app-code change — the wheel contents are unaffected (these files don't ship in the wheel).

## Release plan
After merge, **re-tag `v0.64.0`** onto the fixed commit to run the corrected pipeline and ship the native artifacts + GitHub Release. The 0.64.0 PyPI wheel already published from the prior run is unchanged; `skip-existing` makes the re-run's PyPI step a no-op.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->