### PR TITLE
docs(changelog): record #446 install onboarding in 0.65.0 notes

### DIFF
--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -60,6 +60,11 @@ CHANGELOG: dict[str, list[str]] = {
         "All of the above are mirrored 1:1 on the `kbagent serve` REST API "
         "(`/data-app/.../runs`, `/data-app/.../git-repo/bind-credential`, and the "
         "`use_managed_git_repo` field on create).",
+        "New (#446): the `install.sh` bootstrap got a first-run onboarding pass -- it "
+        "auto-installs `uv` when it is missing (opt out with `KBAGENT_NO_UV_BOOTSTRAP=1`), quiets "
+        "the install output behind tidy step lines, and finishes with a Keboola banner plus a "
+        "'next steps' footer (`kbagent project add`, `kbagent --help`) so first-time users know "
+        "what to run next.",
     ],
     "0.64.0": [
         "New: data-app git-repo introspection + managed-repo credentials -- five `data-app "


### PR DESCRIPTION
#446 (install UX: auto-install uv, quieter output, Keboola banner + next steps) landed after the v0.64.0 tag but added no changelog entry, so it would be missing from the 0.65.0 release notes. This adds the bullet so the 0.65.0 notes cover everything shipped since 0.64.0 (#446 + #455). Changelog-only; no code change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->