### PR TITLE
fix(release): attach the pip/uv wheel on every release

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -255,6 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # softprops/action-gh-release creates the GitHub Release
+      actions: write # dispatch release.yml (the wheel-attach workflow) below
     env:
       VERSION: ${{ needs.version.outputs.VERSION }}
     steps:
@@ -270,6 +271,18 @@ jobs:
           tag_name: v${{ env.VERSION }}
           files: release/*
           prerelease: ${{ needs.version.outputs.IS_PRERELEASE == 'true' }}
+      # Attach the pip/uv wheel too. release.yml builds + uploads it (the asset that
+      # auto-update and install.sh download) on `release: published` -- but a release
+      # created above with GITHUB_TOKEN does NOT emit that event, so on a bot-cut
+      # release the wheel never got attached (this is what broke v0.64.0).
+      # workflow_dispatch is the documented exception to the GITHUB_TOKEN no-cascade
+      # rule, so dispatch release.yml directly; it fires no matter who cut the release.
+      # The release already exists (created above), so release.yml's upload lands.
+      - name: Attach the pip/uv wheel (dispatch release.yml)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh workflow run release.yml -f tag="v${VERSION}"
 
   # ── Publish to S3 (cli-dist.keboola.com/keboola-cli2/) and index the apt/rpm/apk
   #    repos so `apt-get install keboola-cli2` works. Real; needs AWS + GPG secrets.

--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -276,8 +276,9 @@ jobs:
       # job creates with GITHUB_TOKEN does NOT emit that event, so when no one
       # published the release by hand the wheel never got attached -- this broke
       # v0.64.0. workflow_dispatch is the documented exception to the GITHUB_TOKEN
-      # no-trigger rule, so dispatch release.yml directly; it runs whoever created
-      # the release. The release already exists (created above), so the upload lands.
+      # no-trigger rule, so dispatch release.yml directly; that runs it no matter who
+      # or what created the release. The release already exists (created above), so
+      # the upload lands.
       - name: Attach the pip/uv wheel (dispatch release.yml)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -293,12 +294,13 @@ jobs:
         run: |
           for _ in $(seq 1 30); do
             sleep 20
-            if gh release view "v${VERSION}" --json assets --jq '.assets[].name' \
-                 | grep -qx "keboola_cli-${VERSION}-py3-none-any.whl"; then
-              echo "wheel attached"; exit 0
+            names="$(gh release view "v${VERSION}" --json assets --jq '.assets[].name')"
+            if grep -qx "keboola_cli-${VERSION}-py3-none-any.whl" <<<"$names" \
+               && grep -qx "keboola_agent_cli-${VERSION}-py3-none-any.whl" <<<"$names"; then
+              echo "both wheels attached"; exit 0
             fi
           done
-          echo "::error::wheel still missing 10 min after dispatching release.yml for v${VERSION} -- check that run"
+          echo "::error::wheel(s) still missing 10 min after dispatching release.yml for v${VERSION} -- check that run"
           exit 1
 
   # ── Publish to S3 (cli-dist.keboola.com/keboola-cli2/) and index the apt/rpm/apk

--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -272,17 +272,34 @@ jobs:
           files: release/*
           prerelease: ${{ needs.version.outputs.IS_PRERELEASE == 'true' }}
       # Attach the pip/uv wheel too. release.yml builds + uploads it (the asset that
-      # auto-update and install.sh download) on `release: published` -- but a release
-      # created above with GITHUB_TOKEN does NOT emit that event, so on a bot-cut
-      # release the wheel never got attached (this is what broke v0.64.0).
-      # workflow_dispatch is the documented exception to the GITHUB_TOKEN no-cascade
-      # rule, so dispatch release.yml directly; it fires no matter who cut the release.
-      # The release already exists (created above), so release.yml's upload lands.
+      # auto-update and install.sh download) on `release: published`. A release this
+      # job creates with GITHUB_TOKEN does NOT emit that event, so when no one
+      # published the release by hand the wheel never got attached -- this broke
+      # v0.64.0. workflow_dispatch is the documented exception to the GITHUB_TOKEN
+      # no-trigger rule, so dispatch release.yml directly; it runs whoever created
+      # the release. The release already exists (created above), so the upload lands.
       - name: Attach the pip/uv wheel (dispatch release.yml)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
+          GH_REPO: ${{ github.repository }} # required: no checkout in this job, gh can't read the repo from git
         run: gh workflow run release.yml -f tag="v${VERSION}"
+      # gh workflow run is fire-and-forget: it returns once GitHub accepts the
+      # dispatch, not when release.yml finishes. Poll the release for the wheel so a
+      # failed release.yml turns THIS run red instead of silently shipping no wheel.
+      - name: Confirm the wheel was attached
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          for _ in $(seq 1 30); do
+            sleep 20
+            if gh release view "v${VERSION}" --json assets --jq '.assets[].name' \
+                 | grep -qx "keboola_cli-${VERSION}-py3-none-any.whl"; then
+              echo "wheel attached"; exit 0
+            fi
+          done
+          echo "::error::wheel still missing 10 min after dispatching release.yml for v${VERSION} -- check that run"
+          exit 1
 
   # ── Publish to S3 (cli-dist.keboola.com/keboola-cli2/) and index the apt/rpm/apk
   #    repos so `apt-get install keboola-cli2` works. Real; needs AWS + GPG secrets.


### PR DESCRIPTION
## Summary
This fixes wheel publication for releases so the pip/uv wheel is attached every time, including releases created by the native binary pipeline.

## How I found this
I hit the broken update path myself when `kbagent` tried to update itself and failed because the expected wheel asset was missing. The update did not complete, so `kbagent` stayed on the currently installed version instead of downloading the release wheel.

## Root Cause
- `release.yml` only runs on `release: published`.
- `release-kbagent.yml` creates the GitHub Release from a tag push.
- When `release-kbagent.yml` creates the release with `GITHUB_TOKEN`, GitHub does not emit `release: published`.
- So bot-created releases can ship without the wheel unless something else triggers the wheel workflow.

## Evidence
- `v0.64.0` was authored by `github-actions[bot]`.
- Its wheel assets were uploaded later in a separate manual `workflow_dispatch` run by me.
- `v0.65.0` was authored by `padak`, and `release.yml` ran automatically on the `release` event.

## Fix
After creating the GitHub Release, `release-kbagent.yml` now dispatches `release.yml` directly for the same tag.

This keeps wheel publishing attached to every release, regardless of whether the release page was created by a human or by Actions.

## Notes
- The change is minimal: one `actions: write` permission and one `gh workflow run release.yml -f tag=...` step.
- `v0.64.0` is still a useful example because the wheel was missing at initial publish time and only appeared later after manual backfill.
